### PR TITLE
Phase 10: persist preferred city and polish city-first flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ node_modules/
 dist/
 coverage/
 *.tsbuildinfo
+backend/uploads/
 
 # Flutter / Dart
 .dart_tool/

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -122,12 +122,14 @@ model UserAccount {
   displayName      String
   role             UserRole          @default(customer)
   status           UserStatus        @default(active)
+  preferredRegionId String?          @db.Uuid
   lastLoginAt      DateTime?
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt
   shoppingLists    ShoppingList[]
   optimizationRuns OptimizationRun[]
   receiptRecords   ReceiptRecord[]
+  preferredRegion  Region?           @relation("UserPreferredRegion", fields: [preferredRegionId], references: [id], onDelete: SetNull)
 }
 
 model Region {
@@ -143,6 +145,7 @@ model Region {
   establishments  Establishment[]
   shoppingLists   ShoppingList[]
   optimizationRuns OptimizationRun[]
+  preferredByUsers UserAccount[]     @relation("UserPreferredRegion")
 }
 
 model Establishment {

--- a/backend/src/admin/api/admin-dashboard.controller.ts
+++ b/backend/src/admin/api/admin-dashboard.controller.ts
@@ -5,14 +5,23 @@ import {
   Param,
   Patch,
   Post,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { IsBoolean, IsIn, IsNumber, IsOptional, IsString, MaxLength, Min } from 'class-validator';
 
 import { JwtAuthGuard } from '../../common/auth/jwt-auth.guard';
 import { Roles } from '../../common/auth/roles.decorator';
 import { RolesGuard } from '../../common/auth/roles.guard';
 import { AdminDashboardService } from '../application/admin-dashboard.service';
+
+type UploadedMediaFile = {
+  originalname: string;
+  mimetype: string;
+  buffer: Buffer;
+};
 
 class CreateRegionDto {
   @IsString()
@@ -361,6 +370,15 @@ export class AdminDashboardController {
     return this.adminDashboardService.updateProduct(id, body);
   }
 
+  @Post('catalog-products/:id/image')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadCatalogProductImage(
+    @Param('id') id: string,
+    @UploadedFile() file: UploadedMediaFile,
+  ) {
+    return this.adminDashboardService.uploadCatalogProductImage(id, file);
+  }
+
   @Get('product-variants')
   async listProductVariants() {
     return this.adminDashboardService.listProductVariants();
@@ -377,6 +395,15 @@ export class AdminDashboardController {
     @Body() body: UpdateProductVariantDto,
   ) {
     return this.adminDashboardService.updateProductVariant(id, body);
+  }
+
+  @Post('product-variants/:id/image')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadProductVariantImage(
+    @Param('id') id: string,
+    @UploadedFile() file: UploadedMediaFile,
+  ) {
+    return this.adminDashboardService.uploadProductVariantImage(id, file);
   }
 
   @Get('offers')

--- a/backend/src/admin/application/admin-dashboard.service.ts
+++ b/backend/src/admin/application/admin-dashboard.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 import { CatalogProductsService } from '../../catalog/application/catalog-products.service';
+import { CatalogMediaService } from '../../catalog/application/catalog-media.service';
 import { EstablishmentsService } from '../../establishments/application/establishments.service';
 import { PrismaService } from '../../persistence/prisma.service';
 import { OfferManagementService } from '../../pricing/application/offer-management.service';
@@ -15,6 +16,7 @@ export class AdminDashboardService {
     private readonly regionsAdminService: RegionsAdminService,
     private readonly establishmentsService: EstablishmentsService,
     private readonly catalogProductsService: CatalogProductsService,
+    private readonly catalogMediaService: CatalogMediaService,
     private readonly offerManagementService: OfferManagementService,
   ) {}
 
@@ -252,6 +254,15 @@ export class AdminDashboardService {
     return updated;
   }
 
+  async uploadCatalogProductImage(
+    id: string,
+    file: { buffer: Buffer; mimetype: string; originalname: string },
+  ) {
+    const updated = await this.catalogMediaService.uploadCatalogProductImage(id, file);
+    this.logger.log(`Admin uploaded image for catalog product ${id}`);
+    return updated;
+  }
+
   async listProductVariants() {
     return this.prisma.productVariant.findMany({
       include: {
@@ -295,6 +306,15 @@ export class AdminDashboardService {
 
     this.logger.log(`Admin updated product variant ${id}`);
 
+    return updated;
+  }
+
+  async uploadProductVariantImage(
+    id: string,
+    file: { buffer: Buffer; mimetype: string; originalname: string },
+  ) {
+    const updated = await this.catalogMediaService.uploadProductVariantImage(id, file);
+    this.logger.log(`Admin uploaded image for product variant ${id}`);
     return updated;
   }
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -4,12 +4,14 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Patch,
   Post,
   UseGuards,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
+import { UpdatePreferredRegionDto } from './dto/update-preferred-region.dto';
 import { CurrentUser } from '../common/auth/current-user.decorator';
 import { JwtAuthGuard } from '../common/auth/jwt-auth.guard';
 import { type JwtUserPayload } from './auth.types';
@@ -33,5 +35,14 @@ export class AuthController {
   @UseGuards(JwtAuthGuard)
   async me(@CurrentUser() user: JwtUserPayload) {
     return this.authService.getCurrentUser(user.sub);
+  }
+
+  @Patch('preferred-region')
+  @UseGuards(JwtAuthGuard)
+  async updatePreferredRegion(
+    @CurrentUser() user: JwtUserPayload,
+    @Body() body: UpdatePreferredRegionDto,
+  ) {
+    return this.authService.updatePreferredRegion(user.sub, body.regionSlug);
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -56,12 +56,18 @@ export class AuthService {
     return this.usersService.getProfileById(userId);
   }
 
+  async updatePreferredRegion(userId: string, regionSlug: string) {
+    this.logger.log(`Updating preferred region for user ${userId} to ${regionSlug}`);
+    return this.usersService.updatePreferredRegionBySlug(userId, regionSlug);
+  }
+
   private async buildSession(user: {
     id: string;
     email: string;
     displayName: string;
     role: 'customer' | 'admin';
     status: 'active' | 'suspended';
+    preferredRegionId?: string | null;
     lastLoginAt: Date | null;
     createdAt: Date;
     updatedAt: Date;
@@ -74,7 +80,7 @@ export class AuthService {
 
     return {
       accessToken: await this.jwtService.signAsync(payload),
-      user: this.usersService.toProfile(user),
+      user: await this.usersService.getProfileById(user.id),
     };
   }
 }

--- a/backend/src/auth/dto/update-preferred-region.dto.ts
+++ b/backend/src/auth/dto/update-preferred-region.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class UpdatePreferredRegionDto {
+  @IsString()
+  @MinLength(2)
+  regionSlug!: string;
+}

--- a/backend/src/catalog/api/catalog-media.controller.ts
+++ b/backend/src/catalog/api/catalog-media.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param } from '@nestjs/common';
+
+import { CatalogMediaService } from '../application/catalog-media.service';
+
+@Controller('media')
+export class CatalogMediaController {
+  constructor(private readonly catalogMediaService: CatalogMediaService) {}
+
+  @Get('catalog-products/:fileName')
+  getCatalogProductMedia(@Param('fileName') fileName: string) {
+    return this.catalogMediaService.getCatalogProductMedia(fileName);
+  }
+
+  @Get('product-variants/:fileName')
+  getProductVariantMedia(@Param('fileName') fileName: string) {
+    return this.catalogMediaService.getProductVariantMedia(fileName);
+  }
+}

--- a/backend/src/catalog/application/catalog-media.service.ts
+++ b/backend/src/catalog/application/catalog-media.service.ts
@@ -1,0 +1,133 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  StreamableFile,
+} from '@nestjs/common';
+import { createReadStream, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+
+import { PrismaService } from '../../persistence/prisma.service';
+
+const allowedMimeTypes = new Set(['image/png', 'image/jpeg', 'image/webp']);
+
+@Injectable()
+export class CatalogMediaService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async uploadCatalogProductImage(
+    catalogProductId: string,
+    file: { buffer: Buffer; mimetype: string; originalname: string },
+  ) {
+    this.validateImageFile(file);
+
+    const existing = await this.prisma.catalogProduct.findUnique({
+      where: { id: catalogProductId },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Catalog product was not found');
+    }
+
+    const fileName = this.writeFile('catalog-products', catalogProductId, file);
+    return this.prisma.catalogProduct.update({
+      where: { id: catalogProductId },
+      data: {
+        imageUrl: `/media/catalog-products/${fileName}`,
+      },
+      include: {
+        aliases: true,
+        productVariants: true,
+        _count: {
+          select: {
+            productOffers: true,
+          },
+        },
+      },
+    });
+  }
+
+  async uploadProductVariantImage(
+    productVariantId: string,
+    file: { buffer: Buffer; mimetype: string; originalname: string },
+  ) {
+    this.validateImageFile(file);
+
+    const existing = await this.prisma.productVariant.findUnique({
+      where: { id: productVariantId },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Product variant was not found');
+    }
+
+    const fileName = this.writeFile('product-variants', productVariantId, file);
+    return this.prisma.productVariant.update({
+      where: { id: productVariantId },
+      data: {
+        imageUrl: `/media/product-variants/${fileName}`,
+      },
+    });
+  }
+
+  getCatalogProductMedia(fileName: string) {
+    return this.buildStream('catalog-products', fileName);
+  }
+
+  getProductVariantMedia(fileName: string) {
+    return this.buildStream('product-variants', fileName);
+  }
+
+  private validateImageFile(file?: {
+    buffer: Buffer;
+    mimetype: string;
+    originalname: string;
+  }) {
+    if (!file) {
+      throw new BadRequestException('Image file is required');
+    }
+
+    if (!allowedMimeTypes.has(file.mimetype)) {
+      throw new BadRequestException('Only PNG, JPEG, and WEBP images are supported');
+    }
+  }
+
+  private writeFile(
+    directory: 'catalog-products' | 'product-variants',
+    entityId: string,
+    file: { buffer: Buffer; mimetype: string; originalname: string },
+  ) {
+    const baseDirectory = this.resolveMediaDirectory(directory);
+    mkdirSync(baseDirectory, { recursive: true });
+    const extension = extname(file.originalname) || this.extensionForMimeType(file.mimetype);
+    const fileName = `${entityId}-${Date.now()}${extension}`;
+    writeFileSync(join(baseDirectory, fileName), file.buffer);
+    return fileName;
+  }
+
+  private buildStream(directory: 'catalog-products' | 'product-variants', fileName: string) {
+    const filePath = join(this.resolveMediaDirectory(directory), fileName);
+    if (!existsSync(filePath)) {
+      throw new NotFoundException('Image file was not found');
+    }
+
+    return new StreamableFile(createReadStream(filePath));
+  }
+
+  private resolveMediaDirectory(directory: 'catalog-products' | 'product-variants') {
+    return resolve(
+      process.env.PRODUCT_MEDIA_DIR || join(process.cwd(), 'uploads'),
+      directory,
+    );
+  }
+
+  private extensionForMimeType(mimeType: string) {
+    if (mimeType === 'image/png') {
+      return '.png';
+    }
+    if (mimeType === 'image/webp') {
+      return '.webp';
+    }
+    return '.jpg';
+  }
+}

--- a/backend/src/catalog/application/catalog-products.service.ts
+++ b/backend/src/catalog/application/catalog-products.service.ts
@@ -78,29 +78,30 @@ export class CatalogProductsService {
 
   async searchCatalogProducts(query: string) {
     const normalizedQuery = query.trim();
-
-    if (!normalizedQuery) {
-      return [];
-    }
+    const searchFilter = normalizedQuery
+      ? {
+          OR: [
+            { name: { contains: normalizedQuery, mode: 'insensitive' as const } },
+            { aliases: { some: { alias: { contains: normalizedQuery.toLowerCase() } } } },
+            {
+              productVariants: {
+                some: {
+                  isActive: true,
+                  OR: [
+                    { displayName: { contains: normalizedQuery, mode: 'insensitive' as const } },
+                    { brandName: { contains: normalizedQuery, mode: 'insensitive' as const } },
+                  ],
+                },
+              },
+            },
+          ],
+        }
+      : {};
 
     return this.prisma.catalogProduct.findMany({
       where: {
         isActive: true,
-        OR: [
-          { name: { contains: normalizedQuery, mode: 'insensitive' } },
-          { aliases: { some: { alias: { contains: normalizedQuery.toLowerCase() } } } },
-          {
-            productVariants: {
-              some: {
-                isActive: true,
-                OR: [
-                  { displayName: { contains: normalizedQuery, mode: 'insensitive' } },
-                  { brandName: { contains: normalizedQuery, mode: 'insensitive' } },
-                ],
-              },
-            },
-          },
-        ],
+        ...searchFilter,
       },
       include: {
         productVariants: {
@@ -110,7 +111,7 @@ export class CatalogProductsService {
         },
       },
       orderBy: [{ name: 'asc' }],
-      take: 20,
+      take: normalizedQuery ? 20 : 40,
     });
   }
 

--- a/backend/src/catalog/catalog.module.ts
+++ b/backend/src/catalog/catalog.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 
 import { PrismaModule } from '../persistence/prisma.module';
+import { CatalogMediaController } from './api/catalog-media.controller';
+import { CatalogMediaService } from './application/catalog-media.service';
 import { PublicCatalogController } from './api/public-catalog.controller';
 import { ProductMatchRepository } from './infrastructure/product-match.repository';
 import { ProductMatchService } from './application/product-match.service';
@@ -16,14 +18,16 @@ import { CatalogProductsService } from './application/catalog-products.service';
     ProductMatchService,
     PublicCatalogService,
     CatalogProductsService,
+    CatalogMediaService,
   ],
-  controllers: [PublicCatalogController],
+  controllers: [PublicCatalogController, CatalogMediaController],
   exports: [
     ProductNormalizerService,
     ProductMatchService,
     ProductMatchRepository,
     PublicCatalogService,
     CatalogProductsService,
+    CatalogMediaService,
   ],
 })
 export class CatalogModule {}

--- a/backend/src/common/contracts/auth.contract.ts
+++ b/backend/src/common/contracts/auth.contract.ts
@@ -13,6 +13,7 @@ export interface AuthenticatedUserProfile {
   displayName: string;
   role: 'customer' | 'admin';
   status: 'active' | 'suspended';
+  preferredRegionSlug: string | null;
   lastLoginAt: string | null;
   createdAt: string;
   updatedAt: string;

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -59,6 +59,17 @@ export class UsersService {
       throw new NotFoundException('Authenticated account was not found');
     }
 
+    const preferredRegion = user.preferredRegionId
+      ? await this.prisma.region.findUnique({
+          where: {
+            id: user.preferredRegionId,
+          },
+          select: {
+            slug: true,
+          },
+        })
+      : null;
+
     const [shoppingListsCount, completedOptimizationRuns, aggregatedOptimization, receiptSubmissionsCount] =
       await Promise.all([
         this.prisma.shoppingList.count({
@@ -84,14 +95,38 @@ export class UsersService {
         }),
       ]);
 
-    return this.toProfile(user, {
-      completedOptimizationRuns,
-      contributionsCount: receiptSubmissionsCount,
-      offerReportsCount: 0,
-      receiptSubmissionsCount,
-      shoppingListsCount,
-      totalEstimatedSavings: Number(aggregatedOptimization._sum.estimatedSavings ?? 0),
+    return this.toProfile(
+      user,
+      {
+        completedOptimizationRuns,
+        contributionsCount: receiptSubmissionsCount,
+        offerReportsCount: 0,
+        receiptSubmissionsCount,
+        shoppingListsCount,
+        totalEstimatedSavings: Number(aggregatedOptimization._sum.estimatedSavings ?? 0),
+      },
+      preferredRegion?.slug ?? null,
+    );
+  }
+
+  async updatePreferredRegionBySlug(id: string, regionSlug: string): Promise<UserProfile> {
+    const region = await this.prisma.region.findUnique({
+      where: { slug: regionSlug },
+      select: { id: true, slug: true },
     });
+
+    if (!region) {
+      throw new NotFoundException('Selected city was not found');
+    }
+
+    await this.prisma.userAccount.update({
+      where: { id },
+      data: {
+        preferredRegionId: region.id,
+      },
+    });
+
+    return this.getProfileById(id);
   }
 
   toProfile(
@@ -101,11 +136,13 @@ export class UsersService {
     displayName: string;
     role: 'customer' | 'admin';
     status: 'active' | 'suspended';
+    preferredRegionId?: string | null;
     lastLoginAt: Date | null;
     createdAt: Date;
     updatedAt: Date;
     },
     stats: UserProfileStats = this.buildEmptyProfileStats(),
+    preferredRegionSlug: string | null = null,
   ): UserProfile {
     return {
       id: user.id,
@@ -113,6 +150,7 @@ export class UsersService {
       displayName: user.displayName,
       role: user.role,
       status: user.status,
+      preferredRegionSlug,
       lastLoginAt: user.lastLoginAt?.toISOString() ?? null,
       createdAt: user.createdAt.toISOString(),
       updatedAt: user.updatedAt.toISOString(),

--- a/backend/src/users/users.types.ts
+++ b/backend/src/users/users.types.ts
@@ -13,6 +13,7 @@ export interface UserProfile {
   displayName: string;
   role: 'customer' | 'admin';
   status: 'active' | 'suspended';
+  preferredRegionSlug: string | null;
   lastLoginAt: string | null;
   createdAt: string;
   updatedAt: string;

--- a/backend/test/contract/grocery-optimizer-api.contract.spec.ts
+++ b/backend/test/contract/grocery-optimizer-api.contract.spec.ts
@@ -163,6 +163,32 @@ describe('Grocery optimizer API contract', () => {
         })
         .expect(201);
 
+      const meResponse = await request(app.getHttpServer())
+        .get('/auth/me')
+        .set('Authorization', `Bearer ${customer.accessToken}`)
+        .expect(200);
+
+      expect(meResponse.body).toEqual(
+        expect.objectContaining({
+          id: expect.any(String),
+          preferredRegionSlug: null,
+        }),
+      );
+
+      const preferredRegionResponse = await request(app.getHttpServer())
+        .patch('/auth/preferred-region')
+        .set('Authorization', `Bearer ${customer.accessToken}`)
+        .send({
+          regionSlug,
+        })
+        .expect(200);
+
+      expect(preferredRegionResponse.body).toEqual(
+        expect.objectContaining({
+          preferredRegionSlug: regionSlug,
+        }),
+      );
+
       const optimizationResponse = await request(app.getHttpServer())
         .post(`/shopping-lists/${shoppingListResponse.body.id}/optimize`)
         .set('Authorization', `Bearer ${customer.accessToken}`)
@@ -305,6 +331,22 @@ describe('Grocery optimizer API contract', () => {
         expect.objectContaining({
           id: expect.any(String),
           catalogProductId: createProductResponse.body.id,
+        }),
+      );
+
+      const uploadCatalogImageResponse = await request(app.getHttpServer())
+        .post(`/admin/catalog-products/${createProductResponse.body.id}/image`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .attach('file', Buffer.from('catalog-image'), {
+          filename: 'catalog.png',
+          contentType: 'image/png',
+        })
+        .expect(201);
+
+      expect(uploadCatalogImageResponse.body).toEqual(
+        expect.objectContaining({
+          id: createProductResponse.body.id,
+          imageUrl: expect.stringContaining('/media/catalog-products/'),
         }),
       );
 

--- a/backend/test/integration/admin/admin-processing.integration.spec.ts
+++ b/backend/test/integration/admin/admin-processing.integration.spec.ts
@@ -17,6 +17,7 @@ class AdminProcessingPrismaMock {
     displayName: 'Admin',
     role: 'admin',
     status: 'active',
+    preferredRegionId: null,
     lastLoginAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -50,6 +51,7 @@ class AdminProcessingPrismaMock {
       displayName: 'Admin',
       role: 'admin',
       status: 'active',
+      preferredRegionId: null,
       lastLoginAt: new Date(),
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -58,9 +60,19 @@ class AdminProcessingPrismaMock {
   };
 
   readonly shoppingList = { count: async () => 2 };
-  readonly optimizationRun = { count: async () => 3 };
+  readonly optimizationRun = {
+    count: async () => 3,
+    aggregate: async () => ({
+      _sum: {
+        estimatedSavings: 0,
+      },
+    }),
+  };
   readonly receiptRecord = { count: async () => 0 };
-  readonly region = { count: async () => 1 };
+  readonly region = {
+    count: async () => 1,
+    findUnique: async () => null,
+  };
   readonly establishment = { count: async () => 1 };
   readonly catalogProduct = { count: async () => 1 };
   readonly productOffer = { count: async () => 2 };

--- a/backend/test/integration/auth/preferred-region.integration.spec.ts
+++ b/backend/test/integration/auth/preferred-region.integration.spec.ts
@@ -1,0 +1,42 @@
+import request from 'supertest';
+
+import { createUs1TestApp } from '../../support/us1-app.factory';
+
+describe('preferred region integration', () => {
+  it('persists the preferred region selection on the authenticated user profile', async () => {
+    const { app, auth } = await createUs1TestApp();
+
+    try {
+      const session = await auth.registerCustomer();
+
+      expect(session.user.preferredRegionSlug).toBeNull();
+
+      const updateResponse = await request(app.getHttpServer())
+        .patch('/auth/preferred-region')
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .send({
+          regionSlug: 'sao-paulo-sp',
+        })
+        .expect(200);
+
+      expect(updateResponse.body).toEqual(
+        expect.objectContaining({
+          preferredRegionSlug: 'sao-paulo-sp',
+        }),
+      );
+
+      const meResponse = await request(app.getHttpServer())
+        .get('/auth/me')
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .expect(200);
+
+      expect(meResponse.body).toEqual(
+        expect.objectContaining({
+          preferredRegionSlug: 'sao-paulo-sp',
+        }),
+      );
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/backend/test/integration/auth/shared-auth.integration.spec.ts
+++ b/backend/test/integration/auth/shared-auth.integration.spec.ts
@@ -15,6 +15,7 @@ type StoredUser = {
   displayName: string;
   role: 'customer' | 'admin';
   status: 'active' | 'suspended';
+  preferredRegionId: string | null;
   lastLoginAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
@@ -57,6 +58,7 @@ class PrismaUserAccountMock {
       role: args.data.role,
       status: args.data.status,
       lastLoginAt: null,
+      preferredRegionId: null,
       createdAt: now,
       updatedAt: now,
     };
@@ -67,7 +69,7 @@ class PrismaUserAccountMock {
 
   async update(args: {
     where: { id: string };
-    data: Partial<Pick<StoredUser, 'lastLoginAt' | 'displayName' | 'status'>>;
+    data: Partial<Pick<StoredUser, 'lastLoginAt' | 'displayName' | 'status' | 'preferredRegionId'>>;
   }): Promise<StoredUser> {
     const existing = this.users.get(args.where.id);
 
@@ -105,6 +107,16 @@ class PrismaUserAccountMock {
   readonly receiptRecord = {
     count: async () => 0,
   };
+
+  readonly region = {
+    findUnique: async ({ where }: { where: { id?: string; slug?: string } }) => {
+      if (where.id === 'region-test-1' || where.slug === 'sao-paulo-sp') {
+        return { id: 'region-test-1', slug: 'sao-paulo-sp' };
+      }
+
+      return null;
+    },
+  };
 }
 
 describe('Shared auth integration', () => {
@@ -124,6 +136,7 @@ describe('Shared auth integration', () => {
         shoppingList: userAccountMock.shoppingList,
         optimizationRun: userAccountMock.optimizationRun,
         receiptRecord: userAccountMock.receiptRecord,
+        region: userAccountMock.region,
       })
       .compile();
 

--- a/backend/test/integration/catalog/product-media-upload.integration.spec.ts
+++ b/backend/test/integration/catalog/product-media-upload.integration.spec.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+
+import { PrismaService } from '../../../src/persistence/prisma.service';
+import { createUs1TestApp } from '../../support/us1-app.factory';
+
+describe('product media upload integration', () => {
+  it('stores catalog product imagery through the admin API', async () => {
+    const { app } = await createUs1TestApp();
+
+    try {
+      const prisma = app.get(PrismaService);
+      const registerResponse = await request(app.getHttpServer())
+        .post('/auth/register')
+        .send({
+          email: `admin-media-${Date.now()}@pricely.local`,
+          password: 'admin-password',
+          displayName: 'Admin Media',
+        })
+        .expect(201);
+
+      await prisma.userAccount.update({
+        where: { id: registerResponse.body.user.id as string },
+        data: { role: 'admin' },
+      });
+
+      const loginResponse = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({
+          email: registerResponse.body.user.email,
+          password: 'admin-password',
+        })
+        .expect(200);
+
+      const uploadResponse = await request(app.getHttpServer())
+        .post('/admin/catalog-products/product-test-1/image')
+        .set('Authorization', `Bearer ${loginResponse.body.accessToken as string}`)
+        .attach('file', Buffer.from('fake-png-data'), {
+          filename: 'produto.png',
+          contentType: 'image/png',
+        })
+        .expect(201);
+
+      expect(uploadResponse.body).toEqual(
+        expect.objectContaining({
+          id: 'product-test-1',
+          imageUrl: expect.stringContaining('/media/catalog-products/'),
+        }),
+      );
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/backend/test/support/us1-app.factory.ts
+++ b/backend/test/support/us1-app.factory.ts
@@ -35,6 +35,7 @@ type StoredUser = {
   displayName: string;
   role: 'customer' | 'admin';
   status: 'active' | 'suspended';
+  preferredRegionId: string | null;
   lastLoginAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
@@ -332,7 +333,7 @@ class PrismaUserAccountMock {
     }) => this.create(args),
     update: async (args: {
       where: { id: string };
-      data: Partial<Pick<StoredUser, 'lastLoginAt'>>;
+      data: Partial<Pick<StoredUser, 'lastLoginAt' | 'preferredRegionId'>>;
     }) => this.update(args),
     count: async ({ where }: { where?: { status?: string } }) =>
       [...this.users.values()].filter(
@@ -369,6 +370,7 @@ class PrismaUserAccountMock {
       displayName: args.data.displayName,
       role: args.data.role,
       status: args.data.status,
+      preferredRegionId: null,
       lastLoginAt: null,
       createdAt: now,
       updatedAt: now,
@@ -380,7 +382,7 @@ class PrismaUserAccountMock {
 
   private async update(args: {
     where: { id: string };
-    data: Partial<Pick<StoredUser, 'lastLoginAt'>>;
+    data: Partial<Pick<StoredUser, 'lastLoginAt' | 'preferredRegionId'>>;
   }): Promise<StoredUser> {
     const existing = this.users.get(args.where.id);
 
@@ -403,11 +405,26 @@ class PrismaUserAccountMock {
   }
 
   readonly region = {
-    findUnique: async ({ where }: { where: { id?: string; slug?: string } }) => {
+    findUnique: async ({
+      where,
+      select,
+    }: {
+      where: { id?: string; slug?: string };
+      select?: { id?: boolean; slug?: boolean };
+    }) => {
       const region =
         this.regions.find((entry) => entry.id === where.id || entry.slug === where.slug) ??
         null;
-      return region ? structuredClone(region) : null;
+      if (!region) {
+        return null;
+      }
+      if (select) {
+        return {
+          ...(select.id ? { id: region.id } : {}),
+          ...(select.slug ? { slug: region.slug } : {}),
+        };
+      }
+      return structuredClone(region);
     },
     findFirst: async () => structuredClone(this.regions[0]),
     count: async ({ where }: { where?: { implantationStatus?: string } }) =>
@@ -509,6 +526,14 @@ class PrismaUserAccountMock {
           ).length,
         },
       })),
+    findUnique: async ({ where }: { where: { id: string } }) => {
+      const product = this.catalogProducts.find((entry) => entry.id === where.id);
+      if (!product) {
+        return null;
+      }
+
+      return structuredClone(product);
+    },
     create: async ({ data }: { data: any }) => {
       const product = { id: crypto.randomUUID(), isActive: true, ...data };
       this.catalogProducts.push(product);
@@ -532,6 +557,10 @@ class PrismaUserAccountMock {
           this.catalogProducts.find((product) => product.id === entry.catalogProductId),
         ),
       })),
+    findUnique: async ({ where }: { where: { id: string } }) => {
+      const variant = this.productVariants.find((entry) => entry.id === where.id);
+      return variant ? structuredClone(variant) : null;
+    },
     create: async ({ data }: { data: any }) => {
       const variant = { id: crypto.randomUUID(), isActive: true, ...data };
       this.productVariants.push(variant);
@@ -839,7 +868,9 @@ export async function createUs1TestApp(): Promise<{
     optimizationQueue: QueueStub;
   };
   auth: {
-    registerCustomer: (email?: string) => Promise<{ accessToken: string }>;
+    registerCustomer: (
+      email?: string,
+    ) => Promise<{ accessToken: string; user: Record<string, unknown> }>;
   };
 }> {
   process.env.JWT_ACCESS_SECRET = 'test-jwt-secret';
@@ -958,6 +989,7 @@ export async function createUs1TestApp(): Promise<{
 
         return {
           accessToken: response.body.accessToken as string,
+          user: response.body.user as Record<string, unknown>,
         };
       },
     },

--- a/backend/test/unit/auth/auth.service.spec.ts
+++ b/backend/test/unit/auth/auth.service.spec.ts
@@ -16,6 +16,25 @@ describe('AuthService', () => {
         createdAt: new Date('2026-04-27T10:00:00Z'),
         updatedAt: new Date('2026-04-27T10:00:00Z'),
       }),
+      getProfileById: jest.fn().mockResolvedValue({
+        id: 'user-1',
+        email: 'cliente@pricely.local',
+        displayName: 'Cliente Pricely',
+        role: 'customer',
+        status: 'active',
+        preferredRegionSlug: null,
+        lastLoginAt: null,
+        createdAt: '2026-04-27T10:00:00.000Z',
+        updatedAt: '2026-04-27T10:00:00.000Z',
+        profileStats: {
+          totalEstimatedSavings: 0,
+          shoppingListsCount: 0,
+          completedOptimizationRuns: 0,
+          contributionsCount: 0,
+          receiptSubmissionsCount: 0,
+          offerReportsCount: 0,
+        },
+      }),
       toProfile: jest.fn().mockReturnValue({
         id: 'user-1',
         email: 'cliente@pricely.local',
@@ -63,7 +82,7 @@ describe('AuthService', () => {
         passwordHash: expect.any(String),
       }),
     );
-    expect(usersService.toProfile).toHaveBeenCalled();
+    expect(usersService.getProfileById).toHaveBeenCalledWith('user-1');
   });
 
   it('rejects login when the password does not match', async () => {

--- a/backend/test/unit/users/users.service.spec.ts
+++ b/backend/test/unit/users/users.service.spec.ts
@@ -1,0 +1,73 @@
+import { NotFoundException } from '@nestjs/common';
+
+import { UsersService } from '../../../src/users/users.service';
+
+describe('UsersService', () => {
+  it('updates the preferred region by slug and returns the refreshed profile', async () => {
+    const prisma = {
+      userAccount: {
+        findUnique: jest.fn().mockResolvedValue({
+            id: 'user-1',
+            email: 'cliente@pricely.local',
+            passwordHash: 'hash',
+            displayName: 'Cliente',
+            role: 'customer',
+            status: 'active',
+            lastLoginAt: null,
+            createdAt: new Date('2026-04-29T00:00:00.000Z'),
+            updatedAt: new Date('2026-04-29T00:00:00.000Z'),
+            preferredRegionId: 'region-1',
+          }),
+        update: jest.fn().mockResolvedValue(undefined),
+      },
+      region: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'region-1',
+          slug: 'sao-paulo-sp',
+        }),
+      },
+      shoppingList: {
+        count: jest.fn().mockResolvedValue(0),
+      },
+      optimizationRun: {
+        count: jest.fn().mockResolvedValue(0),
+        aggregate: jest.fn().mockResolvedValue({
+          _sum: {
+            estimatedSavings: 0,
+          },
+        }),
+      },
+      receiptRecord: {
+        count: jest.fn().mockResolvedValue(0),
+      },
+    };
+
+    const service = new UsersService(prisma as never);
+
+    const profile = await service.updatePreferredRegionBySlug('user-1', 'sao-paulo-sp');
+
+    expect(prisma.region.findUnique).toHaveBeenCalledWith({
+      where: { slug: 'sao-paulo-sp' },
+      select: { id: true, slug: true },
+    });
+    expect(prisma.userAccount.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { preferredRegionId: 'region-1' },
+    });
+    expect(profile.preferredRegionSlug).toBe('sao-paulo-sp');
+  });
+
+  it('fails when the preferred region slug does not exist', async () => {
+    const prisma = {
+      region: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+    };
+
+    const service = new UsersService(prisma as never);
+
+    await expect(
+      service.updatePreferredRegionBySlug('user-1', 'cidade-inexistente'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/docs/product/preferred-city-qol-phase-plan.md
+++ b/docs/product/preferred-city-qol-phase-plan.md
@@ -1,0 +1,61 @@
+# Phase 10: Preferred City Persistence and QoL
+
+## Delivery Unit
+
+This phase is intentionally grouped into a single delivery unit on one phase branch.
+The work changes shared auth contracts, persisted user preferences, public web state,
+mobile onboarding, and admin catalog media handling at the same time. Splitting these
+changes into isolated task branches would create temporary contract drift between
+backend, web, and mobile.
+
+## Goals
+
+1. Persist the shopper's chosen city on the shared account.
+2. Force city selection after login when the account has no saved city.
+3. Let later city changes update the same persisted account preference.
+4. Improve the public landing and `/listas` surfaces to communicate value better.
+5. Make list creation clearer, denser, and more visual on web and mobile.
+6. Improve admin catalog management with media upload, PT-BR labels, activation
+   controls, and a dark/light theme switch.
+
+## Scope
+
+### Backend
+
+- Add `preferredRegionId` to `UserAccount`.
+- Include preferred city in auth/profile responses.
+- Add authenticated endpoint to update the preferred city.
+- Store uploaded product and variant media locally and return stable URLs.
+- Keep media handling local to the application for now; no external object storage.
+
+### Web Public
+
+- Remove automatic city assignment after login.
+- Show a blocking city-selection modal when the authenticated user has no preferred city.
+- Move low-value public savings copy out of the landing page.
+- Strengthen public landing hero value proposition.
+- Rework `/listas` to surface account information in cards.
+- Rework list creation with card/table rows, live filtering, and explicit
+  save-only vs save-and-optimize actions.
+
+### Web Admin
+
+- Replace unexplained `slug` labels with PT-BR labels and helper text.
+- Support upload-based product and variant imagery.
+- Replace awkward variant deactivation action placement with a visible `Ativo`
+  column and control.
+- Add dark/light mode switching and stronger field contrast.
+
+### Mobile
+
+- Add a dedicated city-selection screen after login when the user has no saved city.
+- Persist city changes back to the backend.
+- Keep city-changing available after onboarding.
+- Rework list creation to match the comparable-product-first flow more clearly.
+
+## Validation
+
+- Backend follows test-first for new preference/media behavior.
+- Web tests cover city modal, landing copy changes, and list-creation actions.
+- Mobile tests cover required city onboarding and persisted city updates.
+- Final smoke includes Docker boot plus login -> city choose -> list save -> optimize.

--- a/mobile/lib/features/auth/application/auth_controller.dart
+++ b/mobile/lib/features/auth/application/auth_controller.dart
@@ -108,6 +108,18 @@ class AuthController extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> updatePreferredRegion(String regionSlug) async {
+    if (_accessToken == null) {
+      return;
+    }
+
+    _currentUser = await _backendGateway.updatePreferredRegion(
+      accessToken: _accessToken!,
+      regionSlug: regionSlug,
+    );
+    notifyListeners();
+  }
+
   Future<void> signOut() async {
     _accessToken = null;
     _currentUser = null;

--- a/mobile/lib/features/auth/presentation/auth_screen.dart
+++ b/mobile/lib/features/auth/presentation/auth_screen.dart
@@ -107,7 +107,7 @@ class _AuthScreenState extends State<AuthScreen> {
                         const SizedBox(height: 10),
                         Text(
                           _isRegister
-                              ? 'Use a mesma conta no mobile e no web para listas, economia estimada e historico.'
+                              ? 'Use a mesma conta para salvar sua cidade, continuar listas e comprar com checklist no mercado.'
                               : 'Acesse a conta compartilhada para sincronizar listas, cidade e resultados de otimizacao.',
                           style: theme.textTheme.bodyLarge
                               ?.copyWith(color: Colors.white70),

--- a/mobile/lib/features/discovery/application/market_discovery_controller.dart
+++ b/mobile/lib/features/discovery/application/market_discovery_controller.dart
@@ -40,9 +40,6 @@ class MarketDiscoveryController extends ChangeNotifier {
 
     try {
       _regions = await _backendGateway.fetchPublicRegions();
-      if (_regions.isNotEmpty) {
-        _selectedRegionSlug ??= _regions.first.slug;
-      }
 
       await _loadOffersForSelectedRegion();
     } catch (_) {
@@ -76,7 +73,20 @@ class MarketDiscoveryController extends ChangeNotifier {
   }
 
   Future<void> refresh() async {
-    await loadInitialData();
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      _regions = await _backendGateway.fetchPublicRegions();
+      await _loadOffersForSelectedRegion();
+    } catch (_) {
+      _errorMessage = 'Nao foi possivel carregar regioes e ofertas agora.';
+      _offers = <PublicOfferSummary>[];
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
   }
 
   Future<PublicOfferDetail> fetchOfferDetail(String offerId) {

--- a/mobile/lib/features/home/presentation/mobile_home_screen.dart
+++ b/mobile/lib/features/home/presentation/mobile_home_screen.dart
@@ -53,6 +53,22 @@ class _MobileHomeScreenState extends State<MobileHomeScreen> {
         widget.receiptFlowController,
       ]),
       builder: (context, _) {
+        final user = widget.authController.currentUser;
+        if (user != null && (user.preferredRegionSlug == null || user.preferredRegionSlug!.isEmpty)) {
+          return _PreferredCityScreen(
+            authController: widget.authController,
+            discoveryController: widget.discoveryController,
+          );
+        }
+
+        if (user?.preferredRegionSlug != null &&
+            user!.preferredRegionSlug!.isNotEmpty &&
+            widget.discoveryController.selectedRegionSlug != user.preferredRegionSlug) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            widget.discoveryController.selectRegion(user.preferredRegionSlug);
+          });
+        }
+
         final pages = <Widget>[
           _HomeTab(
             authController: widget.authController,
@@ -130,6 +146,100 @@ class _MobileHomeScreenState extends State<MobileHomeScreen> {
   }
 }
 
+class _PreferredCityScreen extends StatelessWidget {
+  const _PreferredCityScreen({
+    required this.authController,
+    required this.discoveryController,
+  });
+
+  final AuthController authController;
+  final MarketDiscoveryController discoveryController;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Escolha sua cidade'),
+      ),
+      body: RefreshIndicator(
+        onRefresh: discoveryController.refresh,
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 28),
+          children: <Widget>[
+            Text(
+              'Antes de continuar, precisamos salvar sua cidade.',
+              style: theme.textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'A cidade fica persistida na sua conta e pode ser trocada depois quando voce quiser.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 20),
+            if (discoveryController.regions.isEmpty && !discoveryController.isLoading)
+              OutlinedButton(
+                onPressed: discoveryController.loadInitialData,
+                child: const Text('Carregar cidades disponíveis'),
+              ),
+            if (discoveryController.isLoading)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 24),
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            ...discoveryController.regions.map(
+              (region) => Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(20),
+                  onTap: () async {
+                    await authController.updatePreferredRegion(region.slug);
+                    await discoveryController.selectRegion(region.slug);
+                  },
+                  child: Ink(
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.surface,
+                      borderRadius: BorderRadius.circular(20),
+                      border: Border.all(color: theme.colorScheme.outlineVariant),
+                    ),
+                    padding: const EdgeInsets.all(18),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Row(
+                          children: <Widget>[
+                            Expanded(
+                              child: Text(
+                                '${region.name} · ${region.stateCode}',
+                                style: theme.textTheme.titleMedium,
+                              ),
+                            ),
+                            Text(
+                              '${region.activeEstablishmentCount} lojas',
+                              style: theme.textTheme.labelMedium,
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 10),
+                        Text(
+                          region.offerCoverageStatus == 'collecting_data'
+                              ? 'Cidade ativa, ainda coletando cobertura.'
+                              : 'Cidade com ofertas e estabelecimentos ativos.',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _HomeTab extends StatelessWidget {
   const _HomeTab({
     required this.authController,
@@ -173,8 +283,8 @@ class _HomeTab extends StatelessWidget {
                     const SizedBox(height: 6),
                     Text(
                       user == null
-                          ? 'Escolha a cidade ativa, veja ofertas do dia e monte sua lista com a mesma conta do web.'
-                          : 'Sua conta e a mesma no web e no mobile. Ajuste a cidade, monte a lista e acompanhe as melhores ofertas do dia.',
+                          ? 'Escolha a cidade ativa, veja ofertas do dia e monte sua lista com continuidade entre web e mobile.'
+                          : 'Sua cidade fica salva na conta. Monte a lista, acompanhe ofertas e use o checklist direto no mercado.',
                       style: theme.textTheme.bodyMedium,
                     ),
                   ],
@@ -202,16 +312,19 @@ class _HomeTab extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 Text(
-                  'Economia estimada',
+                  user == null ? 'Cidade e lista sincronizadas' : 'Economia estimada',
                   style: theme.textTheme.labelLarge
                       ?.copyWith(color: Colors.white70),
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  _formatCurrency(user?.totalEstimatedSavings ?? 0),
+                  user == null
+                      ? 'Escolha a cidade e continue no celular'
+                      : _formatCurrency(user.totalEstimatedSavings),
                   style: theme.textTheme.displaySmall?.copyWith(
                     color: Colors.white,
                     fontWeight: FontWeight.w700,
+                    fontSize: user == null ? 26 : null,
                   ),
                 ),
                 const SizedBox(height: 16),
@@ -266,7 +379,15 @@ class _HomeTab extends StatelessWidget {
                         ),
                       )
                       .toList(),
-                  onChanged: discoveryController.selectRegion,
+                  onChanged: (value) async {
+                    if (value == null) {
+                      return;
+                    }
+                    await discoveryController.selectRegion(value);
+                    if (authController.isAuthenticated) {
+                      await authController.updatePreferredRegion(value);
+                    }
+                  },
                   decoration: const InputDecoration(
                     labelText: 'Cidade ativa',
                   ),

--- a/mobile/lib/features/shared/data/pricely_backend_gateway.dart
+++ b/mobile/lib/features/shared/data/pricely_backend_gateway.dart
@@ -46,6 +46,18 @@ class PricelyBackendGateway {
     return AuthUser.fromJson(response);
   }
 
+  Future<AuthUser> updatePreferredRegion({
+    required String accessToken,
+    required String regionSlug,
+  }) async {
+    final response = await _apiClient.patch<Map<String, dynamic>>(
+      '/auth/preferred-region',
+      accessToken: accessToken,
+      body: <String, dynamic>{'regionSlug': regionSlug},
+    );
+    return AuthUser.fromJson(response);
+  }
+
   Future<List<PublicRegionSummary>> fetchPublicRegions() async {
     final response = await _apiClient.get<List<dynamic>>('/regions');
     return response
@@ -226,7 +238,7 @@ class PricelyBackendGateway {
     return ShoppingListDraft(
       id: json['id'] as String,
       title: json['name'] as String? ?? 'Minha lista',
-      regionId: json['preferredRegionId'] as String? ?? 'sao-paulo-sp',
+      regionId: json['preferredRegionId'] as String? ?? '',
       lastMode: json['lastMode'] as String? ?? 'global_full',
       items: items
           .map(
@@ -412,6 +424,7 @@ class AuthUser {
     required this.receiptSubmissionsCount,
     required this.offerReportsCount,
     required this.totalEstimatedSavings,
+    required this.preferredRegionSlug,
   });
 
   final String id;
@@ -424,6 +437,7 @@ class AuthUser {
   final int receiptSubmissionsCount;
   final int offerReportsCount;
   final double totalEstimatedSavings;
+  final String? preferredRegionSlug;
 
   factory AuthUser.fromJson(Map<String, dynamic> json) {
     final profileStats =
@@ -446,6 +460,7 @@ class AuthUser {
           (profileStats['offerReportsCount'] as num? ?? 0).toInt(),
       totalEstimatedSavings:
           (profileStats['totalEstimatedSavings'] as num? ?? 0).toDouble(),
+      preferredRegionSlug: json['preferredRegionSlug'] as String?,
     );
   }
 }

--- a/mobile/lib/features/shopping_lists/application/shopping_list_controller.dart
+++ b/mobile/lib/features/shopping_lists/application/shopping_list_controller.dart
@@ -198,12 +198,6 @@ class ShoppingListController extends ChangeNotifier {
   }
 
   Future<void> searchCatalog(String query) async {
-    if (query.trim().length < 2) {
-      _catalogResults = <CatalogProductSummary>[];
-      notifyListeners();
-      return;
-    }
-
     _catalogResults = await _backendGateway.searchCatalogProducts(query.trim());
     notifyListeners();
   }

--- a/mobile/lib/features/shopping_lists/presentation/shopping_list_screen.dart
+++ b/mobile/lib/features/shopping_lists/presentation/shopping_list_screen.dart
@@ -41,6 +41,9 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
     _quantityController = TextEditingController(text: '1');
     _unitController = TextEditingController(text: 'un');
     _preferredBrandController = TextEditingController();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.controller.searchCatalog('');
+    });
   }
 
   @override
@@ -104,6 +107,15 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
         ]),
         builder: (context, _) {
           final draft = widget.controller.draft;
+          final preferredRegionSlug =
+              widget.authController.currentUser?.preferredRegionSlug;
+          if (preferredRegionSlug != null &&
+              preferredRegionSlug.isNotEmpty &&
+              draft.regionId.isEmpty) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              widget.controller.updateRegionId(preferredRegionSlug);
+            });
+          }
           _titleController.value = _titleController.value.copyWith(
             text: draft.title,
             selection: TextSelection.collapsed(offset: draft.title.length),
@@ -344,6 +356,7 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
                       _selectedVariantId = null;
                       _brandPreferenceMode = 'any';
                     });
+                    await widget.controller.searchCatalog('');
                   },
                   child: Text(
                     _selectedCatalogProductId == null

--- a/mobile/test/unit/features/auth/auth_controller_test.dart
+++ b/mobile/test/unit/features/auth/auth_controller_test.dart
@@ -103,4 +103,69 @@ void main() {
     expect(controller.currentUser?.role, 'admin');
     expect(await cacheService.loadAuthToken(), 'jwt-456');
   });
+
+  test('updates preferred region through the shared profile endpoint', () async {
+    final cacheService = LocalCacheService(InMemoryKeyValueStore());
+    await cacheService.saveAuthToken('jwt-789');
+
+    final backendGateway = PricelyBackendGateway(
+      HttpApiClient(
+        client: MockClient((request) async {
+          if (request.url.path.endsWith('/auth/me')) {
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'id': 'user-3',
+                'email': 'cliente@pricely.app',
+                'displayName': 'Cliente Pricely',
+                'role': 'customer',
+                'preferredRegionSlug': null,
+                'profileStats': <String, dynamic>{
+                  'shoppingListsCount': 1,
+                  'totalEstimatedSavings': 12.4,
+                  'completedOptimizationRuns': 1,
+                  'contributionsCount': 0,
+                  'receiptSubmissionsCount': 0,
+                  'offerReportsCount': 0,
+                },
+              }),
+              200,
+            );
+          }
+
+          if (request.url.path.endsWith('/auth/preferred-region')) {
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'id': 'user-3',
+                'email': 'cliente@pricely.app',
+                'displayName': 'Cliente Pricely',
+                'role': 'customer',
+                'preferredRegionSlug': 'sao-paulo-sp',
+                'profileStats': <String, dynamic>{
+                  'shoppingListsCount': 1,
+                  'totalEstimatedSavings': 12.4,
+                  'completedOptimizationRuns': 1,
+                  'contributionsCount': 0,
+                  'receiptSubmissionsCount': 0,
+                  'offerReportsCount': 0,
+                },
+              }),
+              200,
+            );
+          }
+
+          return http.Response('{}', 404);
+        }),
+      ),
+    );
+
+    final controller = AuthController(
+      cacheService: cacheService,
+      backendGateway: backendGateway,
+    );
+
+    await controller.bootstrap();
+    await controller.updatePreferredRegion('sao-paulo-sp');
+
+    expect(controller.currentUser?.preferredRegionSlug, 'sao-paulo-sp');
+  });
 }

--- a/mobile/test/unit/features/regions/market_discovery_controller_test.dart
+++ b/mobile/test/unit/features/regions/market_discovery_controller_test.dart
@@ -80,6 +80,11 @@ void main() {
     await controller.loadInitialData();
 
     expect(controller.regions, hasLength(2));
+    expect(controller.selectedRegion, isNull);
+    expect(controller.offers, isEmpty);
+
+    await controller.selectRegion('campinas-sp');
+
     expect(controller.selectedRegion?.slug, 'campinas-sp');
     expect(controller.offers, isEmpty);
 

--- a/mobile/test/widget/features/regions/mobile_home_public_regions_test.dart
+++ b/mobile/test/widget/features/regions/mobile_home_public_regions_test.dart
@@ -18,16 +18,33 @@ import 'package:pricely_mobile/features/shopping_lists/application/shopping_list
 import '../../../support/in_memory_key_value_store.dart';
 
 void main() {
+  testWidgets('forces city selection for authenticated users without a saved city', (
+    tester,
+  ) async {
+    final app = await _buildApp(
+      preselectedRegionSlug: null,
+      bootstrapToken: 'token-123',
+      preferredRegionSlug: null,
+    );
+
+    await tester.pumpWidget(app.widget);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Escolha sua cidade'), findsWidgets);
+    expect(find.textContaining('precisamos salvar sua cidade'), findsOneWidget);
+    expect(find.textContaining('Campinas · SP'), findsOneWidget);
+  });
+
   testWidgets('shows zero-store messaging for collecting regions', (
     tester,
   ) async {
-    final app = await _buildApp(preselectedRegionSlug: null);
+    final app = await _buildApp(preselectedRegionSlug: 'campinas-sp');
 
     await tester.pumpWidget(app.widget);
     await tester.pumpAndSettle();
 
     expect(
-      find.textContaining('Ainda'),
+      find.textContaining('Ainda nao temos estabelecimentos ativos'),
       findsOneWidget,
     );
     expect(
@@ -55,10 +72,33 @@ void main() {
 
 Future<_MobileHomeHarness> _buildApp({
   required String? preselectedRegionSlug,
+  String? bootstrapToken,
+  String? preferredRegionSlug,
 }) async {
   final backendGateway = PricelyBackendGateway(
     HttpApiClient(
       client: MockClient((request) async {
+        if (request.url.path == '/auth/me') {
+          return http.Response(
+            jsonEncode(<String, dynamic>{
+              'id': 'user-1',
+              'email': 'cliente@pricely.app',
+              'displayName': 'Cliente Pricely',
+              'role': 'customer',
+              'preferredRegionSlug': preferredRegionSlug,
+              'profileStats': <String, dynamic>{
+                'shoppingListsCount': 2,
+                'totalEstimatedSavings': 18.9,
+                'completedOptimizationRuns': 1,
+                'contributionsCount': 0,
+                'receiptSubmissionsCount': 0,
+                'offerReportsCount': 0,
+              },
+            }),
+            200,
+          );
+        }
+
         if (request.url.path == '/regions') {
           return http.Response(
             jsonEncode(<dynamic>[
@@ -159,6 +199,9 @@ Future<_MobileHomeHarness> _buildApp({
   );
 
   final cacheService = LocalCacheService(InMemoryKeyValueStore());
+  if (bootstrapToken != null) {
+    await cacheService.saveAuthToken(bootstrapToken);
+  }
   final authController = AuthController(
     cacheService: cacheService,
     backendGateway: backendGateway,

--- a/mobile/test/widget/features/shopping_lists/shopping_list_screen_test.dart
+++ b/mobile/test/widget/features/shopping_lists/shopping_list_screen_test.dart
@@ -231,6 +231,21 @@ void main() {
             );
           }
 
+          if (request.url.path.contains('/catalog-products/search')) {
+            return http.Response(
+              jsonEncode(<dynamic>[
+                <String, dynamic>{
+                  'id': 'catalog-1',
+                  'name': 'Cafe torrado',
+                  'category': 'Mercearia',
+                  'defaultUnit': 'un',
+                  'imageUrl': 'https://example.com/cafe.jpg',
+                },
+              ]),
+              200,
+            );
+          }
+
           return http.Response('{}', 200);
         }),
       ),

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -14,7 +14,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Minha lista'), findsOneWidget);
+    expect(find.text('Precos com contexto real'), findsOneWidget);
   });
 }
 

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -262,6 +262,29 @@ Stitch direction while preserving the validated backend behavior.
 
 ---
 
+## Phase 10: Preferred City Persistence and Cross-Surface QoL
+
+**Purpose**: Persist the shopper's chosen city on the shared account, force city
+selection after login, improve list-creation clarity, and harden admin catalog UX
+for media, activation state, and theme visibility.
+
+### Tests for Preferred City and QoL
+
+- [X] T090 [P] Add backend unit, integration, and contract tests for persisted user city preference, city-update APIs, and product media upload in `backend/test/unit/users/`, `backend/test/integration/auth/`, `backend/test/integration/catalog/`, and `backend/test/contract/`
+- [X] T091 [P] Add web tests for post-login city-selection modal, landing copy changes, richer `/listas` account cards, save-vs-optimize actions, and live product-row filtering in `web/src/public/` and `web/src/dashboard/`
+- [X] T092 [P] Add mobile tests for required city onboarding after login, persisted city changes, and richer list-creation product picking in `mobile/test/widget/features/auth/`, `mobile/test/widget/features/regions/`, and `mobile/test/widget/features/shopping_lists/`
+
+### Implementation for Preferred City and QoL
+
+- [X] T093 [P] Persist preferred city on the shared user account, expose read/update APIs, and synchronize auth/profile contracts in `backend/prisma/schema.prisma`, `backend/src/users/`, `backend/src/auth/`, `backend/src/common/contracts/`, and related DTOs/controllers
+- [X] T094 [P] Implement backend product media upload/storage and admin-friendly activation metadata for products and variants in `backend/src/catalog/`, `backend/src/admin/`, `backend/src/common/`, and local media storage wiring
+- [X] T095 [P] Refactor the web public journey so authenticated users must choose a city when none is stored, landing copy highlights concrete value, `/listas` exposes account stats in cards, list creation uses richer card/table rows with live filtering, and users can choose between save-only or save-and-optimize in `web/src/public/`, `web/src/app/`, and `web/src/routes/`
+- [X] T096 [P] Refactor the web admin dashboard to use PT-BR labels for technical fields, add upload-driven product imagery, move variant activation into a dedicated visible active column, and add dark/light mode switching with stronger field contrast in `web/src/dashboard/`, `web/src/components/`, `web/src/app/`, and `web/src/index.css`
+- [X] T097 [P] Refactor the mobile auth/home/list flows so a logged-in user without a saved city lands on a dedicated city-selection screen, city changes persist to the backend, and list creation follows the richer comparable-product picker in `mobile/lib/features/auth/`, `mobile/lib/features/home/`, `mobile/lib/features/regions/`, and `mobile/lib/features/shopping_lists/`
+- [X] T098 [P] Run final cross-surface validation for preferred-city persistence, product media upload, web/mobile list creation, dashboard theme switching, and Docker-backed boot flows in `backend/test/`, `web/src/`, `mobile/test/`, `docs/local-development.md`, and smoke scripts
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -9,6 +9,7 @@ type AuthSessionResponse = {
     email: string;
     displayName: string;
     role: 'customer' | 'admin';
+    preferredRegionSlug: string | null;
     profileStats: {
       totalEstimatedSavings: number;
       shoppingListsCount: number;
@@ -326,7 +327,12 @@ async function apiFetch<T>(
   token?: string | null,
 ): Promise<T> {
   const headers = new Headers(init.headers);
-  headers.set('Content-Type', 'application/json');
+  const isFormDataBody =
+    typeof FormData !== 'undefined' && init.body instanceof FormData;
+
+  if (!isFormDataBody) {
+    headers.set('Content-Type', 'application/json');
+  }
 
   if (token) {
     headers.set('Authorization', `Bearer ${token}`);
@@ -365,6 +371,17 @@ export async function signUp(
 
 export async function fetchMe(token: string) {
   return apiFetch<AuthSessionResponse['user']>('/auth/me', {}, token);
+}
+
+export async function updatePreferredRegion(token: string, regionSlug: string) {
+  return apiFetch<AuthSessionResponse['user']>(
+    '/auth/preferred-region',
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ regionSlug }),
+    },
+    token,
+  );
 }
 
 export async function fetchPublicRegions() {
@@ -608,6 +625,23 @@ export async function updateAdminProduct(
   );
 }
 
+export async function uploadAdminProductImage(
+  token: string,
+  id: string,
+  file: File,
+) {
+  const formData = new FormData();
+  formData.append('file', file);
+  return apiFetch<AdminProductResponse>(
+    `/admin/catalog-products/${id}/image`,
+    {
+      method: 'POST',
+      body: formData,
+    },
+    token,
+  );
+}
+
 export async function fetchAdminProductVariants(token: string) {
   return apiFetch<AdminProductVariantResponse[]>('/admin/product-variants', {}, token);
 }
@@ -636,6 +670,23 @@ export async function updateAdminProductVariant(
     {
       method: 'PATCH',
       body: JSON.stringify(input),
+    },
+    token,
+  );
+}
+
+export async function uploadAdminProductVariantImage(
+  token: string,
+  id: string,
+  file: File,
+) {
+  const formData = new FormData();
+  formData.append('file', file);
+  return apiFetch<AdminProductVariantResponse>(
+    `/admin/product-variants/${id}/image`,
+    {
+      method: 'POST',
+      body: formData,
     },
     token,
   );
@@ -684,7 +735,7 @@ export function mapShoppingList(apiList: ShoppingListApiResponse): ShoppingList 
   return {
     id: apiList.id,
     name: apiList.name,
-    cityId: apiList.preferredRegionId ?? 'sao-paulo-sp',
+    cityId: apiList.preferredRegionId ?? '',
     lastMode: apiList.lastMode,
     updatedAt: apiList.updatedAt,
     expectedSavings: 0,

--- a/web/src/app/media.ts
+++ b/web/src/app/media.ts
@@ -11,6 +11,43 @@ export const neutralProductFallback =
     </svg>`,
   );
 
+export const landingHeroImage =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 720">
+      <defs>
+        <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+          <stop offset="0%" stop-color="#E8F7F3"/>
+          <stop offset="100%" stop-color="#EAF2FF"/>
+        </linearGradient>
+      </defs>
+      <rect width="960" height="720" rx="48" fill="url(#bg)"/>
+      <rect x="96" y="96" width="768" height="528" rx="40" fill="#FFFFFF" opacity="0.92"/>
+      <rect x="148" y="156" width="300" height="46" rx="23" fill="#0F766E" opacity="0.18"/>
+      <rect x="148" y="224" width="228" height="26" rx="13" fill="#2563EB" opacity="0.16"/>
+      <rect x="148" y="282" width="660" height="240" rx="28" fill="#F3F8F6"/>
+      <rect x="186" y="316" width="168" height="168" rx="24" fill="#D8F0EA"/>
+      <rect x="390" y="316" width="168" height="168" rx="24" fill="#E0EDFF"/>
+      <rect x="594" y="316" width="168" height="168" rx="24" fill="#E7F6D8"/>
+      <circle cx="270" cy="402" r="42" fill="#0F766E" opacity="0.28"/>
+      <circle cx="474" cy="402" r="42" fill="#2563EB" opacity="0.28"/>
+      <circle cx="678" cy="402" r="42" fill="#84CC16" opacity="0.28"/>
+      <rect x="186" y="552" width="260" height="24" rx="12" fill="#0F766E" opacity="0.18"/>
+      <rect x="478" y="552" width="200" height="24" rx="12" fill="#2563EB" opacity="0.18"/>
+      <rect x="720" y="552" width="88" height="24" rx="12" fill="#84CC16" opacity="0.22"/>
+    </svg>`,
+  );
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000';
+
 export function resolveProductImage(imageUrl?: string | null) {
-  return imageUrl && imageUrl.trim().length > 0 ? imageUrl : neutralProductFallback;
+  if (!imageUrl || imageUrl.trim().length === 0) {
+    return neutralProductFallback;
+  }
+
+  if (imageUrl.startsWith('/')) {
+    return `${apiBaseUrl}${imageUrl}`;
+  }
+
+  return imageUrl;
 }

--- a/web/src/app/pricely-context.tsx
+++ b/web/src/app/pricely-context.tsx
@@ -18,6 +18,7 @@ import {
   runOptimization as runOptimizationRequest,
   signIn as signInRequest,
   signUp as signUpRequest,
+  updatePreferredRegion as updatePreferredRegionRequest,
   updateShoppingListItemPurchaseStatus,
   type OptimizationResultApiResponse,
 } from './api';
@@ -33,8 +34,8 @@ type SessionUser = {
 
 interface PricelyContextValue {
   accessToken: string | null;
-  cityId: string;
-  setCityId: (cityId: string) => void;
+  cityId: string | null;
+  setCityId: (cityId: string) => Promise<void>;
   cities: typeof supportedCities;
   lists: ShoppingList[];
   selectedListId: string;
@@ -92,7 +93,7 @@ function emptyProfile() {
 }
 
 export function PricelyProvider({ children }: PropsWithChildren) {
-  const [cityId, setCityId] = useState(supportedCities[0].id);
+  const [cityId, setCityIdState] = useState<string | null>(null);
   const [cities, setCities] = useState(supportedCities);
   const [lists, setLists] = useState<ShoppingList[]>([]);
   const [selectedListId, setSelectedListId] = useState('');
@@ -166,7 +167,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
         }>;
 
         if (parsed.cityId) {
-          setCityId(parsed.cityId);
+          setCityIdState(parsed.cityId);
         }
         if (parsed.selectedListId) {
           setSelectedListId(parsed.selectedListId);
@@ -221,9 +222,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
         });
         setLists(mappedLists);
         setSelectedListId((current) => current || mappedLists[0]?.id || '');
-        if (mappedLists[0]?.cityId) {
-          setCityId(mappedLists[0].cityId);
-        }
+        setCityIdState(user.preferredRegionSlug ?? null);
       } catch {
         if (!disposed) {
           window.localStorage.removeItem(TOKEN_KEY);
@@ -231,6 +230,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
           setLists([]);
           setProfile(emptyProfile());
           setCurrentUser(null);
+          setCityIdState(null);
         }
       } finally {
         if (!disposed) {
@@ -245,6 +245,23 @@ export function PricelyProvider({ children }: PropsWithChildren) {
       disposed = true;
     };
   }, [token]);
+
+  const setCityId = async (nextCityId: string) => {
+    setCityIdState(nextCityId);
+
+    if (!token) {
+      return;
+    }
+
+    const updatedUser = await updatePreferredRegionRequest(token, nextCityId);
+    setCurrentUser({
+      id: updatedUser.id,
+      email: updatedUser.email,
+      displayName: updatedUser.displayName,
+      role: updatedUser.role,
+    });
+    setProfile(mapProfile(updatedUser));
+  };
 
   const value = useMemo<PricelyContextValue>(
     () => ({
@@ -272,6 +289,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
         });
         setProfile(mapProfile(session.user));
         setToken(session.accessToken);
+        setCityIdState(session.user.preferredRegionSlug ?? null);
       },
       signUp: async (email, password, displayName) => {
         const session = await signUpRequest(email, password, displayName);
@@ -284,6 +302,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
         });
         setProfile(mapProfile(session.user));
         setToken(session.accessToken);
+        setCityIdState(session.user.preferredRegionSlug ?? null);
       },
       signOut: () => {
         window.localStorage.removeItem(TOKEN_KEY);
@@ -293,6 +312,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
         setSelectedListId('');
         setOptimizationResults({});
         setProfile(emptyProfile());
+        setCityIdState(null);
       },
       saveList: async (input) => {
         if (!token) {

--- a/web/src/app/theme-context.tsx
+++ b/web/src/app/theme-context.tsx
@@ -1,0 +1,62 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from 'react';
+
+type ThemeMode = 'light' | 'dark';
+
+type ThemeContextValue = {
+  theme: ThemeMode;
+  setTheme: (theme: ThemeMode) => void;
+  toggleTheme: () => void;
+};
+
+const STORAGE_KEY = 'pricely-theme-mode';
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: PropsWithChildren) {
+  const [theme, setThemeState] = useState<ThemeMode>('light');
+
+  useEffect(() => {
+    const storedTheme = window.localStorage.getItem(STORAGE_KEY);
+    if (storedTheme === 'dark' || storedTheme === 'light') {
+      setThemeState(storedTheme);
+      return;
+    }
+
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setThemeState('dark');
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      setTheme: (nextTheme) => setThemeState(nextTheme),
+      toggleTheme: () => setThemeState((current) => (current === 'dark' ? 'light' : 'dark')),
+    }),
+    [theme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error('useTheme must be used inside ThemeProvider');
+  }
+
+  return context;
+}

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/web/src/dashboard/admin-shell.tsx
+++ b/web/src/dashboard/admin-shell.tsx
@@ -11,10 +11,12 @@ import {
 } from 'lucide-react';
 
 import { usePricely } from '@/app/pricely-context';
+import { useTheme } from '@/app/theme-context';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
 import {
   Sidebar,
   SidebarContent,
@@ -71,6 +73,7 @@ const adminNav = [
 
 export function AdminLayout() {
   const { currentUser, isAuthenticated } = usePricely();
+  const { theme, toggleTheme } = useTheme();
 
   if (!isAuthenticated || currentUser?.role !== 'admin') {
     return (
@@ -151,6 +154,12 @@ export function AdminLayout() {
             </div>
           </div>
           <div className="hidden items-center gap-2 md:flex">
+            <div className="flex items-center gap-2 rounded-lg border border-border/70 bg-card/80 px-3 py-2">
+              <span className="text-xs text-muted-foreground">
+                {theme === 'dark' ? 'Escuro' : 'Claro'}
+              </span>
+              <Switch checked={theme === 'dark'} onCheckedChange={toggleTheme} />
+            </div>
             <Badge variant="secondary">Acesso admin</Badge>
             <Button asChild size="sm" variant="outline">
               <Link to="/">Voltar para o publico</Link>
@@ -158,7 +167,7 @@ export function AdminLayout() {
           </div>
         </header>
 
-        <div className="flex flex-1 flex-col gap-6 px-4 py-6 lg:px-6">
+        <div className="flex flex-1 flex-col gap-6 bg-[radial-gradient(circle_at_top_left,rgba(15,118,110,0.08),transparent_26%),radial-gradient(circle_at_85%_15%,rgba(37,99,235,0.06),transparent_22%)] px-4 py-6 lg:px-6">
           <Outlet />
         </div>
       </SidebarInset>

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent } from 'react';
+﻿import { useEffect, useState, type FormEvent } from 'react';
 
 import {
   type AdminEstablishmentResponse,
@@ -26,14 +26,18 @@ import {
   updateAdminProduct,
   updateAdminProductVariant,
   updateAdminRegion,
+  uploadAdminProductImage,
+  uploadAdminProductVariantImage,
 } from '@/app/api';
 import { formatCurrency, formatFreshnessLabel } from '@/app/format';
+import { resolveProductImage } from '@/app/media';
 import { usePricely } from '@/app/pricely-context';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 
 function useAdminData<T>(loader: (token: string) => Promise<T>, initialValue: T) {
@@ -489,12 +493,13 @@ export function AdminCatalogPage() {
   const { accessToken } = usePricely();
   const [editingProductId, setEditingProductId] = useState<string | null>(null);
   const [editingVariantId, setEditingVariantId] = useState<string | null>(null);
+  const [productImageFile, setProductImageFile] = useState<File | null>(null);
+  const [variantImageFile, setVariantImageFile] = useState<File | null>(null);
   const [form, setForm] = useState({
     slug: '',
     name: '',
     category: '',
     defaultUnit: '',
-    imageUrl: '',
     alias: '',
   });
   const [variantForm, setVariantForm] = useState({
@@ -504,7 +509,6 @@ export function AdminCatalogPage() {
     brandName: '',
     variantLabel: '',
     packageLabel: '',
-    imageUrl: '',
   });
 
   const handleCreate = async (event: FormEvent) => {
@@ -513,12 +517,15 @@ export function AdminCatalogPage() {
       return;
     }
 
-    if (editingProductId) {
-      await updateAdminProduct(accessToken, editingProductId, form);
-    } else {
-      await createAdminProduct(accessToken, form);
+    const savedProduct = editingProductId
+      ? await updateAdminProduct(accessToken, editingProductId, form)
+      : await createAdminProduct(accessToken, form);
+
+    if (productImageFile) {
+      await uploadAdminProductImage(accessToken, savedProduct.id, productImageFile);
     }
-    setForm({ slug: '', name: '', category: '', defaultUnit: '', imageUrl: '', alias: '' });
+    setForm({ slug: '', name: '', category: '', defaultUnit: '', alias: '' });
+    setProductImageFile(null);
     setEditingProductId(null);
     await reload();
   };
@@ -529,10 +536,12 @@ export function AdminCatalogPage() {
       return;
     }
 
-    if (editingVariantId) {
-      await updateAdminProductVariant(accessToken, editingVariantId, variantForm);
-    } else {
-      await createAdminProductVariant(accessToken, variantForm);
+    const savedVariant = editingVariantId
+      ? await updateAdminProductVariant(accessToken, editingVariantId, variantForm)
+      : await createAdminProductVariant(accessToken, variantForm);
+
+    if (variantImageFile) {
+      await uploadAdminProductVariantImage(accessToken, savedVariant.id, variantImageFile);
     }
     setVariantForm({
       catalogProductId: '',
@@ -541,8 +550,8 @@ export function AdminCatalogPage() {
       brandName: '',
       variantLabel: '',
       packageLabel: '',
-      imageUrl: '',
     });
+    setVariantImageFile(null);
     setEditingVariantId(null);
     await reloadVariants();
     await reload();
@@ -557,12 +566,12 @@ export function AdminCatalogPage() {
           </CardHeader>
           <CardContent>
             <form className="grid gap-3" onSubmit={handleCreate}>
-              <Input placeholder="slug" value={form.slug} onChange={(event) => setForm((current) => ({ ...current, slug: event.target.value }))} />
-              <Input placeholder="nome" value={form.name} onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))} />
-              <Input placeholder="categoria" value={form.category} onChange={(event) => setForm((current) => ({ ...current, category: event.target.value }))} />
-              <Input placeholder="unidade padrao" value={form.defaultUnit} onChange={(event) => setForm((current) => ({ ...current, defaultUnit: event.target.value }))} />
-              <Input placeholder="imagem do produto" value={form.imageUrl} onChange={(event) => setForm((current) => ({ ...current, imageUrl: event.target.value }))} />
-              <Input placeholder="alias inicial" value={form.alias} onChange={(event) => setForm((current) => ({ ...current, alias: event.target.value }))} />
+              <Input placeholder="Identificador da URL" value={form.slug} onChange={(event) => setForm((current) => ({ ...current, slug: event.target.value }))} />
+              <Input placeholder="Nome do produto" value={form.name} onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))} />
+              <Input placeholder="Categoria" value={form.category} onChange={(event) => setForm((current) => ({ ...current, category: event.target.value }))} />
+              <Input placeholder="Unidade padrão" value={form.defaultUnit} onChange={(event) => setForm((current) => ({ ...current, defaultUnit: event.target.value }))} />
+              <Input placeholder="Alias inicial" value={form.alias} onChange={(event) => setForm((current) => ({ ...current, alias: event.target.value }))} />
+              <Input accept="image/png,image/jpeg,image/webp" onChange={(event) => setProductImageFile(event.target.files?.[0] ?? null)} type="file" />
               <Button type="submit">{editingProductId ? 'Salvar produto' : 'Criar produto'}</Button>
             </form>
           </CardContent>
@@ -587,12 +596,12 @@ export function AdminCatalogPage() {
                   </option>
                 ))}
               </select>
-              <Input placeholder="slug da variante" value={variantForm.slug} onChange={(event) => setVariantForm((current) => ({ ...current, slug: event.target.value }))} />
-              <Input placeholder="nome exibido" value={variantForm.displayName} onChange={(event) => setVariantForm((current) => ({ ...current, displayName: event.target.value }))} />
-              <Input placeholder="marca" value={variantForm.brandName} onChange={(event) => setVariantForm((current) => ({ ...current, brandName: event.target.value }))} />
-              <Input placeholder="linha ou tipo" value={variantForm.variantLabel} onChange={(event) => setVariantForm((current) => ({ ...current, variantLabel: event.target.value }))} />
-              <Input placeholder="embalagem" value={variantForm.packageLabel} onChange={(event) => setVariantForm((current) => ({ ...current, packageLabel: event.target.value }))} />
-              <Input placeholder="imagem da variante" value={variantForm.imageUrl} onChange={(event) => setVariantForm((current) => ({ ...current, imageUrl: event.target.value }))} />
+              <Input placeholder="Identificador da URL da variante" value={variantForm.slug} onChange={(event) => setVariantForm((current) => ({ ...current, slug: event.target.value }))} />
+              <Input placeholder="Nome exibido" value={variantForm.displayName} onChange={(event) => setVariantForm((current) => ({ ...current, displayName: event.target.value }))} />
+              <Input placeholder="Marca" value={variantForm.brandName} onChange={(event) => setVariantForm((current) => ({ ...current, brandName: event.target.value }))} />
+              <Input placeholder="Linha ou tipo" value={variantForm.variantLabel} onChange={(event) => setVariantForm((current) => ({ ...current, variantLabel: event.target.value }))} />
+              <Input placeholder="Embalagem" value={variantForm.packageLabel} onChange={(event) => setVariantForm((current) => ({ ...current, packageLabel: event.target.value }))} />
+              <Input accept="image/png,image/jpeg,image/webp" onChange={(event) => setVariantImageFile(event.target.files?.[0] ?? null)} type="file" />
               <Button type="submit" variant="outline">{editingVariantId ? 'Salvar variante' : 'Criar variante'}</Button>
             </form>
           </CardContent>
@@ -623,11 +632,12 @@ export function AdminCatalogPage() {
                         <img
                           alt={product.name}
                           className="mb-3 h-24 w-24 rounded-lg border border-border/70 object-cover"
-                          src={previewImage}
+                          src={resolveProductImage(previewImage)}
                         />
                       ) : null}
                       <div className="font-medium">{product.name}</div>
                       <div className="text-sm text-muted-foreground">{product.category} - {product.defaultUnit ?? 'sem unidade padrao'}</div>
+                      <div className="text-xs text-muted-foreground">URL pública: {product.slug}</div>
                     </div>
                     <Badge variant="secondary">{product._count.productOffers} ofertas</Badge>
                   </div>
@@ -642,9 +652,9 @@ export function AdminCatalogPage() {
                           name: product.name,
                           category: product.category,
                           defaultUnit: product.defaultUnit ?? '',
-                          imageUrl: product.imageUrl ?? '',
                           alias: '',
                         });
+                        setProductImageFile(null);
                       }}
                     >
                       Editar produto
@@ -670,47 +680,59 @@ export function AdminCatalogPage() {
                   </div>
                   <div className="mt-3 flex flex-wrap gap-2">
                     {productVariants.map((variant) => (
-                      <button
-                        key={variant.id}
-                        className="rounded-md border border-border bg-muted px-2 py-1 text-sm"
-                        type="button"
-                        onClick={() => {
-                          setEditingVariantId(variant.id);
-                          setVariantForm({
-                            catalogProductId: variant.catalogProductId,
-                            slug: variant.slug ?? '',
-                            displayName: variant.displayName,
-                            brandName: variant.brandName ?? '',
-                            variantLabel: variant.variantLabel ?? '',
-                            packageLabel: variant.packageLabel ?? '',
-                            imageUrl: variant.imageUrl ?? '',
-                          });
-                        }}
-                      >
-                        {variant.brandName ? `${variant.brandName} - ` : ''}{variant.displayName}
-                      </button>
+                      <div key={variant.id} className="min-w-[280px] rounded-lg border border-border/70 bg-muted/20 p-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex items-center gap-3">
+                            <img
+                              alt={variant.displayName}
+                              className="h-12 w-12 rounded-lg border border-border/70 object-cover"
+                              src={resolveProductImage(variant.imageUrl)}
+                            />
+                            <div className="grid gap-1">
+                              <div className="text-sm font-medium">
+                                {variant.brandName ? `${variant.brandName} - ` : ''}{variant.displayName}
+                              </div>
+                              <div className="text-xs text-muted-foreground">
+                                {variant.packageLabel ?? 'Sem embalagem'} · URL pública: {variant.slug ?? 'não definida'}
+                              </div>
+                            </div>
+                          </div>
+                          <Button
+                            size="sm"
+                            type="button"
+                            variant="ghost"
+                            onClick={() => {
+                              setEditingVariantId(variant.id);
+                              setVariantForm({
+                                catalogProductId: variant.catalogProductId,
+                                slug: variant.slug ?? '',
+                                displayName: variant.displayName,
+                                brandName: variant.brandName ?? '',
+                                variantLabel: variant.variantLabel ?? '',
+                                packageLabel: variant.packageLabel ?? '',
+                              });
+                              setVariantImageFile(null);
+                            }}
+                          >
+                            Editar
+                          </Button>
+                        </div>
+                        <div className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-border/70 bg-background/80 px-3 py-2">
+                          <span className="text-sm font-medium">Ativo</span>
+                          <Switch
+                            checked={variant.isActive}
+                            onCheckedChange={async (checked) => {
+                              if (!accessToken) {
+                                return;
+                              }
+                              await updateAdminProductVariant(accessToken, variant.id, { isActive: checked });
+                              await reloadVariants();
+                            }}
+                          />
+                        </div>
+                      </div>
                     ))}
                   </div>
-                  {productVariants.length > 0 ? (
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      {productVariants.map((variant) => (
-                        <Button
-                          key={`${variant.id}-toggle`}
-                          size="sm"
-                          variant="ghost"
-                          onClick={async () => {
-                            if (!accessToken) {
-                              return;
-                            }
-                            await updateAdminProductVariant(accessToken, variant.id, { isActive: !variant.isActive });
-                            await reloadVariants();
-                          }}
-                        >
-                          {variant.isActive ? `Desativar ${variant.displayName}` : `Ativar ${variant.displayName}`}
-                        </Button>
-                      ))}
-                    </div>
-                  ) : null}
                 </div>
               );
             })
@@ -767,7 +789,7 @@ export function AdminRegionsPage() {
             </Alert>
           ) : null}
           <form className="grid gap-3" onSubmit={handleCreate}>
-            <Input placeholder="slug" value={form.slug} onChange={(event) => setForm((current) => ({ ...current, slug: event.target.value }))} />
+            <Input placeholder="Identificador da URL" value={form.slug} onChange={(event) => setForm((current) => ({ ...current, slug: event.target.value }))} />
             <Input placeholder="nome da cidade" value={form.name} onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))} />
             <Input placeholder="UF" value={form.stateCode} onChange={(event) => setForm((current) => ({ ...current, stateCode: event.target.value }))} />
             <select className="h-10 rounded-md border border-input bg-background px-3 text-sm" value={form.implantationStatus} onChange={(event) => setForm((current) => ({ ...current, implantationStatus: event.target.value }))}>
@@ -799,11 +821,11 @@ export function AdminRegionsPage() {
                 <div>
                   <div className="font-medium">{region.name} · {region.stateCode}</div>
                   <div className="text-sm text-muted-foreground">
-                    {region.slug} · {region.establishmentsCount} estabelecimentos ativos
+                    URL pública: {region.slug} · {region.establishmentsCount} estabelecimentos ativos
                   </div>
                 </div>
                 <Badge variant={region.implantationStatus === 'active' ? 'secondary' : 'outline'}>
-                  {region.implantationStatus === 'active' ? 'ativa' : region.implantationStatus === 'activating' ? 'em ativacao' : 'inativa'}
+                  {region.implantationStatus === 'active' ? 'ativa' : region.implantationStatus === 'activating' ? 'em ativa?o' : 'inativa'}
                 </Badge>
               </div>
               <div className="mt-3">
@@ -1063,3 +1085,5 @@ export function AdminQueuePage() {
     </div>
   );
 }
+
+

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,16 +3,19 @@ import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 
 import { PricelyProvider } from './app/pricely-context';
+import { ThemeProvider } from './app/theme-context';
 import { TooltipProvider } from './components/ui/tooltip';
 import './index.css';
 import { appRouter } from './routes/app-router';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <TooltipProvider>
-      <PricelyProvider>
-        <RouterProvider router={appRouter} />
-      </PricelyProvider>
-    </TooltipProvider>
+    <ThemeProvider>
+      <TooltipProvider>
+        <PricelyProvider>
+          <RouterProvider router={appRouter} />
+        </PricelyProvider>
+      </TooltipProvider>
+    </ThemeProvider>
   </React.StrictMode>,
 );

--- a/web/src/public/list-editor-page.spec.tsx
+++ b/web/src/public/list-editor-page.spec.tsx
@@ -90,32 +90,11 @@ describe('ListEditorPage', () => {
     });
 
     await waitFor(() =>
-      expect(screen.getByText('Selecione um produto comparavel')).toBeTruthy(),
+      expect(screen.getByRole('button', { name: 'Configurar' })).toBeTruthy(),
     );
 
-    fireEvent.change(screen.getByDisplayValue('Selecione um produto comparavel'), {
-      target: { value: 'catalog-1' },
-    });
+    fireEvent.click(screen.getByRole('button', { name: 'Adicionar' }));
 
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Configurar marca' })).toBeTruthy(),
-    );
-
-    expect(
-      (screen.getByRole('button', { name: 'Adicionar item' }) as HTMLButtonElement).disabled,
-    ).toBe(false);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Configurar marca' }));
-    fireEvent.change(screen.getByDisplayValue('Qualquer marca'), {
-      target: { value: 'preferred' },
-    });
-    fireEvent.change(screen.getByLabelText('Marca preferida'), {
-      target: { value: 'Camil' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Fechar' }));
-
-    fireEvent.click(screen.getByRole('button', { name: 'Adicionar item' }));
-
-    expect(await screen.findByText('Preferir: Camil')).toBeTruthy();
+    expect(await screen.findByText('Qualquer marca')).toBeTruthy();
   });
 });

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -6,11 +6,12 @@ import {
   BadgeCheckIcon,
   ChevronRightIcon,
   LogInIcon,
+  MapPinIcon,
   ShieldAlertIcon,
 } from 'lucide-react';
 
 import { formatCurrency, formatDateTime, formatFreshnessLabel } from '@/app/format';
-import { resolveProductImage } from '@/app/media';
+import { landingHeroImage, resolveProductImage } from '@/app/media';
 import {
   getCityById,
   optimizationModes,
@@ -304,8 +305,8 @@ function AuthCard({
 }
 
 export function LandingPage() {
-  const { cityId, cities, currentUser, profile } = usePricely();
-  const city = cities.find((entry) => entry.id === cityId) ?? getCityById(cityId);
+  const { cityId, cities, currentUser } = usePricely();
+  const city = cityId ? cities.find((entry) => entry.id === cityId) ?? getCityById(cityId) : null;
   const [featuredOffers, setFeaturedOffers] = useState<
     Array<{
       id: string;
@@ -323,6 +324,11 @@ export function LandingPage() {
     let disposed = false;
 
     const load = async () => {
+      if (!cityId) {
+        setFeaturedOffers([]);
+        return;
+      }
+
       try {
         const response = await fetchRegionOffers(cityId);
         if (disposed) {
@@ -364,15 +370,15 @@ export function LandingPage() {
         <div className="flex flex-col justify-between rounded-xl border border-border/70 bg-card/85 p-6 shadow-sm sm:p-8">
           <div className="flex flex-col gap-5">
             <Badge variant="secondary" className="w-fit">
-              mesma conta no mobile e no web
+              lista salva, cidade persistida e compra pronta no mercado
             </Badge>
             <div className="flex flex-col gap-4">
               <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
                 Decida sua compra por cidade, lista e preco observado.
               </h1>
               <p className="max-w-2xl text-lg text-muted-foreground">
-                Escolha a cidade ativa, monte a lista com produtos reais e compare os tres
-                modos de otimizacao sem perder o historico entre web e mobile.
+                Monte a lista no computador, continue no celular e chegue ao mercado com
+                a cidade certa, os produtos comparaveis definidos e a melhor estrategia de compra.
               </p>
             </div>
             <div className="flex flex-wrap gap-3">
@@ -391,21 +397,23 @@ export function LandingPage() {
           <div className="mt-8 grid gap-3 sm:grid-cols-3">
             <Card size="sm">
               <CardHeader>
-                <CardTitle>Conta unica</CardTitle>
-                <CardDescription>Mesmo login em todas as superficies.</CardDescription>
+                <CardTitle>Continua do desktop ao corredor</CardTitle>
+                <CardDescription>Escolha a cidade uma vez, monte a lista no web e use o checklist no celular.</CardDescription>
               </CardHeader>
             </Card>
             <Card size="sm">
               <CardHeader>
-                <CardTitle>Economia estimada</CardTitle>
-                <CardDescription>{formatCurrency(profile.totalEstimatedSavings)} acumulados.</CardDescription>
+                <CardTitle>Lista reaproveitavel</CardTitle>
+                <CardDescription>Salve uma vez e reotimize depois quando os precos mudarem.</CardDescription>
               </CardHeader>
             </Card>
             <Card size="sm">
               <CardHeader>
-                <CardTitle>Cidade ativa</CardTitle>
+                <CardTitle>Cidade com contexto real</CardTitle>
                 <CardDescription>
-                  {city.name} - {city.activeStoreCount} estabelecimentos ativos
+                  {city
+                    ? `${city.name} - ${city.activeStoreCount} estabelecimentos ativos`
+                    : 'Escolha uma cidade para carregar cobertura e ofertas publicas'}
                 </CardDescription>
               </CardHeader>
             </Card>
@@ -414,9 +422,9 @@ export function LandingPage() {
 
         <div className="relative overflow-hidden rounded-xl border border-border/70 shadow-sm">
           <img
-            alt="Pessoa organizando compras no supermercado"
+            alt="Visao geral do fluxo de compras por cidade no Pricely"
             className="h-full min-h-[360px] w-full object-cover"
-            src={resolveProductImage()}
+            src={landingHeroImage}
           />
         </div>
       </section>
@@ -452,7 +460,7 @@ export function LandingPage() {
       </section>
 
       <section className="grid gap-4 lg:grid-cols-3">
-        {featuredOffers.map((offer) => (
+        {featuredOffers.length > 0 ? featuredOffers.map((offer) => (
           <Card key={offer.id} className="overflow-hidden">
             <div className="aspect-[16/9] overflow-hidden">
               <img alt={offer.productName} className="h-full w-full object-cover" src={offer.imageUrl} />
@@ -471,7 +479,17 @@ export function LandingPage() {
               <div className="text-2xl font-semibold">{formatCurrency(offer.price)}</div>
             </CardContent>
           </Card>
-        ))}
+        )) : (
+          <Card className="lg:col-span-3">
+            <CardHeader>
+              <CardTitle>Escolha uma cidade para ver ofertas reais</CardTitle>
+              <CardDescription>
+                A vitrine publica depende da cidade selecionada. Depois disso mostramos produtos,
+                lojas, preco observado e confianca da informacao.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        )}
       </section>
     </div>
   );
@@ -479,13 +497,18 @@ export function LandingPage() {
 
 export function OffersPage() {
   const { cityId, cities } = usePricely();
-  const city = cities.find((entry) => entry.id === cityId) ?? getCityById(cityId);
+  const city = cityId ? cities.find((entry) => entry.id === cityId) ?? getCityById(cityId) : null;
   const [offers, setOffers] = useState<RegionOffersApiResponse['offers']>([]);
 
   useEffect(() => {
     let disposed = false;
 
     const load = async () => {
+      if (!cityId) {
+        setOffers([]);
+        return;
+      }
+
       try {
         const response = await fetchRegionOffers(cityId);
         if (!disposed) {
@@ -510,9 +533,21 @@ export function OffersPage() {
       <div className="flex flex-col gap-2">
         <h1 className="text-3xl font-semibold tracking-tight">Ofertas por cidade</h1>
         <p className="text-muted-foreground">
-          {city.name}. Ofertas publicas mostram loja, frescor, confianca e detalhe completo do item.
+          {city
+            ? `${city.name}. Ofertas publicas mostram loja, frescor, confianca e detalhe completo do item.`
+            : 'Selecione uma cidade para carregar as ofertas publicas desta regiao.'}
         </p>
       </div>
+
+      {!cityId ? (
+        <Alert>
+          <MapPinIcon />
+          <AlertTitle>Escolha uma cidade primeiro</AlertTitle>
+          <AlertDescription>
+            A cidade define quais lojas e precos entram na vitrine publica.
+          </AlertDescription>
+        </Alert>
+      ) : null}
 
       <div className="grid gap-4 lg:grid-cols-3">
         {offers.map((offer) => (
@@ -727,7 +762,7 @@ export function SignInPage() {
   return (
     <AuthCard
       ctaLabel="Entrar"
-      description="Use a mesma conta do mobile para acessar listas, otimizacoes e historico."
+      description="Entre para salvar sua cidade, reaproveitar listas e continuar a compra no celular."
       onSubmit={({ email, password }) => signIn(email, password)}
       title="Entrar no Pricely"
     />
@@ -740,7 +775,7 @@ export function SignUpPage() {
   return (
     <AuthCard
       ctaLabel="Criar conta"
-      description="Sua conta sera compartilhada entre web e mobile com o mesmo historico."
+      description="Crie uma conta para salvar sua cidade, sincronizar listas e usar checklist no mercado."
       includeDisplayName
       onSubmit={({ displayName, email, password }) =>
         signUp(email, password, displayName ?? 'Cliente Pricely')
@@ -751,7 +786,8 @@ export function SignUpPage() {
 }
 
 export function ListsPage() {
-  const { lists, profile } = usePricely();
+  const { cityId, currentUser, lists, profile } = usePricely();
+  const currentCity = cityId ? getCityById(cityId) : null;
 
   return (
     <RequireAuthentication
@@ -771,23 +807,38 @@ export function ListsPage() {
           </Button>
         </div>
 
-        <div className="grid gap-4 md:grid-cols-3">
-          <Card>
+        <div className="grid gap-4 lg:grid-cols-4">
+          <Card className="border-border/70 bg-card/90 shadow-sm">
+            <CardHeader>
+              <CardDescription>Conta ativa</CardDescription>
+              <CardTitle>{currentUser?.displayName ?? 'Minha conta'}</CardTitle>
+              <div className="text-sm text-muted-foreground">{currentUser?.email}</div>
+            </CardHeader>
+          </Card>
+          <Card className="border-border/70 bg-card/90 shadow-sm">
+            <CardHeader>
+              <CardDescription>Cidade salva</CardDescription>
+              <CardTitle>{currentCity ? `${currentCity.name} · ${currentCity.stateCode}` : 'Cidade pendente'}</CardTitle>
+              <div className="text-sm text-muted-foreground">
+                {currentCity
+                  ? `${currentCity.activeStoreCount} estabelecimentos ativos`
+                  : 'Escolha a cidade para carregar cobertura e ofertas'}
+              </div>
+            </CardHeader>
+          </Card>
+          <Card className="border-border/70 bg-card/90 shadow-sm">
             <CardHeader>
               <CardDescription>Listas criadas</CardDescription>
               <CardTitle>{profile.listsCreated}</CardTitle>
             </CardHeader>
           </Card>
-          <Card>
+          <Card className="border-border/70 bg-card/90 shadow-sm">
             <CardHeader>
-              <CardDescription>Economia estimada</CardDescription>
+              <CardDescription>Economia estimada acumulada</CardDescription>
               <CardTitle>{formatCurrency(profile.totalEstimatedSavings)}</CardTitle>
-            </CardHeader>
-          </Card>
-          <Card>
-            <CardHeader>
-              <CardDescription>Contribuicoes</CardDescription>
-              <CardTitle>{profile.receiptsShared + profile.invalidPromotionReports}</CardTitle>
+              <div className="text-sm text-muted-foreground">
+                Visivel depois do login para refletir o uso real da conta.
+              </div>
             </CardHeader>
           </Card>
         </div>
@@ -803,7 +854,7 @@ export function ListsPage() {
         ) : (
           <div className="grid gap-4 lg:grid-cols-2">
             {lists.map((list) => (
-              <Card key={list.id}>
+              <Card key={list.id} className="border-border/70 bg-card/90 shadow-sm">
                 <CardHeader>
                   <CardTitle>{list.name}</CardTitle>
                   <CardDescription>
@@ -981,7 +1032,7 @@ export function ListEditorPage() {
   const { cityId, cities, lists, preferredMode, saveList } = usePricely();
   const editingList = listId === 'nova' ? undefined : lists.find((entry) => entry.id === listId);
   const [name, setName] = useState(editingList?.name ?? '');
-  const [selectedCityId, setSelectedCityId] = useState(editingList?.cityId ?? cityId);
+  const [selectedCityId, setSelectedCityId] = useState(editingList?.cityId ?? cityId ?? '');
   const [mode, setMode] = useState<OptimizationModeId>(editingList?.lastMode ?? preferredMode);
   const [items, setItems] = useState<EditableListItem[]>(() => buildEditableItems(editingList));
   const [draftName, setDraftName] = useState('');
@@ -999,6 +1050,52 @@ export function ListEditorPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [isSearchingCatalog, setIsSearchingCatalog] = useState(false);
 
+  const persistList = async (optimizeAfterSave: boolean) => {
+    setError(null);
+
+    if (!selectedCityId) {
+      setError('Escolha a cidade da lista antes de salvar.');
+      return;
+    }
+
+    if (!name.trim()) {
+      setError('Defina um nome para a lista antes de salvar.');
+      return;
+    }
+
+    if (items.length === 0) {
+      setError('Adicione pelo menos um item antes de salvar a lista.');
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      const saved = await saveList({
+        id: editingList?.id,
+        name: name.trim(),
+        cityId: selectedCityId,
+        lastMode: mode,
+        items: items.map((item) => ({
+          name: item.name,
+          catalogProductId: item.catalogProductId,
+          lockedProductVariantId: item.lockedProductVariantId,
+          brandPreferenceMode: item.brandPreferenceMode,
+          preferredBrandNames: item.preferredBrandNames,
+          purchaseStatus: item.purchaseStatus,
+          quantity: item.quantity,
+          unitLabel: item.unitLabel,
+          note: item.note,
+        })),
+      });
+      navigate(optimizeAfterSave ? `/otimizacao/${saved.id}` : '/listas');
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Nao foi possivel salvar a lista.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   useEffect(() => {
     if (!editingList) {
       return;
@@ -1014,11 +1111,6 @@ export function ListEditorPage() {
     let disposed = false;
 
     const loadCatalog = async () => {
-      if (draftName.trim().length < 2) {
-        setCatalogResults([]);
-        return;
-      }
-
       setIsSearchingCatalog(true);
       try {
         const results = await searchCatalogProducts(draftName.trim());
@@ -1043,17 +1135,18 @@ export function ListEditorPage() {
     };
   }, [draftName]);
 
-  const addItem = () => {
-    if (!draftName.trim() || !selectedCatalogProduct) {
+  const addItem = (product = selectedCatalogProduct) => {
+    if (!product) {
       return;
     }
 
+    const displayName = draftName.trim() || product.name;
     setItems((current) => [
       ...current,
       {
         id: `draft-${Date.now()}`,
-        name: draftName.trim(),
-        catalogProductId: selectedCatalogProduct?.id,
+        name: displayName,
+        catalogProductId: product.id,
         lockedProductVariantId: draftBrandPreferenceMode === 'exact' ? selectedVariantId || undefined : undefined,
         brandPreferenceMode: draftBrandPreferenceMode,
         preferredBrandNames:
@@ -1062,7 +1155,7 @@ export function ListEditorPage() {
             : [],
         imageUrl:
           selectedVariants.find((variant) => variant.id === selectedVariantId)?.imageUrl ??
-          selectedCatalogProduct?.imageUrl ??
+          product.imageUrl ??
           undefined,
         quantity: Number.isFinite(Number(draftQuantity)) ? Number(draftQuantity) : 1,
         unitLabel: draftUnit.trim() || 'un',
@@ -1102,33 +1195,7 @@ export function ListEditorPage() {
 
   const handleSave = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setError(null);
-    setIsSaving(true);
-
-    try {
-      const saved = await saveList({
-        id: editingList?.id,
-        name: name.trim(),
-        cityId: selectedCityId,
-        lastMode: mode,
-        items: items.map((item) => ({
-          name: item.name,
-          catalogProductId: item.catalogProductId,
-          lockedProductVariantId: item.lockedProductVariantId,
-          brandPreferenceMode: item.brandPreferenceMode,
-          preferredBrandNames: item.preferredBrandNames,
-          purchaseStatus: item.purchaseStatus,
-          quantity: item.quantity,
-          unitLabel: item.unitLabel,
-          note: item.note,
-        })),
-      });
-      navigate(`/otimizacao/${saved.id}`);
-    } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : 'Nao foi possivel salvar a lista.');
-    } finally {
-      setIsSaving(false);
-    }
+    await persistList(false);
   };
 
   return (
@@ -1146,12 +1213,26 @@ export function ListEditorPage() {
               Monte a lista em etapas. Salve sem processar ou siga direto para a otimizacao.
             </p>
           </div>
-          <Button disabled={isSaving} type="submit">
-            {isSaving ? 'Salvando...' : 'Salvar lista'}
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              disabled={isSaving || !selectedCityId || items.length === 0 || !name.trim()}
+              onClick={() => void persistList(false)}
+              type="button"
+              variant="outline"
+            >
+              {isSaving ? 'Salvando...' : 'Salvar'}
+            </Button>
+            <Button
+              disabled={isSaving || !selectedCityId || items.length === 0 || !name.trim()}
+              onClick={() => void persistList(true)}
+              type="button"
+            >
+              {isSaving ? 'Salvando...' : 'Salvar e otimizar'}
+            </Button>
+          </div>
         </div>
 
-        <Card>
+        <Card className="border-border/70 bg-card/90 shadow-sm">
           <CardHeader>
             <CardTitle>1. Defina o contexto da compra</CardTitle>
             <CardDescription>
@@ -1171,6 +1252,7 @@ export function ListEditorPage() {
                 onChange={(event) => setSelectedCityId(event.target.value)}
                 value={selectedCityId}
               >
+                <option value="">Selecione a cidade da lista</option>
                 {cities.map((city) => (
                   <option key={city.id} value={city.id}>
                     {city.name} - {city.activeStoreCount} estabelecimentos ativos
@@ -1181,16 +1263,15 @@ export function ListEditorPage() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="border-border/70 bg-card/90 shadow-sm">
           <CardHeader>
             <CardTitle>2. Adicione itens reais da sua compra</CardTitle>
             <CardDescription>
-              Pesquise o produto base, revise a regra de marca e adicione o item so quando o
-              catalogo comparavel estiver definido.
+              Digite o produto e filtre em tempo real. Se nao digitar nada, mostramos o catalogo completo.
             </CardDescription>
           </CardHeader>
           <CardContent className="grid gap-4">
-            <div className="grid gap-3 rounded-lg border border-dashed border-border/70 p-4 md:grid-cols-[1.8fr_0.7fr_0.7fr]">
+            <div className="grid gap-3 rounded-lg border border-dashed border-border/70 bg-muted/20 p-4 md:grid-cols-[1.8fr_0.7fr_0.7fr]">
               <Field>
                 <FieldLabel htmlFor="draft-item-name">Produto</FieldLabel>
                 <Input
@@ -1221,66 +1302,95 @@ export function ListEditorPage() {
                 />
               </Field>
               <Field className="md:col-span-3">
-                <FieldLabel>Produto comparavel</FieldLabel>
-                <div className="grid gap-2">
-                  <select
-                    className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-                    onChange={async (event) => {
-                      const product =
-                        catalogResults.find((entry) => entry.id === event.target.value) ?? null;
-                      setSelectedCatalogProduct(product);
-                      setSelectedVariantId('');
-
-                      if (!product) {
-                        setSelectedVariants([]);
-                        return;
-                      }
-
-                      const variants = await fetchCatalogProductVariants(product.id);
-                      setSelectedVariants(variants);
-                    }}
-                    value={selectedCatalogProduct?.id ?? ''}
-                  >
-                    <option value="">
-                      {isSearchingCatalog
-                        ? 'Buscando no catalogo...'
-                        : 'Selecione um produto comparavel'}
-                    </option>
-                    {catalogResults.map((product) => (
-                      <option key={product.id} value={product.id}>
-                        {product.name}
-                      </option>
-                    ))}
-                  </select>
-                  {selectedCatalogProduct ? (
-                    <div className="flex items-center justify-between gap-3 rounded-lg border border-border/70 p-3 text-sm text-muted-foreground">
-                      <div className="flex items-center gap-3">
-                        {selectedCatalogProduct.imageUrl ? (
-                          <img
-                            alt={selectedCatalogProduct.name}
-                            className="h-12 w-12 rounded-lg border border-border/70 object-cover"
-                            src={selectedCatalogProduct.imageUrl}
-                          />
-                        ) : null}
-                        <div className="grid gap-1">
-                          <span>Produto base: {selectedCatalogProduct.name}</span>
-                          <span>{describeBrandRule({ brandPreferenceMode: draftBrandPreferenceMode, preferredBrandNames: draftPreferredBrand.trim() ? [draftPreferredBrand.trim()] : [] })}</span>
-                        </div>
-                      </div>
-                      <Button type="button" variant="outline" size="sm" onClick={() => setIsBrandDialogOpen(true)}>
-                        Configurar marca
-                      </Button>
-                    </div>
-                  ) : draftName.trim().length >= 2 ? (
-                    <Alert>
-                      <AlertCircleIcon />
-                      <AlertTitle>Selecione um produto base</AlertTitle>
-                      <AlertDescription>
-                        A lista agora trabalha primeiro com produto comparavel e so depois com
-                        preferencia de marca.
-                      </AlertDescription>
-                    </Alert>
-                  ) : null}
+                <FieldLabel>Produtos comparaveis</FieldLabel>
+                <div className="overflow-hidden rounded-lg border border-border/70">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Produto</TableHead>
+                        <TableHead>Marca</TableHead>
+                        <TableHead>Quantidade</TableHead>
+                        <TableHead className="text-right">Adicionar</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {catalogResults.length === 0 && !isSearchingCatalog ? (
+                        <TableRow>
+                          <TableCell className="text-muted-foreground" colSpan={4}>
+                            Nenhum produto comparavel encontrado.
+                          </TableCell>
+                        </TableRow>
+                      ) : null}
+                      {catalogResults.map((product) => {
+                        const isSelected = selectedCatalogProduct?.id === product.id;
+                        return (
+                          <TableRow key={product.id} className={isSelected ? 'bg-primary/5' : undefined}>
+                            <TableCell>
+                              <div className="flex items-center gap-3">
+                                <img
+                                  alt={product.name}
+                                  className="h-14 w-14 rounded-lg border border-border/70 object-cover"
+                                  src={resolveProductImage(product.imageUrl)}
+                                />
+                                <div className="grid gap-1">
+                                  <div className="font-medium">{product.name}</div>
+                                  <div className="text-xs text-muted-foreground">
+                                    {product.category} · {product.defaultUnit ?? 'sem unidade padrao'}
+                                  </div>
+                                </div>
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <div className="grid gap-2">
+                                <span className="text-sm text-muted-foreground">
+                                  {isSelected
+                                    ? describeBrandRule({
+                                        brandPreferenceMode: draftBrandPreferenceMode,
+                                        preferredBrandNames: draftPreferredBrand.trim() ? [draftPreferredBrand.trim()] : [],
+                                      })
+                                    : 'Qualquer marca'}
+                                </span>
+                                <Button
+                                  onClick={async () => {
+                                    setSelectedCatalogProduct(product);
+                                    setSelectedVariantId('');
+                                    const variants = await fetchCatalogProductVariants(product.id);
+                                    setSelectedVariants(variants);
+                                    setIsBrandDialogOpen(true);
+                                  }}
+                                  size="sm"
+                                  type="button"
+                                  variant="outline"
+                                >
+                                  Configurar
+                                </Button>
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <div className="text-sm text-muted-foreground">
+                                {draftQuantity} {draftUnit.trim() || 'un'}
+                              </div>
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <Button
+                                onClick={async () => {
+                                  setSelectedCatalogProduct(product);
+                                  if (selectedCatalogProduct?.id !== product.id) {
+                                    setSelectedVariantId('');
+                                    setSelectedVariants(await fetchCatalogProductVariants(product.id));
+                                  }
+                                  addItem(product);
+                                }}
+                                type="button"
+                              >
+                                Adicionar
+                              </Button>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
                 </div>
               </Field>
               <Field className="md:col-span-3">
@@ -1292,16 +1402,6 @@ export function ListEditorPage() {
                   value={draftNote}
                 />
               </Field>
-              <div className="md:col-span-3">
-                <Button
-                  disabled={!selectedCatalogProduct}
-                  onClick={addItem}
-                  type="button"
-                  variant="outline"
-                >
-                  Adicionar item
-                </Button>
-              </div>
             </div>
 
             {items.length === 0 ? (
@@ -1325,7 +1425,7 @@ export function ListEditorPage() {
                         <img
                           alt={item.name}
                           className="h-16 w-16 rounded-lg border border-border/70 object-cover"
-                          src={item.imageUrl}
+                          src={resolveProductImage(item.imageUrl)}
                         />
                       ) : null}
                       <div className="grid gap-1">
@@ -1411,7 +1511,7 @@ export function ListEditorPage() {
           </DialogContent>
         </Dialog>
 
-        <Card>
+        <Card className="border-border/70 bg-card/90 shadow-sm">
           <CardHeader>
             <CardTitle>3. Salve agora ou otimize depois</CardTitle>
             <CardDescription>
@@ -1613,7 +1713,7 @@ export function OptimizationPage() {
                                 <img
                                   alt={selection.shoppingListItemName}
                                   className="h-14 w-14 rounded-lg border border-border/70 object-cover"
-                                  src={listItemsById.get(selection.shoppingListItemId)?.imageUrl}
+                                  src={resolveProductImage(listItemsById.get(selection.shoppingListItemId)?.imageUrl)}
                                 />
                               ) : null}
                               <div className="flex flex-col gap-1">

--- a/web/src/public/public-shell.spec.tsx
+++ b/web/src/public/public-shell.spec.tsx
@@ -43,6 +43,13 @@ vi.mock('@/app/pricely-context', () => ({
   }),
 }));
 
+vi.mock('@/app/theme-context', () => ({
+  useTheme: () => ({
+    theme: 'light',
+    toggleTheme: vi.fn(),
+  }),
+}));
+
 vi.mock('@/components/ui/select', () => {
   const collectItems = (children: unknown): Array<{ value: string; label: string }> => {
     const items: Array<{ value: string; label: string }> = [];

--- a/web/src/public/public-shell.tsx
+++ b/web/src/public/public-shell.tsx
@@ -1,8 +1,17 @@
 import { Link, NavLink, Outlet } from 'react-router-dom';
-import { MapPinIcon, ShieldCheckIcon, SparklesIcon } from 'lucide-react';
+import { MapPinIcon, MoonStarIcon, ShieldCheckIcon, SparklesIcon, SunMediumIcon } from 'lucide-react';
 
 import { usePricely } from '@/app/pricely-context';
+import { useTheme } from '@/app/theme-context';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import {
   Select,
   SelectContent,
@@ -11,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 
 function AppLogo() {
   return (
@@ -30,8 +40,15 @@ const linkClassName = ({ isActive }: { isActive: boolean }) =>
   isActive ? 'text-foreground' : 'text-muted-foreground transition-colors hover:text-foreground';
 
 export function PublicLayout() {
-  const { cityId, cities, currentUser, isAuthenticated, setCityId, signOut } = usePricely();
-  const activeCity = cities.find((city) => city.id === cityId) ?? cities[0];
+  const { cityId, cities, currentUser, isAuthenticated, isBootstrapping, setCityId, signOut } =
+    usePricely();
+  const { theme, toggleTheme } = useTheme();
+  const activeCity = cityId ? cities.find((city) => city.id === cityId) ?? null : null;
+  const shouldRequireCitySelection =
+    isAuthenticated && !isBootstrapping && !cityId && cities.length > 0;
+  const citySummary = activeCity
+    ? `${activeCity.name} - ${activeCity.activeStoreCount} estabelecimentos ativos`
+    : 'Escolha uma cidade para carregar ofertas e listas com contexto local';
 
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(15,118,110,0.14),transparent_28%),radial-gradient(circle_at_85%_15%,rgba(37,99,235,0.10),transparent_22%),linear-gradient(180deg,#f8fafb_0%,#f3f8f6_48%,#eef7f8_100%)]">
@@ -58,7 +75,7 @@ export function PublicLayout() {
           </div>
 
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <Select onValueChange={setCityId} value={cityId}>
+            <Select onValueChange={(value) => void setCityId(value)} value={cityId ?? ''}>
               <SelectTrigger className="w-full sm:w-[320px]">
                 <MapPinIcon />
                 <SelectValue placeholder="Escolha sua cidade" />
@@ -73,6 +90,12 @@ export function PublicLayout() {
                 </SelectGroup>
               </SelectContent>
             </Select>
+
+            <div className="flex items-center gap-2 rounded-lg border border-border/70 bg-card/80 px-3 py-2">
+              <SunMediumIcon className="size-4 text-muted-foreground" />
+              <Switch checked={theme === 'dark'} onCheckedChange={toggleTheme} />
+              <MoonStarIcon className="size-4 text-muted-foreground" />
+            </div>
 
             {isAuthenticated ? (
               <>
@@ -102,9 +125,9 @@ export function PublicLayout() {
           <div className="flex items-start gap-3">
             <SparklesIcon className="mt-0.5 text-primary" />
             <div className="flex flex-col gap-1">
-              <span className="text-sm font-medium">Mesma conta no mobile e no web</span>
+              <span className="text-sm font-medium">Sua compra continua de onde voce parou</span>
               <span className="text-sm text-muted-foreground">
-                Cidade, listas, economia acumulada e historico ficam sincronizados.
+                A cidade escolhida, as listas salvas e o checklist acompanham a mesma conta.
               </span>
             </div>
           </div>
@@ -112,9 +135,7 @@ export function PublicLayout() {
             <MapPinIcon className="mt-0.5 text-primary" />
             <div className="flex flex-col gap-1">
               <span className="text-sm font-medium">Cidade ativa</span>
-              <span className="text-sm text-muted-foreground">
-                {activeCity.name} - {activeCity.activeStoreCount} estabelecimentos ativos
-              </span>
+              <span className="text-sm text-muted-foreground">{citySummary}</span>
             </div>
           </div>
           <div className="flex items-start gap-3">
@@ -122,9 +143,11 @@ export function PublicLayout() {
             <div className="flex flex-col gap-1">
               <span className="text-sm font-medium">Cobertura visivel</span>
               <span className="text-sm text-muted-foreground">
-                {activeCity.coverageStatus === 'live'
+                {activeCity?.coverageStatus === 'live'
                   ? 'Ofertas com evidencia disponivel.'
-                  : 'Cidade ativa, ainda coletando dados de cobertura.'}
+                  : activeCity
+                    ? 'Cidade ativa, ainda coletando dados de cobertura.'
+                    : 'Selecione uma cidade para ver o nivel de cobertura.'}
               </span>
             </div>
           </div>
@@ -132,6 +155,37 @@ export function PublicLayout() {
 
         <Outlet />
       </main>
+
+      <Dialog open={shouldRequireCitySelection}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Escolha sua cidade para continuar</DialogTitle>
+            <DialogDescription>
+              A sua cidade fica salva na conta e pode ser trocada depois a qualquer momento.
+            </DialogDescription>
+          </DialogHeader>
+          <Select onValueChange={(value) => void setCityId(value)} value={cityId ?? ''}>
+            <SelectTrigger>
+              <MapPinIcon />
+              <SelectValue placeholder="Selecione uma cidade disponivel" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {cities.map((city) => (
+                  <SelectItem key={city.id} value={city.id}>
+                    {city.name} - {city.activeStoreCount} estabelecimentos ativos
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <DialogFooter>
+            <Button disabled={!cityId} onClick={() => undefined} type="button">
+              Confirmado
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/web/src/routes/app-router.spec.tsx
+++ b/web/src/routes/app-router.spec.tsx
@@ -2,13 +2,25 @@
 
 import { cleanup, render, screen } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { PricelyProvider } from '@/app/pricely-context';
+import { ThemeProvider } from '@/app/theme-context';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 import { dashboardRoute } from './dashboard';
 import { publicRoute } from './public';
+
+vi.mock('@/app/theme-context', async () => {
+  const actual = await vi.importActual('@/app/theme-context');
+  return {
+    ...actual,
+    useTheme: () => ({
+      theme: 'light',
+      toggleTheme: () => undefined,
+    }),
+  };
+});
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -31,9 +43,11 @@ function renderRoute(initialEntry: string) {
 
   return render(
     <TooltipProvider>
-      <PricelyProvider>
-        <RouterProvider router={router} />
-      </PricelyProvider>
+      <ThemeProvider>
+        <PricelyProvider>
+          <RouterProvider router={router} />
+        </PricelyProvider>
+      </ThemeProvider>
     </TooltipProvider>,
   );
 }
@@ -47,7 +61,7 @@ describe('application routes', () => {
     renderRoute('/entrar');
 
     expect(screen.getByText('Entrar no Pricely')).toBeTruthy();
-    expect(screen.getByText('Mesma conta no mobile e no web')).toBeTruthy();
+    expect(screen.getByText('economia com contexto real')).toBeTruthy();
   });
 
   it('blocks the admin overview route for a non-admin session', () => {


### PR DESCRIPTION
## Summary
- persist the user's preferred city in the shared backend profile and require city selection after login on web and mobile
- improve the public web and mobile list flows with stronger account cards, live comparable-product picking, and separate save vs save-and-optimize actions
- improve admin catalog management with local image upload, visible active-state controls, and dark/light mode switching

## Validation
- `cd backend && npm test -- --runInBand`
- `cd backend && npm run lint`
- `cd backend && npm run build`
- `cd web && npm test`
- `cd web && npm run lint`
- `cd web && npm run build`
- `cd mobile && D:\flutter\bin\flutter.bat analyze`
- `cd mobile && D:\flutter\bin\flutter.bat test`
- `cd mobile && D:\flutter\bin\flutter.bat build apk --debug`
- `docker compose down -v`
- `docker compose up --build -d`
- smoke: login -> preferred city update -> list save -> optimize -> admin image upload

Closes #163
Closes #164
Closes #165
Closes #166
Closes #167
