### PR TITLE
T006: add shared auth module foundation

### DIFF
--- a/backend/src/admin/admin-access.controller.ts
+++ b/backend/src/admin/admin-access.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../common/auth/jwt-auth.guard';
+import { Roles } from '../common/auth/roles.decorator';
+import { RolesGuard } from '../common/auth/roles.guard';
+
+@Controller('admin')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class AdminAccessController {
+  @Get('access-check')
+  @Roles('admin')
+  accessCheck() {
+    return {
+      status: 'ok',
+    };
+  }
+}

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,4 +1,9 @@
 import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { AdminAccessController } from './admin-access.controller';
 
-@Module({})
+@Module({
+  imports: [AuthModule],
+  controllers: [AdminAccessController],
+})
 export class AdminModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { AdminModule } from './admin/admin.module';
+import { AuthModule } from './auth/auth.module';
 import { CatalogModule } from './catalog/catalog.module';
 import { JobsModule } from './jobs/jobs.module';
 import { ListsModule } from './lists/lists.module';
@@ -17,6 +18,7 @@ import { StoresModule } from './stores/stores.module';
     LoggingModule,
     PrismaModule,
     MongoModule,
+    AuthModule,
     QueueModule,
     ReceiptsModule,
     CatalogModule,

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
+import { CurrentUser } from '../common/auth/current-user.decorator';
+import { JwtAuthGuard } from '../common/auth/jwt-auth.guard';
+import { type JwtUserPayload } from './auth.types';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  async register(@Body() body: RegisterDto) {
+    return this.authService.register(body);
+  }
+
+  @Post('login')
+  @HttpCode(HttpStatus.OK)
+  async login(@Body() body: LoginDto) {
+    return this.authService.login(body);
+  }
+
+  @Get('me')
+  @UseGuards(JwtAuthGuard)
+  async me(@CurrentUser() user: JwtUserPayload) {
+    return this.authService.getCurrentUser(user.sub);
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { RolesGuard } from '../common/auth/roles.guard';
+import { UsersModule } from '../users/users.module';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './jwt.strategy';
+
+function resolveJwtSecret(): string {
+  return process.env.JWT_ACCESS_SECRET ?? 'changeme-local-secret';
+}
+
+@Module({
+  imports: [
+    UsersModule,
+    PassportModule,
+    JwtModule.registerAsync({
+      useFactory: async () => ({
+        secret: resolveJwtSecret(),
+        signOptions: {
+          expiresIn: '7d',
+        },
+      }),
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy, RolesGuard],
+  exports: [AuthService, JwtModule, PassportModule, JwtStrategy, RolesGuard],
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,72 @@
+import {
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { compare, hash } from 'bcryptjs';
+import { type JwtUserPayload } from './auth.types';
+import { UsersService } from '../users/users.service';
+import { type LoginDto } from './dto/login.dto';
+import { type RegisterDto } from './dto/register.dto';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  async register(input: RegisterDto) {
+    const passwordHash = await hash(input.password, 10);
+    const user = await this.usersService.createCustomerAccount({
+      email: input.email,
+      passwordHash,
+      displayName: input.displayName,
+    });
+
+    return this.buildSession(user);
+  }
+
+  async login(input: LoginDto) {
+    const user = await this.usersService.findByEmail(input.email);
+
+    if (!user) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const passwordMatches = await compare(input.password, user.passwordHash);
+
+    if (!passwordMatches) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const updatedUser = await this.usersService.markSuccessfulLogin(user.id);
+    return this.buildSession(updatedUser);
+  }
+
+  async getCurrentUser(userId: string) {
+    return this.usersService.getProfileById(userId);
+  }
+
+  private async buildSession(user: {
+    id: string;
+    email: string;
+    displayName: string;
+    role: 'customer' | 'admin';
+    status: 'active' | 'suspended';
+    lastLoginAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    const payload: JwtUserPayload = {
+      sub: user.id,
+      email: user.email,
+      role: user.role,
+    };
+
+    return {
+      accessToken: await this.jwtService.signAsync(payload),
+      user: this.usersService.toProfile(user),
+    };
+  }
+}

--- a/backend/src/auth/auth.types.ts
+++ b/backend/src/auth/auth.types.ts
@@ -1,0 +1,5 @@
+export interface JwtUserPayload {
+  sub: string;
+  email: string;
+  role: 'customer' | 'admin';
+}

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @MinLength(8)
+  password!: string;
+}

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,0 +1,14 @@
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class RegisterDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @MinLength(8)
+  password!: string;
+
+  @IsString()
+  @MinLength(2)
+  displayName!: string;
+}

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -1,0 +1,30 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { type JwtUserPayload } from './auth.types';
+import { UsersService } from '../users/users.service';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(private readonly usersService: UsersService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: process.env.JWT_ACCESS_SECRET ?? 'changeme-local-secret',
+    });
+  }
+
+  async validate(payload: JwtUserPayload): Promise<JwtUserPayload> {
+    const user = await this.usersService.findById(payload.sub);
+
+    if (!user || user.status !== 'active') {
+      throw new UnauthorizedException('The provided session is no longer valid');
+    }
+
+    return {
+      sub: user.id,
+      email: user.email,
+      role: user.role,
+    };
+  }
+}

--- a/backend/src/common/auth/current-user.decorator.ts
+++ b/backend/src/common/auth/current-user.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, type ExecutionContext } from '@nestjs/common';
+import { type JwtUserPayload } from '../../auth/auth.types';
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, context: ExecutionContext): JwtUserPayload => {
+    const request = context.switchToHttp().getRequest<{ user: JwtUserPayload }>();
+    return request.user;
+  },
+);

