### PR TITLE
T004: add shared web and mobile endpoint config

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -42,12 +42,27 @@ Current default values:
 
 - Web dev server: `5173`
 - Backend API base URL: `http://localhost:3000`
+- Auth base path: `/auth`
+- Public regions base path: `/regions`
 
 ## Mobile Setup
 
 1. Ensure Flutter stable with Dart 3 is installed.
 2. Install Flutter dependencies in `mobile/`.
 3. Run the app on an emulator or device.
+
+Current mobile defaults are centralized in
+[api_environment.dart](/D:/Pricely/mobile/lib/core/networking/api_environment.dart):
+
+- API base URL: `http://10.0.2.2:3000`
+- Auth base path: `/auth`
+- Public regions base path: `/regions`
+
+Example override for a physical device or alternate host:
+
+```bash
+flutter run --dart-define=PRICELY_API_BASE_URL=http://192.168.0.10:3000
+```
 
 ## Notes
 

--- a/mobile/lib/core/networking/api_environment.dart
+++ b/mobile/lib/core/networking/api_environment.dart
@@ -1,0 +1,15 @@
+class ApiEnvironment {
+  const ApiEnvironment._();
+
+  static const String baseUrl = String.fromEnvironment(
+    'PRICELY_API_BASE_URL',
+    defaultValue: 'http://10.0.2.2:3000',
+  );
+
+  static const String authBasePath = '/auth';
+  static const String regionsBasePath = '/regions';
+
+  static const String loginPath = '$authBasePath/login';
+  static const String registerPath = '$authBasePath/register';
+  static const String profilePath = '$authBasePath/me';
+}

--- a/mobile/test/unit/core/networking/api_environment_test.dart
+++ b/mobile/test/unit/core/networking/api_environment_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pricely_mobile/core/networking/api_environment.dart';
+
+void main() {
+  test('exposes shared auth and region endpoints for local development', () {
+    expect(ApiEnvironment.baseUrl, isNotEmpty);
+    expect(ApiEnvironment.authBasePath, '/auth');
+    expect(ApiEnvironment.regionsBasePath, '/regions');
+    expect(ApiEnvironment.loginPath, '/auth/login');
+    expect(ApiEnvironment.profilePath, '/auth/me');
+  });
+}

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,1 +1,3 @@
 VITE_API_BASE_URL=http://localhost:3000
+VITE_AUTH_BASE_PATH=/auth
+VITE_REGIONS_BASE_PATH=/regions


### PR DESCRIPTION
## Summary
- add shared auth and region endpoint defaults to the web environment example
- centralize mobile API endpoint defaults for local development
- document the shared local endpoint conventions for web and mobile

## Validation
- wrote the mobile endpoint test first, then implemented the production file to satisfy it
- mobile automated execution is currently blocked because lutter and dart are not available in PATH in this session

## Related issues
- closes #82
