### PR TITLE
Fix account list sync metrics

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,4 +1,5 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../persistence/prisma.service';
 import { type UserProfile, type UserProfileStats } from './users.types';
 
@@ -70,7 +71,7 @@ export class UsersService {
         })
       : null;
 
-    const [shoppingListsCount, completedOptimizationRuns, aggregatedOptimization, receiptSubmissionsCount] =
+    const [shoppingListsCount, completedOptimizationRuns, latestOptimizationSavings, receiptSubmissionsCount] =
       await Promise.all([
         this.prisma.shoppingList.count({
           where: { userId: id },
@@ -81,15 +82,7 @@ export class UsersService {
             status: 'completed',
           },
         }),
-        this.prisma.optimizationRun.aggregate({
-          where: {
-            userId: id,
-            status: 'completed',
-          },
-          _sum: {
-            estimatedSavings: true,
-          },
-        }),
+        this.getLatestCompletedSavingsByList(id),
         this.prisma.receiptRecord.count({
           where: { userId: id },
         }),
@@ -103,7 +96,7 @@ export class UsersService {
         offerReportsCount: 0,
         receiptSubmissionsCount,
         shoppingListsCount,
-        totalEstimatedSavings: Number(aggregatedOptimization._sum.estimatedSavings ?? 0),
+        totalEstimatedSavings: latestOptimizationSavings,
       },
       preferredRegion?.slug ?? null,
     );
@@ -167,5 +160,23 @@ export class UsersService {
       receiptSubmissionsCount: 0,
       offerReportsCount: 0,
     };
+  }
+
+  private async getLatestCompletedSavingsByList(userId: string): Promise<number> {
+    const rows = await this.prisma.$queryRaw<
+      Array<{ totalEstimatedSavings: Prisma.Decimal | number | string | null }>
+    >`
+      SELECT COALESCE(SUM(latest."estimatedSavings"), 0) AS "totalEstimatedSavings"
+      FROM (
+        SELECT DISTINCT ON ("shoppingListId") "shoppingListId", "estimatedSavings"
+        FROM "OptimizationRun"
+        WHERE "userId" = ${userId}
+          AND "status" = 'completed'
+          AND "estimatedSavings" IS NOT NULL
+        ORDER BY "shoppingListId", "createdAt" DESC
+      ) latest
+    `;
+
+    return Number(rows[0]?.totalEstimatedSavings ?? 0);
   }
 }

--- a/backend/test/unit/users/users.service.spec.ts
+++ b/backend/test/unit/users/users.service.spec.ts
@@ -31,12 +31,8 @@ describe('UsersService', () => {
       },
       optimizationRun: {
         count: jest.fn().mockResolvedValue(0),
-        aggregate: jest.fn().mockResolvedValue({
-          _sum: {
-            estimatedSavings: 0,
-          },
-        }),
       },
+      $queryRaw: jest.fn().mockResolvedValue([{ totalEstimatedSavings: 0 }]),
       receiptRecord: {
         count: jest.fn().mockResolvedValue(0),
       },
@@ -55,6 +51,47 @@ describe('UsersService', () => {
       data: { preferredRegionId: 'region-1' },
     });
     expect(profile.preferredRegionSlug).toBe('sao-paulo-sp');
+  });
+
+  it('sums only the latest completed optimization savings for each user list', async () => {
+    const prisma = {
+      userAccount: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'user-1',
+          email: 'cliente@pricely.local',
+          passwordHash: 'hash',
+          displayName: 'Cliente',
+          role: 'customer',
+          status: 'active',
+          lastLoginAt: null,
+          createdAt: new Date('2026-04-29T00:00:00.000Z'),
+          updatedAt: new Date('2026-04-29T00:00:00.000Z'),
+          preferredRegionId: null,
+        }),
+      },
+      region: {
+        findUnique: jest.fn(),
+      },
+      shoppingList: {
+        count: jest.fn().mockResolvedValue(2),
+      },
+      optimizationRun: {
+        count: jest.fn().mockResolvedValue(4),
+      },
+      $queryRaw: jest.fn().mockResolvedValue([{ totalEstimatedSavings: '31.50' }]),
+      receiptRecord: {
+        count: jest.fn().mockResolvedValue(0),
+      },
+    };
+
+    const service = new UsersService(prisma as never);
+
+    const profile = await service.getProfileById('user-1');
+
+    expect(profile.profileStats.shoppingListsCount).toBe(2);
+    expect(profile.profileStats.completedOptimizationRuns).toBe(4);
+    expect(profile.profileStats.totalEstimatedSavings).toBe(31.5);
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
   });
 
   it('fails when the preferred region slug does not exist', async () => {

--- a/web/src/app/pricely-context.tsx
+++ b/web/src/app/pricely-context.tsx
@@ -387,6 +387,18 @@ export function PricelyProvider({ children }: PropsWithChildren) {
           ...current,
           [listId]: result,
         }));
+        setLists((current) =>
+          current.map((list) =>
+            list.id === listId
+              ? {
+                  ...list,
+                  lastMode: mode,
+                  expectedSavings:
+                    result.estimatedSavings ?? list.expectedSavings,
+                }
+              : list,
+          ),
+        );
         setPreferredMode(mode);
         return result;
       },

