### PR TITLE
fix(backend): load .env before Nest bootstrap

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "bullmq": "^5.41.5",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "dotenv": "^16.6.1",
         "mongodb": "^6.13.0",
         "nestjs-pino": "^4.4.1",
         "pino-pretty": "^13.0.0",
@@ -3507,6 +3508,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "bullmq": "^5.41.5",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "dotenv": "^16.6.1",
     "mongodb": "^6.13.0",
     "nestjs-pino": "^4.4.1",
     "pino-pretty": "^13.0.0",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,9 +1,12 @@
+import { config as loadEnv } from 'dotenv';
 import { NestFactory } from '@nestjs/core';
 import { Logger } from 'nestjs-pino';
 
 import { HttpExceptionFilter } from './common/errors/http-exception.filter';
 import { AppValidationPipe } from './common/validation/validation.pipe';
 import { AppModule } from './app.module';
+
+loadEnv();
 
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule, {


### PR DESCRIPTION
## Summary
- load backend environment variables before bootstrapping Nest
- add dotenv to the backend runtime dependencies
- prevent local and homolog startup failures when relying on backend/.env

## Validation
- npm install
- npm run build
- npm run start:dev with a temporary backend/.env copied from .env.example