--- a/backend/src/common/auth/jwt-auth.guard.ts
+++ b/backend/src/common/auth/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/backend/src/common/auth/roles.decorator.ts
+++ b/backend/src/common/auth/roles.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_METADATA_KEY = 'required_roles';
+
+export const Roles = (...roles: Array<'customer' | 'admin'>) =>
+  SetMetadata(ROLES_METADATA_KEY, roles);

--- a/backend/src/common/auth/roles.guard.ts
+++ b/backend/src/common/auth/roles.guard.ts
@@ -1,0 +1,32 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { type JwtUserPayload } from '../../auth/auth.types';
+import { ROLES_METADATA_KEY } from './roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<
+      Array<'customer' | 'admin'>
+    >(ROLES_METADATA_KEY, [context.getHandler(), context.getClass()]);
+
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<{ user?: JwtUserPayload }>();
+
+    if (!request.user || !requiredRoles.includes(request.user.role)) {
+      throw new ForbiddenException('You do not have access to this resource');
+    }
+
+    return true;
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../persistence/prisma.module';
+import { UsersService } from './users.service';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,0 +1,98 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../persistence/prisma.service';
+import { type UserProfile, type UserProfileStats } from './users.types';
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findByEmail(email: string) {
+    return this.prisma.userAccount.findUnique({
+      where: {
+        email: email.trim().toLowerCase(),
+      },
+    });
+  }
+
+  async findById(id: string) {
+    return this.prisma.userAccount.findUnique({
+      where: { id },
+    });
+  }
+
+  async createCustomerAccount(input: {
+    email: string;
+    passwordHash: string;
+    displayName: string;
+  }) {
+    const normalizedEmail = input.email.trim().toLowerCase();
+    const existing = await this.findByEmail(normalizedEmail);
+
+    if (existing) {
+      throw new ConflictException('An account with this email already exists');
+    }
+
+    return this.prisma.userAccount.create({
+      data: {
+        email: normalizedEmail,
+        passwordHash: input.passwordHash,
+        displayName: input.displayName.trim(),
+        role: 'customer',
+        status: 'active',
+      },
+    });
+  }
+
+  async markSuccessfulLogin(id: string) {
+    return this.prisma.userAccount.update({
+      where: { id },
+      data: {
+        lastLoginAt: new Date(),
+      },
+    });
+  }
+
+  async getProfileById(id: string): Promise<UserProfile> {
+    const user = await this.findById(id);
+
+    if (!user) {
+      throw new NotFoundException('Authenticated account was not found');
+    }
+
+    return this.toProfile(user);
+  }
+
+  toProfile(user: {
+    id: string;
+    email: string;
+    displayName: string;
+    role: 'customer' | 'admin';
+    status: 'active' | 'suspended';
+    lastLoginAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): UserProfile {
+    return {
+      id: user.id,
+      email: user.email,
+      displayName: user.displayName,
+      role: user.role,
+      status: user.status,
+      lastLoginAt: user.lastLoginAt?.toISOString() ?? null,
+      createdAt: user.createdAt.toISOString(),
+      updatedAt: user.updatedAt.toISOString(),
+      profileStats: this.buildEmptyProfileStats(),
+    };
+  }
+
+  private buildEmptyProfileStats(): UserProfileStats {
+    return {
+      totalEstimatedSavings: 0,
+      shoppingListsCount: 0,
+      completedOptimizationRuns: 0,
+      contributionsCount: 0,
+      receiptSubmissionsCount: 0,
+      offerReportsCount: 0,
+    };
+  }
+}

