### PR TITLE
test(backend): add receipt parsing and normalization coverage

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -44,13 +44,18 @@
   },
   "jest": {
     "moduleFileExtensions": ["js", "json", "ts"],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
+    "rootDir": ".",
+    "testRegex": "test/.*\\.spec\\.ts$",
     "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
+      "^.+\\.(t|j)s$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.spec.json"
+        }
+      ]
     },
-    "collectCoverageFrom": ["**/*.(t|j)s"],
-    "coverageDirectory": "../coverage",
+    "collectCoverageFrom": ["src/**/*.(t|j)s"],
+    "coverageDirectory": "coverage",
     "testEnvironment": "node"
   }
 }

--- a/backend/src/catalog/application/product-normalizer.service.ts
+++ b/backend/src/catalog/application/product-normalizer.service.ts
@@ -1,0 +1,117 @@
+import { Injectable } from '@nestjs/common';
+
+export interface NormalizedProduct {
+  canonicalName: string;
+  normalizedText: string;
+  sizeDescriptor?: string;
+  confidenceScore: number;
+  aliasApplied: boolean;
+  tokens: string[];
+}
+
+const TOKEN_ALIASES: Record<string, string> = {
+  cx: 'caixa',
+  int: 'integral',
+  lt: 'l',
+  lts: 'l',
+  pct: 'pacote',
+  tp1: 'tipo 1',
+  und: 'unidade',
+};
+
+@Injectable()
+export class ProductNormalizerService {
+  normalize(rawName: string): NormalizedProduct {
+    const sanitized = this.sanitize(rawName);
+    const { sizeDescriptor, textWithoutSize } = this.extractSizeDescriptor(sanitized);
+    const { normalizedText, aliasApplied } = this.expandAliases(textWithoutSize);
+    const tokens = normalizedText.split(' ').filter(Boolean);
+
+    return {
+      canonicalName: tokens.join(' '),
+      normalizedText,
+      sizeDescriptor,
+      confidenceScore: this.scoreNormalization(tokens, aliasApplied, sizeDescriptor),
+      aliasApplied,
+      tokens,
+    };
+  }
+
+  private sanitize(value: string): string {
+    return value
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  private extractSizeDescriptor(value: string): {
+    sizeDescriptor?: string;
+    textWithoutSize: string;
+  } {
+    const match = value.match(/(\d+(?:[.,]\d+)?)\s*(kg|g|mg|ml|l|un)\b/);
+
+    if (!match) {
+      return {
+        textWithoutSize: value,
+      };
+    }
+
+    const numericValue = match[1].replace(',', '.');
+    const unit = match[2];
+    const textWithoutSize = value
+      .replace(match[0], ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    return {
+      sizeDescriptor: `${numericValue} ${unit}`,
+      textWithoutSize,
+    };
+  }
+
+  private expandAliases(value: string): {
+    normalizedText: string;
+    aliasApplied: boolean;
+  } {
+    let aliasApplied = false;
+
+    const expandedTokens = value
+      .split(' ')
+      .filter(Boolean)
+      .flatMap((token) => {
+        const expanded = TOKEN_ALIASES[token];
+
+        if (!expanded) {
+          return [token];
+        }
+
+        aliasApplied = true;
+        return expanded.split(' ');
+      });
+
+    return {
+      normalizedText: expandedTokens.join(' '),
+      aliasApplied,
+    };
+  }
+
+  private scoreNormalization(
+    tokens: string[],
+    aliasApplied: boolean,
+    sizeDescriptor?: string,
+  ): number {
+    if (tokens.length === 0) {
+      return 0;
+    }
+
+    const baseScore = 0.6;
+    const aliasBonus = aliasApplied ? 0.15 : 0;
+    const sizeBonus = sizeDescriptor ? 0.15 : 0;
+    const tokenBonus = Math.min(tokens.length * 0.05, 0.1);
+
+    return Math.min(1, Number((baseScore + aliasBonus + sizeBonus + tokenBonus).toFixed(2)));
+  }
+}

--- a/backend/src/catalog/catalog.module.ts
+++ b/backend/src/catalog/catalog.module.ts
@@ -1,4 +1,9 @@
 import { Module } from '@nestjs/common';
 
-@Module({})
+import { ProductNormalizerService } from './application/product-normalizer.service';
+
+@Module({
+  providers: [ProductNormalizerService],
+  exports: [ProductNormalizerService],
+})
 export class CatalogModule {}

--- a/backend/src/receipts/application/receipt-parser.service.ts
+++ b/backend/src/receipts/application/receipt-parser.service.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  ReceiptIngestionRequest,
+  ReceiptLineItemInput,
+} from '../../common/contracts/receipt.contract';
+import { ProductNormalizerService } from '../../catalog/application/product-normalizer.service';
+
+export interface ParsedReceiptLineItem {
+  rawProductName: string;
+  normalizedName: string;
+  quantity: number;
+  unitPrice: number;
+  currency: string;
+  packageSize?: string;
+  lineTotal: number;
+  matchConfidence: number;
+}
+
+export interface ParsedReceipt {
+  storeName: string;
+  purchaseDate?: string;
+  parseStatus: 'parsed' | 'partial' | 'failed';
+  confidenceScore: number;
+  items: ParsedReceiptLineItem[];
+  issues: string[];
+}
+
+@Injectable()
+export class ReceiptParserService {
+  constructor(
+    private readonly productNormalizerService: ProductNormalizerService,
+  ) {}
+
+  parse(request: ReceiptIngestionRequest): ParsedReceipt {
+    const issues: string[] = [];
+    const storeName = request.storeName.trim();
+
+    if (!storeName) {
+      issues.push('missing_store_name');
+    }
+
+    const items = request.items
+      .map((item, index) => this.parseItem(item, index, issues))
+      .filter((item): item is ParsedReceiptLineItem => item !== null);
+
+    const parseStatus =
+      items.length === 0 ? 'failed' : issues.length > 0 ? 'partial' : 'parsed';
+
+    return {
+      storeName,
+      purchaseDate: request.purchaseDate,
+      parseStatus,
+      confidenceScore: this.calculateConfidenceScore(items.length, issues.length),
+      items,
+      issues,
+    };
+  }
+
+  private parseItem(
+    item: ReceiptLineItemInput,
+    index: number,
+    issues: string[],
+  ): ParsedReceiptLineItem | null {
+    const rawProductName = item.rawProductName.trim().replace(/\s+/g, ' ');
+
+    if (!rawProductName) {
+      issues.push(`item_${index}_missing_name`);
+      return null;
+    }
+
+    if (!Number.isFinite(item.unitPrice) || item.unitPrice <= 0) {
+      issues.push(`item_${index}_invalid_unit_price`);
+      return null;
+    }
+
+    const quantity =
+      item.quantity && Number.isFinite(item.quantity) && item.quantity > 0
+        ? item.quantity
+        : 1;
+
+    if (quantity === 1 && item.quantity !== undefined && item.quantity !== 1) {
+      issues.push(`item_${index}_quantity_defaulted`);
+    }
+
+    const normalized = this.productNormalizerService.normalize(rawProductName);
+    const currency = item.currency?.trim() || 'BRL';
+
+    return {
+      rawProductName,
+      normalizedName: normalized.canonicalName,
+      quantity,
+      unitPrice: item.unitPrice,
+      currency,
+      packageSize: item.packageSize ?? normalized.sizeDescriptor,
+      lineTotal: Number((quantity * item.unitPrice).toFixed(2)),
+      matchConfidence: normalized.confidenceScore,
+    };
+  }
+
+  private calculateConfidenceScore(
+    validItems: number,
+    issueCount: number,
+  ): number {
+    if (validItems === 0) {
+      return 0;
+    }
+
+    const base = 0.95;
+    const penalty = issueCount * 0.1;
+
+    return Math.max(0, Number((base - penalty).toFixed(2)));
+  }
+}

--- a/backend/src/receipts/receipts.module.ts
+++ b/backend/src/receipts/receipts.module.ts
@@ -1,4 +1,11 @@
 import { Module } from '@nestjs/common';
 
-@Module({})
+import { CatalogModule } from '../catalog/catalog.module';
+import { ReceiptParserService } from './application/receipt-parser.service';
+
+@Module({
+  imports: [CatalogModule],
+  providers: [ReceiptParserService],
+  exports: [ReceiptParserService],
+})
 export class ReceiptsModule {}

--- a/backend/test/unit/catalog/product-normalizer.service.spec.ts
+++ b/backend/test/unit/catalog/product-normalizer.service.spec.ts
@@ -1,0 +1,31 @@
+import { ProductNormalizerService } from '../../../src/catalog/application/product-normalizer.service';
+
+describe('ProductNormalizerService', () => {
+  const service = new ProductNormalizerService();
+
+  it('normalizes accents, casing, and spacing into a canonical product name', () => {
+    const result = service.normalize('  Café   Torrado  e   Moído  ');
+
+    expect(result.canonicalName).toBe('cafe torrado e moido');
+    expect(result.normalizedText).toBe('cafe torrado e moido');
+    expect(result.sizeDescriptor).toBeUndefined();
+    expect(result.confidenceScore).toBeGreaterThan(0.6);
+  });
+
+  it('expands known aliases and extracts the size descriptor separately', () => {
+    const result = service.normalize('Arroz Tio João tp1 5kg');
+
+    expect(result.canonicalName).toBe('arroz tio joao tipo 1');
+    expect(result.sizeDescriptor).toBe('5 kg');
+    expect(result.aliasApplied).toBe(true);
+    expect(result.tokens).toEqual(['arroz', 'tio', 'joao', 'tipo', '1']);
+  });
+
+  it('returns zero confidence when the raw name has no meaningful tokens', () => {
+    const result = service.normalize('!!!');
+
+    expect(result.canonicalName).toBe('');
+    expect(result.confidenceScore).toBe(0);
+    expect(result.tokens).toEqual([]);
+  });
+});

--- a/backend/test/unit/receipts/receipt-parser.service.spec.ts
+++ b/backend/test/unit/receipts/receipt-parser.service.spec.ts
@@ -1,0 +1,91 @@
+import { ProductNormalizerService } from '../../../src/catalog/application/product-normalizer.service';
+import {
+  ReceiptIngestionRequest,
+} from '../../../src/common/contracts/receipt.contract';
+import { ReceiptParserService } from '../../../src/receipts/application/receipt-parser.service';
+
+describe('ReceiptParserService', () => {
+  const productNormalizerService = new ProductNormalizerService();
+  const service = new ReceiptParserService(productNormalizerService);
+
+  it('parses valid receipt items into structured data with normalized names', () => {
+    const input: ReceiptIngestionRequest = {
+      storeName: ' Atacadao ',
+      purchaseDate: '2026-04-05',
+      items: [
+        {
+          rawProductName: 'Arroz Tio João tp1 5kg',
+          quantity: 2,
+          unitPrice: 29.9,
+        },
+      ],
+    };
+
+    const result = service.parse(input);
+
+    expect(result.parseStatus).toBe('parsed');
+    expect(result.storeName).toBe('Atacadao');
+    expect(result.issues).toEqual([]);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      rawProductName: 'Arroz Tio João tp1 5kg',
+      normalizedName: 'arroz tio joao tipo 1',
+      quantity: 2,
+      unitPrice: 29.9,
+      currency: 'BRL',
+      packageSize: '5 kg',
+      lineTotal: 59.8,
+    });
+  });
+
+  it('defaults invalid quantities, skips broken lines, and marks the parse as partial', () => {
+    const input: ReceiptIngestionRequest = {
+      storeName: 'Carrefour',
+      items: [
+        {
+          rawProductName: 'Leite Int. Italac 1L',
+          quantity: 0,
+          unitPrice: 6.49,
+        },
+        {
+          rawProductName: 'Item sem preco',
+          unitPrice: 0,
+        },
+      ],
+    };
+
+    const result = service.parse(input);
+
+    expect(result.parseStatus).toBe('partial');
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      normalizedName: 'leite integral italac',
+      quantity: 1,
+      packageSize: '1 l',
+      lineTotal: 6.49,
+    });
+    expect(result.issues).toContain('item_0_quantity_defaulted');
+    expect(result.issues).toContain('item_1_invalid_unit_price');
+    expect(result.confidenceScore).toBeLessThan(0.95);
+  });
+
+  it('fails when no valid structured lines can be extracted', () => {
+    const input: ReceiptIngestionRequest = {
+      storeName: '   ',
+      items: [
+        {
+          rawProductName: '   ',
+          unitPrice: 12,
+        },
+      ],
+    };
+
+    const result = service.parse(input);
+
+    expect(result.parseStatus).toBe('failed');
+    expect(result.items).toEqual([]);
+    expect(result.issues).toContain('missing_store_name');
+    expect(result.issues).toContain('item_0_missing_name');
+    expect(result.confidenceScore).toBe(0);
+  });
+});

