### PR TITLE
Add local PgAdmin planning

### DIFF
--- a/backend/src/regions/application/regions-admin.service.ts
+++ b/backend/src/regions/application/regions-admin.service.ts
@@ -19,6 +19,21 @@ export class RegionsAdminService {
             },
           },
         },
+        establishments: {
+          orderBy: [{ unitName: 'asc' }],
+          include: {
+            _count: {
+              select: {
+                productOffers: {
+                  where: {
+                    isActive: true,
+                    availabilityStatus: 'available',
+                  },
+                },
+              },
+            },
+          },
+        },
       },
     });
 
@@ -30,6 +45,15 @@ export class RegionsAdminService {
       implantationStatus: region.implantationStatus,
       publicSortOrder: region.publicSortOrder,
       activeEstablishmentsCount: region._count.establishments,
+      establishments: region.establishments.map((establishment) => ({
+        id: establishment.id,
+        brandName: establishment.brandName,
+        unitName: establishment.unitName,
+        neighborhood: establishment.neighborhood,
+        cityName: establishment.cityName,
+        isActive: establishment.isActive,
+        auditedProductsCount: establishment._count.productOffers,
+      })),
     }));
   }
 

--- a/backend/test/unit/regions/regions-admin.service.spec.ts
+++ b/backend/test/unit/regions/regions-admin.service.spec.ts
@@ -15,6 +15,19 @@ describe('RegionsAdminService', () => {
             _count: {
               establishments: 3,
             },
+            establishments: [
+              {
+                id: 'store-1',
+                brandName: 'Mercado Azul',
+                unitName: 'Unidade Pinheiros',
+                neighborhood: 'Pinheiros',
+                cityName: 'Sao Paulo',
+                isActive: true,
+                _count: {
+                  productOffers: 12,
+                },
+              },
+            ],
           },
         ]),
       },
@@ -31,6 +44,17 @@ describe('RegionsAdminService', () => {
         implantationStatus: 'active',
         publicSortOrder: 1,
         activeEstablishmentsCount: 3,
+        establishments: [
+          {
+            id: 'store-1',
+            brandName: 'Mercado Azul',
+            unitName: 'Unidade Pinheiros',
+            neighborhood: 'Pinheiros',
+            cityName: 'Sao Paulo',
+            isActive: true,
+            auditedProductsCount: 12,
+          },
+        ],
       },
     ]);
 
@@ -42,6 +66,21 @@ describe('RegionsAdminService', () => {
             establishments: {
               where: {
                 isActive: true,
+              },
+            },
+          },
+        },
+        establishments: {
+          orderBy: [{ unitName: 'asc' }],
+          include: {
+            _count: {
+              select: {
+                productOffers: {
+                  where: {
+                    isActive: true,
+                    availabilityStatus: 'available',
+                  },
+                },
               },
             },
           },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,24 @@ services:
       timeout: 5s
       retries: 10
 
+  pgadmin:
+    image: dpage/pgadmin4:9
+    container_name: pricely-pgadmin
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@pricely.local
+      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_CONFIG_SERVER_MODE: "False"
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
+    ports:
+      - "5050:80"
+    volumes:
+      - ./infra/pgadmin/servers.json:/pgadmin4/servers.json:ro
+      - ./infra/pgadmin/pgpass:/tmp/pgpass:ro
+      - pricely-pgadmin-data:/var/lib/pgadmin
+
   backend:
     build:
       context: ./backend
@@ -80,5 +98,6 @@ services:
 volumes:
   pricely-postgres-data:
   pricely-redis-data:
+  pricely-pgadmin-data:
   pricely-backend-node-modules:
   pricely-web-node-modules:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -42,6 +42,7 @@ local. A stack sobe:
 
 - `postgres` em `localhost:5433`
 - `redis` em `localhost:6380`
+- `pgadmin` em `http://localhost:5050`
 - `backend` em `localhost:3000`
 - `web` em `localhost:5173`
 
@@ -69,6 +70,9 @@ Observacoes:
   `prisma db seed` antes de iniciar a API em modo de desenvolvimento.
 - A stack de compose e orientada a desenvolvimento local, com volumes montados e banco
   descartavel quando necessario.
+- O PgAdmin local usa `admin@pricely.local` / `admin` e ja importa o servidor
+  `Pricely PostgreSQL` apontando para o host Docker `postgres`. Quando solicitado,
+  use a senha do banco `postgres`.
 - A URL de API usada pelo navegador e `http://localhost:3000`.
 - Validacao local de referencia em `2026-04-27`:
   - `docker compose up --build -d`

--- a/infra/pgadmin/pgpass
+++ b/infra/pgadmin/pgpass
@@ -1,0 +1,1 @@
+postgres:5432:pricely:postgres:postgres

--- a/infra/pgadmin/servers.json
+++ b/infra/pgadmin/servers.json
@@ -1,0 +1,14 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "Pricely PostgreSQL",
+      "Group": "Pricely",
+      "Host": "postgres",
+      "Port": 5432,
+      "MaintenanceDB": "pricely",
+      "Username": "postgres",
+      "SSLMode": "prefer",
+      "PassFile": "/tmp/pgpass"
+    }
+  }
+}