--- a/backend/src/users/users.types.ts
+++ b/backend/src/users/users.types.ts
@@ -1,0 +1,20 @@
+export interface UserProfileStats {
+  totalEstimatedSavings: number;
+  shoppingListsCount: number;
+  completedOptimizationRuns: number;
+  contributionsCount: number;
+  receiptSubmissionsCount: number;
+  offerReportsCount: number;
+}
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  displayName: string;
+  role: 'customer' | 'admin';
+  status: 'active' | 'suspended';
+  lastLoginAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  profileStats: UserProfileStats;
+}

--- a/backend/test/integration/auth/shared-auth.integration.spec.ts
+++ b/backend/test/integration/auth/shared-auth.integration.spec.ts
@@ -1,0 +1,250 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+import { AdminModule } from '../../../src/admin/admin.module';
+import { AuthModule } from '../../../src/auth/auth.module';
+import { HttpExceptionFilter } from '../../../src/common/errors/http-exception.filter';
+import { AppValidationPipe } from '../../../src/common/validation/validation.pipe';
+import { PrismaService } from '../../../src/persistence/prisma.service';
+
+type StoredUser = {
+  id: string;
+  email: string;
+  passwordHash: string;
+  displayName: string;
+  role: 'customer' | 'admin';
+  status: 'active' | 'suspended';
+  lastLoginAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+class PrismaUserAccountMock {
+  private readonly users = new Map<string, StoredUser>();
+
+  seed(user: StoredUser): void {
+    this.users.set(user.id, structuredClone(user));
+  }
+
+  async findUnique(args: {
+    where: { id?: string; email?: string };
+  }): Promise<StoredUser | null> {
+    if (args.where.id) {
+      return this.clone(this.users.get(args.where.id) ?? null);
+    }
+
+    if (args.where.email) {
+      const user =
+        [...this.users.values()].find((entry) => entry.email === args.where.email) ??
+        null;
+      return this.clone(user);
+    }
+
+    return null;
+  }
+
+  async create(args: {
+    data: Pick<StoredUser, 'email' | 'passwordHash' | 'displayName' | 'role' | 'status'>;
+  }): Promise<StoredUser> {
+    const id = crypto.randomUUID();
+    const now = new Date();
+    const user: StoredUser = {
+      id,
+      email: args.data.email,
+      passwordHash: args.data.passwordHash,
+      displayName: args.data.displayName,
+      role: args.data.role,
+      status: args.data.status,
+      lastLoginAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.users.set(id, user);
+    return this.clone(user) as StoredUser;
+  }
+
+  async update(args: {
+    where: { id: string };
+    data: Partial<Pick<StoredUser, 'lastLoginAt' | 'displayName' | 'status'>>;
+  }): Promise<StoredUser> {
+    const existing = this.users.get(args.where.id);
+
+    if (!existing) {
+      throw new Error(`User ${args.where.id} not found`);
+    }
+
+    const updated: StoredUser = {
+      ...existing,
+      ...args.data,
+      updatedAt: new Date(),
+    };
+
+    this.users.set(updated.id, updated);
+    return this.clone(updated) as StoredUser;
+  }
+
+  private clone(user: StoredUser | null): StoredUser | null {
+    return user ? structuredClone(user) : null;
+  }
+}
+
+describe('Shared auth integration', () => {
+  let app: INestApplication;
+  let userAccountMock: PrismaUserAccountMock;
+
+  beforeAll(async () => {
+    process.env.JWT_ACCESS_SECRET = 'test-jwt-secret';
+    userAccountMock = new PrismaUserAccountMock();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AuthModule, AdminModule],
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        userAccount: userAccountMock,
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(new AppValidationPipe());
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('registers a customer account and returns a shared session payload', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: 'cliente@pricely.local',
+        password: 'strong-password',
+        displayName: 'Cliente Pricely',
+      })
+      .expect(201);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        accessToken: expect.any(String),
+        user: expect.objectContaining({
+          email: 'cliente@pricely.local',
+          role: 'customer',
+          profileStats: expect.objectContaining({
+            totalEstimatedSavings: 0,
+            shoppingListsCount: 0,
+            completedOptimizationRuns: 0,
+            contributionsCount: 0,
+            receiptSubmissionsCount: 0,
+            offerReportsCount: 0,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('authenticates an existing account and exposes /auth/me with the same identity', async () => {
+    const registerResponse = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: 'admin@pricely.local',
+        password: 'admin-password',
+        displayName: 'Admin Pricely',
+      })
+      .expect(201);
+
+    const createdUserId = registerResponse.body.user.id as string;
+    await userAccountMock.update({
+      where: { id: createdUserId },
+      data: {},
+    });
+
+    const storedUser = await userAccountMock.findUnique({
+      where: { id: createdUserId },
+    });
+
+    userAccountMock.seed({
+      ...(storedUser as StoredUser),
+      role: 'admin',
+    });
+
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        email: 'admin@pricely.local',
+        password: 'admin-password',
+      })
+      .expect(200);
+
+    const accessToken = loginResponse.body.accessToken as string;
+
+    const meResponse = await request(app.getHttpServer())
+      .get('/auth/me')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(meResponse.body).toEqual(
+      expect.objectContaining({
+        email: 'admin@pricely.local',
+        role: 'admin',
+        profileStats: expect.any(Object),
+      }),
+    );
+  });
+
+  it('enforces admin-only access on protected dashboard endpoints', async () => {
+    const customerRegister = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: 'customer-role@pricely.local',
+        password: 'customer-password',
+        displayName: 'Customer Role',
+      })
+      .expect(201);
+
+    const customerToken = customerRegister.body.accessToken as string;
+
+    await request(app.getHttpServer())
+      .get('/admin/access-check')
+      .set('Authorization', `Bearer ${customerToken}`)
+      .expect(403);
+
+    const adminRegister = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: 'dashboard-admin@pricely.local',
+        password: 'dashboard-password',
+        displayName: 'Dashboard Admin',
+      })
+      .expect(201);
+
+    const adminUserId = adminRegister.body.user.id as string;
+    const adminUser = await userAccountMock.findUnique({
+      where: { id: adminUserId },
+    });
+
+    userAccountMock.seed({
+      ...(adminUser as StoredUser),
+      role: 'admin',
+    });
+
+    const adminLogin = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        email: 'dashboard-admin@pricely.local',
+        password: 'dashboard-password',
+      })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get('/admin/access-check')
+      .set('Authorization', `Bearer ${adminLogin.body.accessToken as string}`)
+      .expect(200)
+      .expect({
+        status: 'ok',
+      });
+  });
+});

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -46,7 +46,7 @@ replanned backend.
 **CRITICAL**: No user story work should begin until this phase is complete.
 
 - [ ] T005 Replace Mongo bootstrap with PostgreSQL/Prisma persistence bootstrap in `backend/src/persistence/`, `backend/src/app.module.ts`, and `backend/src/main.ts`