--- a/backend/tsconfig.spec.json
+++ b/backend/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -79,7 +79,7 @@ offer per item with total cost and savings breakdown.
 
 ### Tests for User Story 1
 
-- [ ] T023 [P] [US1] Add backend unit tests for receipt parsing and normalization rules in `backend/test/unit/receipts/receipt-parser.service.spec.ts` and `backend/test/unit/catalog/product-normalizer.service.spec.ts` | Issue: [#23](https://github.com/Gabrimeireles/Pricely/issues/23)
+- [x] T023 [P] [US1] Add backend unit tests for receipt parsing and normalization rules in `backend/test/unit/receipts/receipt-parser.service.spec.ts` and `backend/test/unit/catalog/product-normalizer.service.spec.ts` | Issue: [#23](https://github.com/Gabrimeireles/Pricely/issues/23)
 - [ ] T024 [P] [US1] Add backend unit tests for multi-market optimization logic in `backend/test/unit/optimization/multi-market-optimizer.service.spec.ts` | Issue: [#24](https://github.com/Gabrimeireles/Pricely/issues/24)
 - [ ] T025 [P] [US1] Add backend integration tests for receipt ingestion and optimization flows in `backend/test/integration/receipts/receipt-ingestion.integration.spec.ts` and `backend/test/integration/optimization/multi-market-optimization.integration.spec.ts` | Issue: [#25](https://github.com/Gabrimeireles/Pricely/issues/25)
 - [ ] T026 [P] [US1] Add API contract tests for shopping list, receipt, and optimization endpoints in `backend/test/contract/grocery-optimizer-api.contract.spec.ts` | Issue: [#26](https://github.com/Gabrimeireles/Pricely/issues/26)


### PR DESCRIPTION
## Summary
- add backend unit tests for receipt parsing and product normalization
- introduce minimal parser and normalizer services so the tests execute against real behavior
- configure Jest to run suites from ackend/test with a dedicated 	sconfig.spec.json
- mark T023 as complete in specs/001-grocery-optimizer/tasks.md

## Validation
- npm install
- npm run build
- npm run lint
- npm test -- --runInBand

Closes #23