--- a/web/src/public/list-editor-page.spec.tsx
+++ b/web/src/public/list-editor-page.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -78,6 +78,7 @@ describe('ListEditorPage', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    cleanup();
   });
 
   it('lets the user choose a base product and keep the default variant rule', async () => {
@@ -107,9 +108,60 @@ describe('ListEditorPage', () => {
     const searchImage = screen.getByAltText('Arroz tipo 1 1kg') as HTMLImageElement;
     expect(searchImage.src).toContain('https://example.com/arroz-camil.jpg');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Adicionar' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Adicionar' })[0]);
 
     expect(await screen.findByText('Qualquer variante')).toBeTruthy();
+    expect(screen.getAllByText('Arroz tipo 1 1kg').length).toBeGreaterThan(0);
+  });
+
+  it('keeps the comparable product list active after adding the first item', async () => {
+    render(
+      <MemoryRouter initialEntries={['/listas/nova']}>
+        <Routes>
+          <Route path="/listas/:listId" element={<ListEditorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Produto'), {
+      target: { value: 'Arroz' },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Adicionar' })).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Adicionar' }));
+
+    expect(screen.getByText('Produtos comparáveis')).toBeTruthy();
+    expect(screen.getAllByText('Arroz tipo 1 1kg').length).toBeGreaterThan(0);
+  });
+
+  it('shows the selected exact variant image in the variant configuration dialog', async () => {
+    render(
+      <MemoryRouter initialEntries={['/listas/nova']}>
+        <Routes>
+          <Route path="/listas/:listId" element={<ListEditorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: 'Configurar' }).length).toBeGreaterThan(0),
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Configurar' })[0]);
+    await screen.findByText('Configurar marca');
+    fireEvent.change(screen.getByDisplayValue('Qualquer variante'), {
+      target: { value: 'exact' },
+    });
+    fireEvent.change(screen.getByDisplayValue('Selecione a variante'), {
+      target: { value: 'variant-1' },
+    });
+
+    const variantImage = await screen.findByAltText('Camil · Arroz Tipo 1 1kg');
+    expect((variantImage as HTMLImageElement).src).toContain('https://example.com/arroz-camil.jpg');
+    expect(screen.getByText('Variante exata selecionada')).toBeTruthy();
   });
 
   it('renders the exact variant name for existing list items', async () => {

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -1206,7 +1206,6 @@ export function ListEditorPage() {
     setSelectedVariantId('');
     setSelectedVariants([]);
     setIsBrandDialogOpen(false);
-    setCatalogResults([]);
   };
 
   const removeItem = (itemId: string) => {
@@ -1486,21 +1485,38 @@ export function ListEditorPage() {
                 </select>
               </Field>
               {draftBrandPreferenceMode === 'exact' ? (
-                <Field>
-                  <FieldLabel>Variante exata</FieldLabel>
-                  <select
-                    className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-                    onChange={(event) => setSelectedVariantId(event.target.value)}
-                    value={selectedVariantId}
-                  >
-                    <option value="">Selecione a variante</option>
-                    {selectedVariants.map((variant) => (
-                      <option key={variant.id} value={variant.id}>
-                        {variant.brandName ? `${variant.brandName} - ` : ''}{variant.displayName}
-                      </option>
-                    ))}
-                  </select>
-                </Field>
+                <div className="grid gap-3">
+                  <Field>
+                    <FieldLabel>Variante exata</FieldLabel>
+                    <select
+                      className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                      onChange={(event) => setSelectedVariantId(event.target.value)}
+                      value={selectedVariantId}
+                    >
+                      <option value="">Selecione a variante</option>
+                      {selectedVariants.map((variant) => (
+                        <option key={variant.id} value={variant.id}>
+                          {variant.brandName ? `${variant.brandName} - ` : ''}{variant.displayName}
+                        </option>
+                      ))}
+                    </select>
+                  </Field>
+                  {selectedVariant ? (
+                    <div className="flex items-center gap-3 rounded-lg border border-border/70 bg-muted/20 p-3">
+                      <img
+                        alt={selectedExactVariantLabel}
+                        className="h-14 w-14 rounded-lg border border-border/70 object-cover"
+                        src={resolveProductImage(selectedVariant.imageUrl)}
+                      />
+                      <div className="grid gap-1">
+                        <span className="text-sm font-medium">{selectedExactVariantLabel}</span>
+                        <span className="text-xs text-muted-foreground">
+                          Variante exata selecionada
+                        </span>
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
               ) : null}
             </div>
             <DialogFooter>

--- a/web/src/public/public-shell.tsx
+++ b/web/src/public/public-shell.tsx
@@ -132,7 +132,7 @@ export function PublicLayout() {
               <div className="flex min-w-0 flex-col gap-1">
                 <span className="text-sm font-medium">Sua compra continua de onde você parou</span>
                 <span className="text-sm leading-6 text-muted-foreground">
-                  A cidade escolhida, as listas salvas e o checklist acompanham a mesma conta.
+                  A cidade escolhida, as listas salvas e o checklist acompanham a mesma conta em todas as plataformas.
                 </span>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- Updates public shell copy to mention all platforms.
- Keeps the comparable catalog list active after adding the first item.
- Shows selected exact variant image/name in the list editor dialog.
- Updates local list mode and estimated savings after optimization finishes.
- Computes account savings from the latest completed optimization per list, avoiding inflated totals after reoptimization.

## Validation

- `backend`: `npm run build`
- `backend`: `npm test -- --runTestsByPath test/unit/users/users.service.spec.ts`
- `web`: `npm run build`
- `web`: `npm test -- src/public/list-editor-page.spec.tsx src/public/public-shell.spec.tsx`

Issue: #181