--- a/specs/001-grocery-optimizer/plan.md
+++ b/specs/001-grocery-optimizer/plan.md
@@ -195,6 +195,52 @@ while sharing auth and domain contracts.
    preselect current city when available, allow manual override, and remove default
    optimization-mode choice from list creation.
 
+## Next Phase Planning
+
+### Phase 12: Account List Sync and Real User Metrics
+
+- Keep saved city, shopping lists, checklist state, and optimization mode consistent
+  across web and mobile sessions for the same account.
+- Keep catalog search results visible in list creation, using the product field only
+  as a filter.
+- Compute user savings from the latest completed optimization per list so repeated
+  optimization does not inflate the account total.
+
+### Phase 13: Offer Price Model and Store Comparisons
+
+- Extend offers with base/original price and promotional price so receipts can capture
+  discounted and non-discounted values.
+- Compare identical variants across establishments in the same city/region and expose
+  the monetary difference to shopper-facing UI.
+- Show promotional price treatment in UI, including crossed original price and savings
+  versus other stores or regional average when enough data exists.
+
+### Phase 14: Queue, Health, and Optimization Auditability
+
+- Enrich processing jobs with list owner, request/completion timestamps, optimization
+  mode, run id, job id, and attempt semantics.
+- Add a detailed operations view for a run with selected offers, rejected alternatives,
+  calculations, comparisons, and decision trace.
+- Clarify repeated completed jobs for the same list as separate optimization runs unless
+  they share the same processing job attempt chain.
+
+### Phase 15: Cities, Seed Data, and Local Infra
+
+- Expand city admin screens with establishments and audited product counts per store.
+- Keep Docker Compose useful for local operations by including PgAdmin connected to the
+  development PostgreSQL service.
+- Evolve seed data with multiple real-like variants, images, establishments, and price
+  comparison cases.
+
+### Phase 16: Observability, Deployment, and Infrastructure Planning
+
+- Standardize application logging with Pino patterns across existing backend modules and
+  new modules.
+- Plan Sentry integration for backend/web/mobile exception telemetry.
+- Plan Railway deployment topology for API, worker, PostgreSQL, Redis, and web hosting.
+- Plan Terraform modules for future production infrastructure without blocking local MVP
+  delivery.
+
 ## Complexity Tracking
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -240,6 +240,41 @@ web, and mobile.
 
 ---
 