-- [ ] T006 [P] Implement shared auth module, JWT/session guards, and role enforcement in `backend/src/auth/`, `backend/src/users/`, and `backend/src/common/`
+- [X] T006 [P] Implement shared auth module, JWT/session guards, and role enforcement in `backend/src/auth/`, `backend/src/users/`, and `backend/src/common/`
 - [ ] T007 [P] Introduce shared request logging, correlation IDs, and severity-oriented error mapping in `backend/src/common/logging/`, `backend/src/common/errors/`, and `backend/src/common/validation/`
 - [ ] T008 [P] Add queue-backed processing job persistence and BullMQ worker wiring in `backend/src/common/queue/`, `backend/src/processing/`, and `backend/src/jobs/`
 - [ ] T009 Create core relational entities and Prisma mappings for accounts, regions, establishments, products, offers, lists, optimization runs, and jobs in `backend/prisma/schema.prisma`


### PR DESCRIPTION
## Summary
- add shared auth and users modules backed by Prisma user persistence
- add JWT auth guard, current-user decorator, roles decorator, and roles guard
- add integration coverage for register, login, auth/me, and admin-only access

## Validation
- npm test (backend)
- npm run build (backend)
- npm run lint (backend)
- npm run build (web)
- npm run lint (web)
- npm test (web)