+## Phase 12: Account List Sync and Real User Metrics
+
+- [~] T089 [P] Update web copy, list search persistence, exact variant image preview, and optimization mode persistence in `web/src/public/` and `web/src/app/`
+- [~] T090 [P] Correct user profile metrics so list count is real and savings sum only latest completed optimization per list in `backend/src/users/`
+- [ ] T091 [P] Align mobile checklist/list rendering with exact variant names and images in `mobile/lib/features/shopping_lists/` and `mobile/lib/features/optimization/`
+- [ ] T092 Add backend and frontend regression tests for cross-platform account sync semantics in `backend/test/`, `web/src/`, and `mobile/test/`
+
+## Phase 13: Offer Price Model and Store Comparisons
+
+- [ ] T093 Extend `ProductOffer` with base/original and promotional price fields in `backend/prisma/schema.prisma`
+- [ ] T094 Update receipt parsing and ingestion to capture original and promotional prices in `backend/src/receipts/`
+- [ ] T095 Implement variant-level establishment comparisons and regional average helpers in `backend/src/pricing/` and `backend/src/optimization/`
+- [ ] T096 Render promotional price, crossed original price, and comparison savings in `web/src/public/`, `mobile/lib/features/`, and related tests
+
+## Phase 14: Queue, Health, and Optimization Auditability
+
+- [ ] T097 Enrich admin processing job responses with owner, run, mode, request time, completion time, and attempt context in `backend/src/admin/`
+- [ ] T098 Add optimization detail route/modal with calculations, selected/rejected offers, and decision trace in `web/src/dashboard/`
+- [ ] T099 Add queue semantics tests for repeated runs versus repeated attempts in `backend/test/unit/jobs/` and `backend/test/integration/admin/`
+
+## Phase 15: Cities, Seed Data, and Local Infra
+
+- [~] T100 Add PgAdmin to Docker Compose with imported PostgreSQL server config in `docker-compose.yml` and `infra/pgadmin/`
+- [ ] T101 Show establishments and audited product counts inside admin city screens in `backend/src/admin/` and `web/src/dashboard/`
+- [ ] T102 Expand seed data with multiple establishments, variants, images, and price comparison cases in `backend/prisma/seed.js`
+
+## Phase 16: Observability, Deployment, and Infrastructure Planning
+
+- [ ] T103 Define Pino logging patterns and apply them consistently across backend modules in `backend/src/common/logging/` and feature services
+- [ ] T104 Plan Sentry instrumentation for backend, web, and mobile in `docs/` and future implementation tasks
+- [ ] T105 Plan Railway deployment topology and environment requirements in `docs/`
+- [ ] T106 Plan Terraform modules for future production infrastructure in `infra/terraform/` and `docs/`
+
+---
+
 ## Phase 9: UX Flow Polish and Stitch Fidelity Hardening
 
 **Purpose**: Eliminate UX friction found in the post-release audit, fix PT-BR copy

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -244,6 +244,15 @@ type AdminRegionResponse = {
   implantationStatus: 'active' | 'activating' | 'inactive';
   publicSortOrder: number;
   activeEstablishmentsCount: number;
+  establishments: Array<{
+    id: string;
+    brandName: string;
+    unitName: string;
+    neighborhood: string;
+    cityName: string;
+    isActive: boolean;
+    auditedProductsCount: number;
+  }>;
 };
 
 type AdminShoppingListAuditResponse = {

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -166,6 +166,17 @@ describe('Admin dashboard pages', () => {
         implantationStatus: 'active',
         publicSortOrder: 1,
         activeEstablishmentsCount: 2,
+        establishments: [
+          {
+            id: 'store-1',
+            brandName: 'Mercado Azul',
+            unitName: 'Unidade Pinheiros',
+            neighborhood: 'Pinheiros',
+            cityName: 'Sao Paulo',
+            isActive: true,
+            auditedProductsCount: 12,
+          },
+        ],
       },
     ]);
     fetchAdminEstablishments.mockResolvedValue([
@@ -190,9 +201,10 @@ describe('Admin dashboard pages', () => {
     render(<AdminRegionsPage />);
     expect(await screen.findByText('Cidades públicas')).toBeTruthy();
     expect(screen.getAllByText(/Sao Paulo/).length).toBeGreaterThan(0);
+    expect(screen.getByText('12 produtos auditados')).toBeTruthy();
 
     render(<AdminEstablishmentsPage />);
     expect(await screen.findByText('Unidades por cidade')).toBeTruthy();
-    expect(screen.getByText('Unidade Pinheiros')).toBeTruthy();
+    expect(screen.getAllByText('Unidade Pinheiros').length).toBeGreaterThan(0);
   });
 });

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -944,6 +944,30 @@ export function AdminRegionsPage() {
                   {region.implantationStatus === 'active' ? 'Desativar cidade' : 'Ativar cidade'}
                 </Button>
               </div>
+              {region.establishments.length > 0 ? (
+                <div className="mt-4 grid gap-2">
+                  {region.establishments.map((establishment) => (
+                    <div
+                      key={establishment.id}
+                      className="grid gap-2 rounded-lg border border-border/70 bg-background/80 p-3 md:grid-cols-[1fr_auto]"
+                    >
+                      <div>
+                        <div className="text-sm font-medium">{establishment.unitName}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {establishment.brandName} · {establishment.neighborhood} · {establishment.isActive ? 'ativo' : 'inativo'}
+                        </div>
+                      </div>
+                      <Badge variant="secondary">
+                        {establishment.auditedProductsCount} produtos auditados
+                      </Badge>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="mt-4 rounded-lg border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
+                  Nenhum estabelecimento vinculado a esta cidade ainda.
+                </div>
+              )}
             </div>
           ))}
         </CardContent>


### PR DESCRIPTION
## Summary

- Adds PgAdmin to local Docker Compose on `localhost:5050`.
- Imports a `Pricely PostgreSQL` PgAdmin server pointing at the Docker `postgres` service.
- Documents local PgAdmin credentials and connection behavior.
- Updates Spec Kit planning docs with phases for sync metrics, offer price modeling, queue auditability, cities/seed/infra, and observability/deployment/Terraform planning.
- Enriches admin city responses with establishments and audited product counts.
- Shows establishments and audited product counts directly in the admin city screen.

## Validation

- `docker compose config`
- `git diff --check`
- `backend`: `npm run build`
- `backend`: `npm test -- --runTestsByPath test/unit/regions/regions-admin.service.spec.ts`
- `web`: `npm run build`
- `web`: `npm test -- src/dashboard/dashboard-pages.spec.tsx`

Issue: #184