### PR TITLE
Add offer price comparisons

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -225,6 +225,8 @@ model ProductOffer {
   displayName        String
   packageLabel       String
   priceAmount        Decimal                 @db.Decimal(10, 2)
+  basePriceAmount    Decimal?                @db.Decimal(10, 2)
+  promotionalPriceAmount Decimal?            @db.Decimal(10, 2)
   currencyCode       String                  @default("BRL") @db.VarChar(3)
   availabilityStatus OfferAvailabilityStatus
   confidenceLevel    OfferConfidenceLevel
@@ -242,6 +244,7 @@ model ProductOffer {
   @@index([catalogProductId, isActive, observedAt])
   @@index([productVariantId, isActive, observedAt])
   @@index([establishmentId, isActive])
+  @@index([productVariantId, establishmentId, isActive])
 }
 
 model ShoppingList {
@@ -319,6 +322,9 @@ model OptimizationSelection {
   productOfferId    String?                     @db.Uuid
   status            OptimizationSelectionStatus
   estimatedCost     Decimal?                    @db.Decimal(10, 2)
+  comparisonPriceAmount Decimal?                 @db.Decimal(10, 2)
+  regionalAveragePriceAmount Decimal?            @db.Decimal(10, 2)
+  savingsVsComparison Decimal?                   @db.Decimal(10, 2)
   confidenceNotice  String?
   optimizationRun   OptimizationRun             @relation(fields: [optimizationRunId], references: [id], onDelete: Cascade)
   productOffer      ProductOffer?               @relation(fields: [productOfferId], references: [id], onDelete: SetNull)

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -77,6 +77,20 @@ async function main() {
     },
   });
 
+  const comparisonEstablishment = await prisma.establishment.upsert({
+    where: { cnpj: '98.765.432/0001-11' },
+    update: {},
+    create: {
+      brandName: 'Mercado Comparativo',
+      unitName: 'Unidade Vila Mariana',
+      cnpj: '98.765.432/0001-11',
+      cityName: 'Sao Paulo',
+      neighborhood: 'Vila Mariana',
+      regionId: region.id,
+      isActive: true,
+    },
+  });
+
   const catalogProduct = await prisma.catalogProduct.upsert({
     where: { slug: 'arroz-tipo-1-5kg' },
     update: {},
@@ -103,12 +117,17 @@ async function main() {
 
   const productVariant = await prisma.productVariant.upsert({
     where: { slug: 'arroz-tipo-1-5kg-seed-5kg' },
-    update: {},
+    update: {
+      brandName: 'Camil',
+      imageUrl: 'https://images.unsplash.com/photo-1586201375761-83865001e31c?auto=format&fit=crop&w=900&q=80',
+    },
     create: {
       catalogProductId: catalogProduct.id,
       slug: 'arroz-tipo-1-5kg-seed-5kg',
-      displayName: 'Arroz tipo 1 5kg',
+      displayName: 'Arroz Camil tipo 1 5kg',
+      brandName: 'Camil',
       packageLabel: '5 kg',
+      imageUrl: 'https://images.unsplash.com/photo-1586201375761-83865001e31c?auto=format&fit=crop&w=900&q=80',
       isActive: true,
     },
   });
@@ -139,11 +158,38 @@ async function main() {
       displayName: 'Arroz tipo 1 5kg',
       packageLabel: '5 kg',
       priceAmount: '22.90',
+      basePriceAmount: '24.90',
+      promotionalPriceAmount: '22.90',
       currencyCode: 'BRL',
       availabilityStatus: 'available',
       confidenceLevel: 'high',
       sourceType: 'admin',
       sourceReference: 'Seed local',
+      observedAt: new Date(),
+      isActive: true,
+    },
+  });
+
+  await prisma.productOffer.upsert({
+    where: {
+      id: '44444444-4444-4444-4444-444444444444',
+    },
+    update: {},
+    create: {
+      id: '44444444-4444-4444-4444-444444444444',
+      catalogProductId: catalogProduct.id,
+      productVariantId: productVariant.id,
+      establishmentId: comparisonEstablishment.id,
+      displayName: 'Arroz Camil tipo 1 5kg',
+      packageLabel: '5 kg',
+      priceAmount: '21.90',
+      basePriceAmount: '21.90',
+      promotionalPriceAmount: null,
+      currencyCode: 'BRL',
+      availabilityStatus: 'available',
+      confidenceLevel: 'high',
+      sourceType: 'admin',
+      sourceReference: 'Seed comparativo',
       observedAt: new Date(),
       isActive: true,
     },
@@ -162,6 +208,8 @@ async function main() {
       displayName: 'Cafe Pilao 500g',
       packageLabel: '500 g',
       priceAmount: '15.90',
+      basePriceAmount: '18.90',
+      promotionalPriceAmount: '15.90',
       currencyCode: 'BRL',
       availabilityStatus: 'available',
       confidenceLevel: 'high',
@@ -192,6 +240,7 @@ async function main() {
       customerEmail: customer.email,
       region: region.slug,
       establishment: establishment.unitName,
+      comparisonEstablishment: comparisonEstablishment.unitName,
       product: catalogProduct.slug,
       variant: productVariant.slug,
       publicOfferProduct: coffeeCatalogProduct.slug,

--- a/backend/src/admin/api/admin-dashboard.controller.ts
+++ b/backend/src/admin/api/admin-dashboard.controller.ts
@@ -227,6 +227,16 @@ class CreateOfferDto {
   @Min(0)
   priceAmount!: number;
 
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  basePriceAmount?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  promotionalPriceAmount?: number;
+
   @IsIn(['available', 'unavailable', 'uncertain'])
   availabilityStatus!: 'available' | 'unavailable' | 'uncertain';
 
@@ -275,6 +285,16 @@ class UpdateOfferDto {
   @IsNumber()
   @Min(0)
   priceAmount?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  basePriceAmount?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  promotionalPriceAmount?: number;
 
   @IsOptional()
   @IsIn(['available', 'unavailable', 'uncertain'])

--- a/backend/src/admin/application/admin-dashboard.service.ts
+++ b/backend/src/admin/application/admin-dashboard.service.ts
@@ -399,6 +399,8 @@ export class AdminDashboardService {
     displayName: string;
     packageLabel: string;
     priceAmount: number;
+    basePriceAmount?: number;
+    promotionalPriceAmount?: number | null;
     availabilityStatus: 'available' | 'unavailable' | 'uncertain';
     confidenceLevel: 'high' | 'medium' | 'low';
     sourceType?: string;
@@ -422,6 +424,8 @@ export class AdminDashboardService {
       displayName: string;
       packageLabel: string;
       priceAmount: number;
+      basePriceAmount: number;
+      promotionalPriceAmount: number | null;
       availabilityStatus: 'available' | 'unavailable' | 'uncertain';
       confidenceLevel: 'high' | 'medium' | 'low';
       sourceType: string;

--- a/backend/src/catalog/application/public-catalog.service.ts
+++ b/backend/src/catalog/application/public-catalog.service.ts
@@ -86,6 +86,12 @@ export class PublicCatalogService {
         productVariantId: offer.productVariantId,
         displayName: offer.displayName,
         priceAmount: Number(offer.priceAmount),
+        basePriceAmount:
+          offer.basePriceAmount !== null ? Number(offer.basePriceAmount) : Number(offer.priceAmount),
+        promotionalPriceAmount:
+          offer.promotionalPriceAmount !== null
+            ? Number(offer.promotionalPriceAmount)
+            : undefined,
         observedAt: offer.observedAt.toISOString(),
         confidenceLevel: offer.confidenceLevel,
         packageLabel: offer.packageLabel,

--- a/backend/src/common/contracts/catalog.contract.ts
+++ b/backend/src/common/contracts/catalog.contract.ts
@@ -38,6 +38,8 @@ export interface CatalogProductDetailContract {
     displayName: string;
     packageLabel: string;
     priceAmount: number;
+    basePriceAmount?: number;
+    promotionalPriceAmount?: number;
     observedAt: string;
     confidenceLevel: 'high' | 'medium' | 'low';
     storeName: string;

--- a/backend/src/common/contracts/optimization.contract.ts
+++ b/backend/src/common/contracts/optimization.contract.ts
@@ -15,6 +15,9 @@ export interface OptimizationSelection {
   establishmentNeighborhood?: string;
   estimatedCost?: number;
   priceAmount?: number;
+  comparisonPriceAmount?: number;
+  regionalAveragePriceAmount?: number;
+  savingsVsComparison?: number;
   sourceLabel?: string;
   observedAt?: string;
   selectionStatus: 'selected' | 'missing' | 'review';

--- a/backend/src/common/contracts/receipt.contract.ts
+++ b/backend/src/common/contracts/receipt.contract.ts
@@ -2,6 +2,8 @@ export interface ReceiptLineItemInput {
   rawProductName: string;
   quantity?: number;
   unitPrice: number;
+  originalUnitPrice?: number;
+  promotionalUnitPrice?: number;
   currency?: string;
   packageSize?: string;
 }

--- a/backend/src/common/contracts/regions.contract.ts
+++ b/backend/src/common/contracts/regions.contract.ts
@@ -32,6 +32,9 @@ export interface RegionalOffersContract {
     displayName: string;
     packageLabel: string;
     priceAmount: number;
+    basePriceAmount?: number;
+    promotionalPriceAmount?: number;
+    savingsVsRegionalAverage?: number;
     observedAt: string;
     sourceLabel: string;
     storeName: string;

--- a/backend/src/jobs/optimization-run.processor.ts
+++ b/backend/src/jobs/optimization-run.processor.ts
@@ -63,6 +63,18 @@ export class OptimizationRunProcessor {
             selection.estimatedCost !== undefined
               ? new Prisma.Decimal(selection.estimatedCost)
               : null,
+          comparisonPriceAmount:
+            selection.comparisonPriceAmount !== undefined
+              ? new Prisma.Decimal(selection.comparisonPriceAmount)
+              : null,
+          regionalAveragePriceAmount:
+            selection.regionalAveragePriceAmount !== undefined
+              ? new Prisma.Decimal(selection.regionalAveragePriceAmount)
+              : null,
+          savingsVsComparison:
+            selection.savingsVsComparison !== undefined
+              ? new Prisma.Decimal(selection.savingsVsComparison)
+              : null,
           confidenceNotice: selection.confidenceNotice ?? null,
         })),
       }),

--- a/backend/src/jobs/receipt-ingestion.processor.ts
+++ b/backend/src/jobs/receipt-ingestion.processor.ts
@@ -35,6 +35,8 @@ export class ReceiptIngestionProcessor {
           canonicalName: lineItem.normalizedName,
           displayName: lineItem.rawProductName,
           price: lineItem.unitPrice,
+          basePrice: lineItem.originalUnitPrice ?? lineItem.unitPrice,
+          promotionalPrice: lineItem.promotionalUnitPrice,
           quantityContext: lineItem.packageSize,
           availabilityStatus: 'available',
           confidenceScore: lineItem.matchConfidence,

--- a/backend/src/optimization/application/optimization-result.service.ts
+++ b/backend/src/optimization/application/optimization-result.service.ts
@@ -143,6 +143,18 @@ export class OptimizationResultService {
           selection.productOffer?.priceAmount !== undefined
             ? Number(selection.productOffer.priceAmount)
             : undefined,
+        comparisonPriceAmount:
+          selection.comparisonPriceAmount !== null
+            ? Number(selection.comparisonPriceAmount)
+            : undefined,
+        regionalAveragePriceAmount:
+          selection.regionalAveragePriceAmount !== null
+            ? Number(selection.regionalAveragePriceAmount)
+            : undefined,
+        savingsVsComparison:
+          selection.savingsVsComparison !== null
+            ? Number(selection.savingsVsComparison)
+            : undefined,
         sourceLabel: selection.productOffer?.sourceReference ?? undefined,
         observedAt: selection.productOffer?.observedAt.toISOString(),
         selectionStatus:

--- a/backend/src/optimization/domain/multi-market-optimizer.service.ts
+++ b/backend/src/optimization/domain/multi-market-optimizer.service.ts
@@ -29,6 +29,11 @@ export class MultiMarketOptimizerService {
         .reduce((accumulator, selection) => accumulator + (selection.estimatedCost || 0), 0)
         .toFixed(2),
     );
+    const estimatedSavings = Number(
+      selections
+        .reduce((accumulator, selection) => accumulator + (selection.savingsVsComparison || 0), 0)
+        .toFixed(2),
+    );
     const selectedOffers = selections.filter((selection) => selection.selectionStatus === 'selected');
     const coverageStatus =
       selectedOffers.length === 0
@@ -43,6 +48,7 @@ export class MultiMarketOptimizerService {
       mode,
       status: 'completed',
       totalEstimatedCost: selectedOffers.length > 0 ? totalEstimatedCost : undefined,
+      estimatedSavings: estimatedSavings > 0 ? estimatedSavings : 0,
       coverageStatus,
       createdAt: new Date().toISOString(),
       explanationSummary:
@@ -99,6 +105,7 @@ export class MultiMarketOptimizerService {
     }
 
     const quantity = item.quantity && item.quantity > 0 ? item.quantity : 1;
+    const comparison = this.calculateVariantComparison(cheapestOffer, matchingOffers);
 
     return {
       id: `sel_${item.id}`,
@@ -109,12 +116,39 @@ export class MultiMarketOptimizerService {
       selectionStatus: 'selected',
       estimatedCost: Number((cheapestOffer.price * quantity).toFixed(2)),
       priceAmount: Number(cheapestOffer.price.toFixed(2)),
+      comparisonPriceAmount: comparison.highestPriceAmount,
+      regionalAveragePriceAmount: comparison.averagePriceAmount,
+      savingsVsComparison: Number(
+        Math.max(0, (comparison.highestPriceAmount - cheapestOffer.price) * quantity).toFixed(2),
+      ),
       sourceLabel: cheapestOffer.sourceReceiptLineItemId,
       observedAt: cheapestOffer.observedAt,
       confidenceNotice:
         cheapestOffer.confidenceScore < 0.75
           ? 'Selected from low-confidence market evidence.'
           : undefined,
+    };
+  }
+
+  private calculateVariantComparison(
+    selectedOffer: StoreOfferEntity,
+    matchingOffers: StoreOfferEntity[],
+  ) {
+    const comparableOffers = matchingOffers.filter((offer) =>
+      selectedOffer.productVariantId
+        ? offer.productVariantId === selectedOffer.productVariantId
+        : offer.canonicalName === selectedOffer.canonicalName,
+    );
+    const prices = comparableOffers.map((offer) => offer.price);
+    const highestPriceAmount = prices.length > 0 ? Math.max(...prices) : selectedOffer.price;
+    const averagePriceAmount =
+      prices.length > 0
+        ? Number((prices.reduce((sum, price) => sum + price, 0) / prices.length).toFixed(2))
+        : selectedOffer.price;
+
+    return {
+      highestPriceAmount: Number(highestPriceAmount.toFixed(2)),
+      averagePriceAmount,
     };
   }
 

--- a/backend/src/optimization/domain/optimization-selection.entity.ts
+++ b/backend/src/optimization/domain/optimization-selection.entity.ts
@@ -12,6 +12,9 @@ export interface OptimizationSelectionEntity {
   establishmentNeighborhood?: string;
   estimatedCost?: number;
   priceAmount?: number;
+  comparisonPriceAmount?: number;
+  regionalAveragePriceAmount?: number;
+  savingsVsComparison?: number;
   sourceLabel?: string;
   observedAt?: string;
   selectionStatus: SelectionStatus;

--- a/backend/src/pricing/application/offer-management.service.ts
+++ b/backend/src/pricing/application/offer-management.service.ts
@@ -28,6 +28,8 @@ export class OfferManagementService {
     displayName: string;
     packageLabel: string;
     priceAmount: number;
+    basePriceAmount?: number;
+    promotionalPriceAmount?: number | null;
     availabilityStatus: 'available' | 'unavailable' | 'uncertain';
     confidenceLevel: 'high' | 'medium' | 'low';
     sourceType?: string;
@@ -35,6 +37,8 @@ export class OfferManagementService {
     observedAt?: string;
     isActive?: boolean;
   }) {
+    const effectivePrice = input.promotionalPriceAmount ?? input.priceAmount;
+
     return this.prisma.productOffer.create({
       data: {
         catalogProductId: input.catalogProductId,
@@ -42,7 +46,9 @@ export class OfferManagementService {
         establishmentId: input.establishmentId,
         displayName: input.displayName,
         packageLabel: input.packageLabel,
-        priceAmount: input.priceAmount,
+        priceAmount: effectivePrice,
+        basePriceAmount: input.basePriceAmount ?? input.priceAmount,
+        promotionalPriceAmount: input.promotionalPriceAmount ?? null,
         currencyCode: 'BRL',
         availabilityStatus: input.availabilityStatus,
         confidenceLevel: input.confidenceLevel,
@@ -63,6 +69,8 @@ export class OfferManagementService {
       displayName: string;
       packageLabel: string;
       priceAmount: number;
+      basePriceAmount: number;
+      promotionalPriceAmount: number | null;
       availabilityStatus: 'available' | 'unavailable' | 'uncertain';
       confidenceLevel: 'high' | 'medium' | 'low';
       sourceType: string;
@@ -71,10 +79,19 @@ export class OfferManagementService {
       isActive: boolean;
     }>,
   ) {
+    const priceData =
+      input.promotionalPriceAmount !== undefined
+        ? {
+            promotionalPriceAmount: input.promotionalPriceAmount,
+            priceAmount: input.promotionalPriceAmount ?? input.priceAmount,
+          }
+        : {};
+
     return this.prisma.productOffer.update({
       where: { id },
       data: {
         ...input,
+        ...priceData,
         observedAt: input.observedAt ? new Date(input.observedAt) : undefined,
       },
     });

--- a/backend/src/pricing/application/public-pricing.service.ts
+++ b/backend/src/pricing/application/public-pricing.service.ts
@@ -38,6 +38,7 @@ export class PublicPricingService {
       },
       orderBy: [{ observedAt: 'desc' }, { priceAmount: 'asc' }],
     });
+    const comparisonByVariant = this.buildComparisonByVariant(offers);
 
     const response = {
       region: {
@@ -53,22 +54,12 @@ export class PublicPricingService {
         },
       }),
       offerCoverageStatus: offers.length > 0 ? 'live' : 'collecting_data',
-      offers: offers.map((offer) => ({
-        id: offer.id,
-        catalogProductId: offer.catalogProductId,
-        productVariantId: offer.productVariantId,
-        productName: offer.catalogProduct.name,
-        variantName: offer.productVariant.displayName,
-        imageUrl: offer.productVariant.imageUrl ?? offer.catalogProduct.imageUrl,
-        displayName: offer.displayName,
-        packageLabel: offer.packageLabel,
-        priceAmount: Number(offer.priceAmount),
-        observedAt: offer.observedAt.toISOString(),
-        sourceLabel: offer.sourceReference ?? offer.sourceType,
-        storeName: offer.establishment.unitName,
-        neighborhood: offer.establishment.neighborhood,
-        confidenceLevel: offer.confidenceLevel,
-      })),
+      offers: offers.map((offer) =>
+        this.projectRegionalOffer(
+          offer,
+          comparisonByVariant.get(offer.productVariantId),
+        ),
+      ),
     };
 
     this.logger.log(
@@ -106,7 +97,7 @@ export class PublicPricingService {
 
     const alternativeOffers = await this.prisma.productOffer.findMany({
       where: {
-        catalogProductId: offer.catalogProductId,
+        productVariantId: offer.productVariantId,
         isActive: true,
         availabilityStatus: 'available',
         establishment: {
@@ -119,6 +110,7 @@ export class PublicPricingService {
       },
       orderBy: [{ priceAmount: 'asc' }, { observedAt: 'desc' }],
     });
+    const comparison = this.calculateComparison(alternativeOffers);
 
     const response = {
       id: offer.id,
@@ -145,6 +137,19 @@ export class PublicPricingService {
         displayName: offer.displayName,
         packageLabel: offer.packageLabel,
         priceAmount: Number(offer.priceAmount),
+        basePriceAmount:
+          offer.basePriceAmount !== null && offer.basePriceAmount !== undefined
+            ? Number(offer.basePriceAmount)
+            : Number(offer.priceAmount),
+        promotionalPriceAmount:
+          offer.promotionalPriceAmount !== null && offer.promotionalPriceAmount !== undefined
+            ? Number(offer.promotionalPriceAmount)
+            : undefined,
+        regionalAveragePriceAmount: comparison.averagePriceAmount,
+        comparisonPriceAmount: comparison.highestPriceAmount,
+        savingsVsComparison: Number(
+          Math.max(0, comparison.highestPriceAmount - Number(offer.priceAmount)).toFixed(2),
+        ),
         observedAt: offer.observedAt.toISOString(),
         sourceLabel: offer.sourceReference ?? offer.sourceType,
         storeName: offer.establishment.unitName,
@@ -157,6 +162,14 @@ export class PublicPricingService {
         neighborhood: entry.establishment.neighborhood,
         packageLabel: entry.packageLabel,
         priceAmount: Number(entry.priceAmount),
+        basePriceAmount:
+          entry.basePriceAmount !== null && entry.basePriceAmount !== undefined
+            ? Number(entry.basePriceAmount)
+            : Number(entry.priceAmount),
+        promotionalPriceAmount:
+          entry.promotionalPriceAmount !== null && entry.promotionalPriceAmount !== undefined
+            ? Number(entry.promotionalPriceAmount)
+            : undefined,
         observedAt: entry.observedAt.toISOString(),
         sourceLabel: entry.sourceReference ?? entry.sourceType,
         confidenceLevel: entry.confidenceLevel,
@@ -168,5 +181,102 @@ export class PublicPricingService {
     );
 
     return response;
+  }
+
+  private buildComparisonByVariant(
+    offers: Array<{
+      productVariantId: string;
+      priceAmount: { toString(): string } | number;
+    }>,
+  ) {
+    const grouped = new Map<string, Array<{ priceAmount: { toString(): string } | number }>>();
+
+    for (const offer of offers) {
+      const existing = grouped.get(offer.productVariantId) ?? [];
+      existing.push(offer);
+      grouped.set(offer.productVariantId, existing);
+    }
+
+    return new Map(
+      [...grouped.entries()].map(([variantId, entries]) => [
+        variantId,
+        this.calculateComparison(entries),
+      ]),
+    );
+  }
+
+  private calculateComparison(
+    offers: Array<{ priceAmount: { toString(): string } | number }>,
+  ) {
+    const prices = offers.map((offer) => Number(offer.priceAmount));
+    const highestPriceAmount = prices.length > 0 ? Math.max(...prices) : 0;
+    const averagePriceAmount =
+      prices.length > 0
+        ? Number((prices.reduce((sum, price) => sum + price, 0) / prices.length).toFixed(2))
+        : 0;
+
+    return {
+      highestPriceAmount,
+      averagePriceAmount,
+    };
+  }
+
+  private projectRegionalOffer(
+    offer: {
+      id: string;
+      catalogProductId: string;
+      productVariantId: string;
+      displayName: string;
+      packageLabel: string;
+      priceAmount: { toString(): string } | number;
+      basePriceAmount?: { toString(): string } | number | null;
+      promotionalPriceAmount?: { toString(): string } | number | null;
+      observedAt: Date;
+      sourceReference: string | null;
+      sourceType: string;
+      confidenceLevel: 'high' | 'medium' | 'low';
+      catalogProduct: {
+        name: string;
+        imageUrl: string | null;
+      };
+      productVariant: {
+        displayName: string;
+        imageUrl: string | null;
+      };
+      establishment: {
+        unitName: string;
+        neighborhood: string;
+      };
+    },
+    comparison?: { averagePriceAmount: number; highestPriceAmount: number },
+  ) {
+    const priceAmount = Number(offer.priceAmount);
+    const average = comparison?.averagePriceAmount ?? priceAmount;
+
+    return {
+      id: offer.id,
+      catalogProductId: offer.catalogProductId,
+      productVariantId: offer.productVariantId,
+      productName: offer.catalogProduct.name,
+      variantName: offer.productVariant.displayName,
+      imageUrl: offer.productVariant.imageUrl ?? offer.catalogProduct.imageUrl,
+      displayName: offer.displayName,
+      packageLabel: offer.packageLabel,
+      priceAmount,
+      basePriceAmount:
+        offer.basePriceAmount !== null && offer.basePriceAmount !== undefined
+          ? Number(offer.basePriceAmount)
+          : priceAmount,
+      promotionalPriceAmount:
+        offer.promotionalPriceAmount !== null && offer.promotionalPriceAmount !== undefined
+          ? Number(offer.promotionalPriceAmount)
+          : undefined,
+      savingsVsRegionalAverage: Number(Math.max(0, average - priceAmount).toFixed(2)),
+      observedAt: offer.observedAt.toISOString(),
+      sourceLabel: offer.sourceReference ?? offer.sourceType,
+      storeName: offer.establishment.unitName,
+      neighborhood: offer.establishment.neighborhood,
+      confidenceLevel: offer.confidenceLevel,
+    };
   }
 }

--- a/backend/src/receipts/api/dto/receipt-ingestion.dto.ts
+++ b/backend/src/receipts/api/dto/receipt-ingestion.dto.ts
@@ -25,6 +25,16 @@ class ReceiptLineItemInputDto {
   unitPrice!: number;
 
   @IsOptional()
+  @IsNumber()
+  @Min(0.0001)
+  originalUnitPrice?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0.0001)
+  promotionalUnitPrice?: number;
+
+  @IsOptional()
   @IsString()
   currency?: string;
 

--- a/backend/src/receipts/application/receipt-ingestion.service.ts
+++ b/backend/src/receipts/application/receipt-ingestion.service.ts
@@ -42,6 +42,8 @@ export class ReceiptIngestionService {
           packageSize: item.packageSize,
           quantity: item.quantity,
           unitPrice: item.unitPrice,
+          originalUnitPrice: item.originalUnitPrice,
+          promotionalUnitPrice: item.promotionalUnitPrice,
           currency: item.currency,
           matchConfidence: item.matchConfidence,
         };

--- a/backend/src/receipts/application/receipt-parser.service.ts
+++ b/backend/src/receipts/application/receipt-parser.service.ts
@@ -11,6 +11,8 @@ export interface ParsedReceiptLineItem {
   normalizedName: string;
   quantity: number;
   unitPrice: number;
+  originalUnitPrice?: number;
+  promotionalUnitPrice?: number;
   currency: string;
   packageSize?: string;
   lineTotal: number;
@@ -86,14 +88,28 @@ export class ReceiptParserService {
     const normalized = this.productNormalizerService.normalize(rawProductName);
     const currency = item.currency?.trim() || 'BRL';
 
+    const originalUnitPrice =
+      item.originalUnitPrice && item.originalUnitPrice > 0
+        ? item.originalUnitPrice
+        : item.unitPrice;
+    const promotionalUnitPrice =
+      item.promotionalUnitPrice &&
+      item.promotionalUnitPrice > 0 &&
+      item.promotionalUnitPrice < originalUnitPrice
+        ? item.promotionalUnitPrice
+        : undefined;
+    const effectiveUnitPrice = promotionalUnitPrice ?? item.unitPrice;
+
     return {
       rawProductName,
       normalizedName: normalized.canonicalName,
       quantity,
-      unitPrice: item.unitPrice,
+      unitPrice: effectiveUnitPrice,
+      originalUnitPrice,
+      promotionalUnitPrice,
       currency,
       packageSize: item.packageSize ?? normalized.sizeDescriptor,
-      lineTotal: Number((quantity * item.unitPrice).toFixed(2)),
+      lineTotal: Number((quantity * effectiveUnitPrice).toFixed(2)),
       matchConfidence: normalized.confidenceScore,
     };
   }

--- a/backend/src/receipts/domain/receipt-record.entity.ts
+++ b/backend/src/receipts/domain/receipt-record.entity.ts
@@ -23,6 +23,8 @@ export interface ReceiptLineItemEntity {
   packageSize?: string;
   quantity: number;
   unitPrice: number;
+  originalUnitPrice?: number;
+  promotionalUnitPrice?: number;
   currency: string;
   matchConfidence: number;
 }

--- a/backend/src/stores/domain/store-offer.entity.ts
+++ b/backend/src/stores/domain/store-offer.entity.ts
@@ -14,6 +14,8 @@ export interface StoreOfferEntity {
   canonicalName: string;
   displayName: string;
   price: number;
+  basePrice?: number;
+  promotionalPrice?: number;
   quantityContext?: string;
   availabilityStatus: StoreOfferAvailabilityStatus;
   confidenceScore: number;

--- a/backend/src/stores/infrastructure/store-offer.repository.ts
+++ b/backend/src/stores/infrastructure/store-offer.repository.ts
@@ -28,6 +28,8 @@ export class StoreOfferRepository {
         displayName: offer.displayName,
         packageLabel: offer.quantityContext ?? 'un',
         priceAmount: offer.price,
+        basePriceAmount: offer.basePrice ?? offer.price,
+        promotionalPriceAmount: offer.promotionalPrice ?? null,
         availabilityStatus:
           offer.availabilityStatus === 'available'
             ? 'available'
@@ -53,6 +55,8 @@ export class StoreOfferRepository {
         displayName: offer.displayName,
         packageLabel: offer.quantityContext ?? 'un',
         priceAmount: offer.price,
+        basePriceAmount: offer.basePrice ?? offer.price,
+        promotionalPriceAmount: offer.promotionalPrice ?? null,
         currencyCode: 'BRL',
         availabilityStatus:
           offer.availabilityStatus === 'available'
@@ -121,6 +125,14 @@ export class StoreOfferRepository {
           canonicalName: normalizedProductName,
           displayName: offer.displayName,
           price: Number(offer.priceAmount),
+          basePrice:
+            offer.basePriceAmount !== null
+              ? Number(offer.basePriceAmount)
+              : Number(offer.priceAmount),
+          promotionalPrice:
+            offer.promotionalPriceAmount !== null
+              ? Number(offer.promotionalPriceAmount)
+              : undefined,
           quantityContext: offer.packageLabel,
           availabilityStatus:
             offer.availabilityStatus === 'available'
@@ -200,6 +212,14 @@ export class StoreOfferRepository {
           canonicalName: normalizedProductName,
           displayName: offer.displayName,
           price: Number(offer.priceAmount),
+          basePrice:
+            offer.basePriceAmount !== null
+              ? Number(offer.basePriceAmount)
+              : Number(offer.priceAmount),
+          promotionalPrice:
+            offer.promotionalPriceAmount !== null
+              ? Number(offer.promotionalPriceAmount)
+              : undefined,
           quantityContext: offer.packageLabel,
           availabilityStatus:
             offer.availabilityStatus === 'available'

--- a/backend/test/unit/optimization/multi-market-optimizer.service.spec.ts
+++ b/backend/test/unit/optimization/multi-market-optimizer.service.spec.ts
@@ -107,6 +107,67 @@ describe('MultiMarketOptimizerService', () => {
 
     expect(result.selections.every((selection) => selection.establishmentName === 'Mercado B')).toBe(true);
     expect(result.totalEstimatedCost).toBe(17);
+    expect(result.estimatedSavings).toBe(4);
+    expect(result.selections[0]).toEqual(
+      expect.objectContaining({
+        comparisonPriceAmount: 10,
+        regionalAveragePriceAmount: 9,
+        savingsVsComparison: 2,
+      }),
+    );
+  });
+
+  it('calculates savings against the same variant in another establishment', () => {
+    const list = createList();
+    list.items = [
+      {
+        ...list.items[0],
+        catalogProductId: 'product-arroz',
+        lockedProductVariantId: 'variant-camil',
+        brandPreferenceMode: 'exact',
+      },
+    ];
+
+    const result = service.optimize(
+      list,
+      [
+        createOffer({
+          id: 'offer-store-1',
+          catalogProductId: 'product-arroz',
+          productVariantId: 'variant-camil',
+          storeId: 'store-1',
+          storeName: 'Estabelecimento 1',
+          canonicalName: 'arroz',
+          displayName: 'Arroz Camil 5kg',
+          price: 20.99,
+          sourceReceiptLineItemId: 'src-1',
+          observedAt: new Date().toISOString(),
+        }),
+        createOffer({
+          id: 'offer-store-2',
+          catalogProductId: 'product-arroz',
+          productVariantId: 'variant-camil',
+          storeId: 'store-2',
+          storeName: 'Estabelecimento 2',
+          canonicalName: 'arroz',
+          displayName: 'Arroz Camil 5kg',
+          price: 19.99,
+          sourceReceiptLineItemId: 'src-2',
+          observedAt: new Date().toISOString(),
+        }),
+      ],
+      'global_full',
+    );
+
+    expect(result.selections[0]).toEqual(
+      expect.objectContaining({
+        establishmentName: 'Estabelecimento 2',
+        priceAmount: 19.99,
+        comparisonPriceAmount: 20.99,
+        savingsVsComparison: 1,
+      }),
+    );
+    expect(result.estimatedSavings).toBe(1);
   });
 
   it('concentrates selection in one store in global_unique mode', () => {

--- a/backend/test/unit/pricing/public-pricing.service.spec.ts
+++ b/backend/test/unit/pricing/public-pricing.service.spec.ts
@@ -7,15 +7,13 @@ describe('PublicPricingService', () => {
     const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
     const prisma = {
       region: {
-        findUnique: jest
-          .fn()
-          .mockResolvedValueOnce({
-            id: 'region-1',
-            slug: 'sao-paulo-sp',
-            name: 'Sao Paulo',
-            stateCode: 'SP',
-            implantationStatus: 'active',
-          }),
+        findUnique: jest.fn().mockResolvedValueOnce({
+          id: 'region-1',
+          slug: 'sao-paulo-sp',
+          name: 'Sao Paulo',
+          stateCode: 'SP',
+          implantationStatus: 'active',
+        }),
       },
       establishment: {
         count: jest.fn().mockResolvedValue(1),
@@ -31,6 +29,8 @@ describe('PublicPricingService', () => {
               displayName: 'Cafe 500g',
               packageLabel: '500 g',
               priceAmount: 15.9,
+              basePriceAmount: 18.9,
+              promotionalPriceAmount: 15.9,
               sourceType: 'admin',
               sourceReference: 'Painel admin',
               observedAt: new Date('2026-04-27T10:00:00Z'),
@@ -54,6 +54,8 @@ describe('PublicPricingService', () => {
               id: 'offer-1',
               packageLabel: '500 g',
               priceAmount: 15.9,
+              basePriceAmount: 18.9,
+              promotionalPriceAmount: 15.9,
               sourceType: 'admin',
               sourceReference: 'Painel admin',
               observedAt: new Date('2026-04-27T10:00:00Z'),
@@ -72,6 +74,8 @@ describe('PublicPricingService', () => {
           displayName: 'Cafe 500g',
           packageLabel: '500 g',
           priceAmount: 15.9,
+          basePriceAmount: 18.9,
+          promotionalPriceAmount: 15.9,
           sourceType: 'admin',
           sourceReference: 'Painel admin',
           observedAt: new Date('2026-04-27T10:00:00Z'),
@@ -123,6 +127,9 @@ describe('PublicPricingService', () => {
           variantName: 'Cafe 500g',
           imageUrl: 'https://example.com/cafe.png',
           storeName: 'Mercado Centro',
+          priceAmount: 15.9,
+          basePriceAmount: 18.9,
+          promotionalPriceAmount: 15.9,
         }),
       ],
     });
@@ -138,10 +145,19 @@ describe('PublicPricingService', () => {
           id: 'variant-1',
           brandName: 'Pilao',
         }),
+        activeOffer: expect.objectContaining({
+          basePriceAmount: 18.9,
+          promotionalPriceAmount: 15.9,
+          regionalAveragePriceAmount: 15.9,
+          comparisonPriceAmount: 15.9,
+          savingsVsComparison: 0,
+        }),
         alternativeOffers: [
           expect.objectContaining({
             id: 'offer-1',
             storeName: 'Mercado Centro',
+            basePriceAmount: 18.9,
+            promotionalPriceAmount: 15.9,
           }),
         ],
       }),
@@ -152,6 +168,112 @@ describe('PublicPricingService', () => {
     );
     expect(logSpy).toHaveBeenCalledWith(
       'Offer detail requested for offer-1: 1 regional alternatives',
+    );
+  });
+
+  it('compares only identical variants across establishments in the same region', async () => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    const prisma = {
+      productOffer: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'offer-cheap',
+          isActive: true,
+          catalogProductId: 'product-arroz',
+          productVariantId: 'variant-camil',
+          displayName: 'Arroz Camil 5kg',
+          packageLabel: '5 kg',
+          priceAmount: 19.99,
+          basePriceAmount: 20.99,
+          promotionalPriceAmount: 19.99,
+          sourceType: 'receipt',
+          sourceReference: 'NFCe 2',
+          observedAt: new Date('2026-04-27T10:00:00Z'),
+          confidenceLevel: 'high',
+          catalogProduct: {
+            id: 'product-arroz',
+            name: 'Arroz tipo 1 5kg',
+            category: 'mercearia',
+            imageUrl: null,
+          },
+          productVariant: {
+            id: 'variant-camil',
+            displayName: 'Arroz Camil 5kg',
+            brandName: 'Camil',
+            packageLabel: '5 kg',
+            imageUrl: null,
+          },
+          establishment: {
+            isActive: true,
+            regionId: 'region-1',
+            unitName: 'Estabelecimento 2',
+            neighborhood: 'Pinheiros',
+            region: {
+              id: 'region-1',
+              slug: 'sao-paulo-sp',
+              name: 'Sao Paulo',
+              stateCode: 'SP',
+            },
+          },
+        }),
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'offer-cheap',
+            packageLabel: '5 kg',
+            priceAmount: 19.99,
+            basePriceAmount: 20.99,
+            promotionalPriceAmount: 19.99,
+            sourceType: 'receipt',
+            sourceReference: 'NFCe 2',
+            observedAt: new Date('2026-04-27T10:00:00Z'),
+            confidenceLevel: 'high',
+            establishment: {
+              unitName: 'Estabelecimento 2',
+              neighborhood: 'Pinheiros',
+            },
+          },
+          {
+            id: 'offer-expensive',
+            packageLabel: '5 kg',
+            priceAmount: 20.99,
+            basePriceAmount: 20.99,
+            promotionalPriceAmount: null,
+            sourceType: 'receipt',
+            sourceReference: 'NFCe 1',
+            observedAt: new Date('2026-04-27T09:00:00Z'),
+            confidenceLevel: 'high',
+            establishment: {
+              unitName: 'Estabelecimento 1',
+              neighborhood: 'Centro',
+            },
+          },
+        ]),
+      },
+    };
+
+    const service = new PublicPricingService(prisma as never);
+
+    await expect(service.getOfferDetail('offer-cheap')).resolves.toEqual(
+      expect.objectContaining({
+        activeOffer: expect.objectContaining({
+          priceAmount: 19.99,
+          comparisonPriceAmount: 20.99,
+          savingsVsComparison: 1,
+        }),
+        alternativeOffers: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'offer-expensive',
+            priceAmount: 20.99,
+          }),
+        ]),
+      }),
+    );
+
+    expect(prisma.productOffer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          productVariantId: 'variant-camil',
+        }),
+      }),
     );
   });
 

--- a/backend/test/unit/receipts/receipt-parser.service.spec.ts
+++ b/backend/test/unit/receipts/receipt-parser.service.spec.ts
@@ -69,6 +69,30 @@ describe('ReceiptParserService', () => {
     expect(result.confidenceScore).toBeLessThan(0.95);
   });
 
+  it('keeps original and promotional prices when a receipt line has a discount', () => {
+    const input: ReceiptIngestionRequest = {
+      storeName: 'Mercado Centro',
+      items: [
+        {
+          rawProductName: 'Arroz Camil tipo 1 5kg',
+          quantity: 1,
+          unitPrice: 18.99,
+          originalUnitPrice: 20.99,
+          promotionalUnitPrice: 18.99,
+        },
+      ],
+    };
+
+    const result = service.parse(input);
+
+    expect(result.items[0]).toMatchObject({
+      unitPrice: 18.99,
+      originalUnitPrice: 20.99,
+      promotionalUnitPrice: 18.99,
+      lineTotal: 18.99,
+    });
+  });
+
   it('fails when no valid structured lines can be extracted', () => {
     const input: ReceiptIngestionRequest = {
       storeName: '   ',

--- a/mobile/lib/features/home/presentation/mobile_home_screen.dart
+++ b/mobile/lib/features/home/presentation/mobile_home_screen.dart
@@ -1186,10 +1186,27 @@ class _OfferCard extends StatelessWidget {
                     color: const Color(0xFF487500),
                     borderRadius: BorderRadius.circular(999),
                   ),
-                  child: Text(
-                    _formatCurrency(offer.priceAmount),
-                    style: theme.textTheme.labelLarge
-                        ?.copyWith(color: const Color(0xFFB5FF56)),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: <Widget>[
+                      if (offer.promotionalPriceAmount != null &&
+                          offer.basePriceAmount != null &&
+                          offer.basePriceAmount! >
+                              offer.promotionalPriceAmount!) ...<Widget>[
+                        Text(
+                          _formatCurrency(offer.basePriceAmount!),
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: const Color(0xFFE5E7EB),
+                            decoration: TextDecoration.lineThrough,
+                          ),
+                        ),
+                      ],
+                      Text(
+                        _formatCurrency(offer.priceAmount),
+                        style: theme.textTheme.labelLarge
+                            ?.copyWith(color: const Color(0xFFB5FF56)),
+                      ),
+                    ],
                   ),
                 ),
               ],
@@ -1253,7 +1270,23 @@ class _OfferDetailRow extends StatelessWidget {
           const SizedBox(height: 4),
           Text('${offer.packageLabel} · ${offer.sourceLabel}'),
           const SizedBox(height: 8),
+          if (offer.promotionalPriceAmount != null &&
+              offer.basePriceAmount != null &&
+              offer.basePriceAmount! > offer.promotionalPriceAmount!) ...<Widget>[
+            Text(
+              _formatCurrency(offer.basePriceAmount!),
+              style: const TextStyle(decoration: TextDecoration.lineThrough),
+            ),
+            const SizedBox(height: 2),
+          ],
           Text(_formatCurrency(offer.priceAmount)),
+          if (offer.savingsVsComparison != null &&
+              offer.savingsVsComparison! > 0) ...<Widget>[
+            const SizedBox(height: 4),
+            Text(
+              'Economia de ${_formatCurrency(offer.savingsVsComparison!)} versus outra loja',
+            ),
+          ],
         ],
       ),
     );

--- a/mobile/lib/features/shared/data/pricely_backend_gateway.dart
+++ b/mobile/lib/features/shared/data/pricely_backend_gateway.dart
@@ -513,6 +513,10 @@ class PublicOfferSummary {
     required this.displayName,
     required this.packageLabel,
     required this.priceAmount,
+    this.basePriceAmount,
+    this.promotionalPriceAmount,
+    this.savingsVsRegionalAverage,
+    this.savingsVsComparison,
     required this.observedAt,
     required this.sourceLabel,
     required this.storeName,
@@ -527,6 +531,10 @@ class PublicOfferSummary {
   final String displayName;
   final String packageLabel;
   final double priceAmount;
+  final double? basePriceAmount;
+  final double? promotionalPriceAmount;
+  final double? savingsVsRegionalAverage;
+  final double? savingsVsComparison;
   final String observedAt;
   final String sourceLabel;
   final String storeName;
@@ -546,6 +554,12 @@ class PublicOfferSummary {
           'Oferta',
       packageLabel: json['packageLabel'] as String? ?? '',
       priceAmount: (json['priceAmount'] as num? ?? 0).toDouble(),
+      basePriceAmount: (json['basePriceAmount'] as num?)?.toDouble(),
+      promotionalPriceAmount:
+          (json['promotionalPriceAmount'] as num?)?.toDouble(),
+      savingsVsRegionalAverage:
+          (json['savingsVsRegionalAverage'] as num?)?.toDouble(),
+      savingsVsComparison: (json['savingsVsComparison'] as num?)?.toDouble(),
       observedAt: json['observedAt'] as String? ?? '',
       sourceLabel: json['sourceLabel'] as String? ?? 'manual',
       storeName: json['storeName'] as String? ?? 'Loja',
@@ -593,6 +607,9 @@ class PublicOfferDetail {
               activeOffer['displayName'] ?? product['name'] ?? 'Oferta',
           'packageLabel': activeOffer['packageLabel'] ?? '',
           'priceAmount': activeOffer['priceAmount'] ?? 0,
+          'basePriceAmount': activeOffer['basePriceAmount'],
+          'promotionalPriceAmount': activeOffer['promotionalPriceAmount'],
+          'savingsVsComparison': activeOffer['savingsVsComparison'],
           'observedAt': activeOffer['observedAt'] ?? '',
           'sourceLabel': activeOffer['sourceLabel'] ?? 'manual',
           'storeName': activeOffer['storeName'] ?? 'Loja',
@@ -611,6 +628,8 @@ class PublicOfferDetail {
                 'displayName': product['name'] ?? 'Oferta',
                 'packageLabel': entry['packageLabel'] ?? '',
                 'priceAmount': entry['priceAmount'] ?? 0,
+                'basePriceAmount': entry['basePriceAmount'],
+                'promotionalPriceAmount': entry['promotionalPriceAmount'],
                 'observedAt': entry['observedAt'] ?? '',
                 'sourceLabel': entry['sourceLabel'] ?? 'manual',
                 'storeName': entry['storeName'] ?? 'Loja',

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -67,6 +67,9 @@ type OptimizationResultApiResponse = {
     establishmentNeighborhood?: string;
     estimatedCost?: number;
     priceAmount?: number;
+    comparisonPriceAmount?: number;
+    regionalAveragePriceAmount?: number;
+    savingsVsComparison?: number;
     sourceLabel?: string;
     observedAt?: string;
     selectionStatus: 'selected' | 'missing' | 'review';
@@ -117,6 +120,9 @@ type RegionOffersApiResponse = {
     displayName: string;
     packageLabel: string;
     priceAmount: number;
+    basePriceAmount?: number;
+    promotionalPriceAmount?: number;
+    savingsVsRegionalAverage?: number;
     observedAt: string;
     sourceLabel: string;
     storeName: string;
@@ -150,6 +156,11 @@ type OfferDetailApiResponse = {
     displayName: string;
     packageLabel: string;
     priceAmount: number;
+    basePriceAmount?: number;
+    promotionalPriceAmount?: number;
+    regionalAveragePriceAmount?: number;
+    comparisonPriceAmount?: number;
+    savingsVsComparison?: number;
     observedAt: string;
     sourceLabel: string;
     storeName: string;
@@ -162,6 +173,8 @@ type OfferDetailApiResponse = {
     neighborhood: string;
     packageLabel: string;
     priceAmount: number;
+    basePriceAmount?: number;
+    promotionalPriceAmount?: number;
     observedAt: string;
     sourceLabel: string;
     confidenceLevel: 'high' | 'medium' | 'low';
@@ -328,6 +341,8 @@ type AdminOfferResponse = {
   displayName: string;
   packageLabel: string;
   priceAmount: number | string;
+  basePriceAmount?: number | string | null;
+  promotionalPriceAmount?: number | string | null;
   availabilityStatus: string;
   confidenceLevel: string;
   observedAt: string;

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -328,6 +328,8 @@ export function AdminPricesPage() {
     displayName: '',
     packageLabel: '',
     priceAmount: '',
+    basePriceAmount: '',
+    promotionalPriceAmount: '',
   });
   const productVariants = products.flatMap((product) =>
     product.productVariants.map((variant) => ({
@@ -356,6 +358,8 @@ export function AdminPricesPage() {
       displayName: form.displayName,
       packageLabel: form.packageLabel,
       priceAmount: Number(form.priceAmount),
+      basePriceAmount: form.basePriceAmount ? Number(form.basePriceAmount) : Number(form.priceAmount),
+      promotionalPriceAmount: form.promotionalPriceAmount ? Number(form.promotionalPriceAmount) : null,
       availabilityStatus: 'available',
       confidenceLevel: 'high',
     };
@@ -372,6 +376,8 @@ export function AdminPricesPage() {
       displayName: '',
       packageLabel: '',
       priceAmount: '',
+      basePriceAmount: '',
+      promotionalPriceAmount: '',
     });
     setEditingOfferId(null);
     await reload();
@@ -414,8 +420,10 @@ export function AdminPricesPage() {
             </select>
             <Input placeholder="Nome exibido" value={form.displayName} onChange={(event) => setForm((current) => ({ ...current, displayName: event.target.value }))} />
             <Input placeholder="Embalagem" value={form.packageLabel} onChange={(event) => setForm((current) => ({ ...current, packageLabel: event.target.value }))} />
+            <Input placeholder="Preço base" value={form.basePriceAmount} onChange={(event) => setForm((current) => ({ ...current, basePriceAmount: event.target.value }))} />
+            <Input placeholder="Preço promocional" value={form.promotionalPriceAmount} onChange={(event) => setForm((current) => ({ ...current, promotionalPriceAmount: event.target.value, priceAmount: event.target.value || current.basePriceAmount || current.priceAmount }))} />
             <div className="flex gap-2">
-              <Input placeholder="Preço" value={form.priceAmount} onChange={(event) => setForm((current) => ({ ...current, priceAmount: event.target.value }))} />
+              <Input placeholder="Preço efetivo" value={form.priceAmount} onChange={(event) => setForm((current) => ({ ...current, priceAmount: event.target.value }))} />
               <Button type="submit">{editingOfferId ? 'Salvar' : 'Criar'}</Button>
             </div>
           </form>
@@ -479,7 +487,16 @@ export function AdminPricesPage() {
                                 </div>
                               </TableCell>
                               <TableCell>{offer.establishment.unitName}</TableCell>
-                              <TableCell>{formatCurrency(Number(offer.priceAmount))}</TableCell>
+                              <TableCell>
+                                <div className="grid gap-1">
+                                  {offer.promotionalPriceAmount && offer.basePriceAmount ? (
+                                    <span className="text-xs text-muted-foreground line-through">
+                                      {formatCurrency(Number(offer.basePriceAmount))}
+                                    </span>
+                                  ) : null}
+                                  <span>{formatCurrency(Number(offer.priceAmount))}</span>
+                                </div>
+                              </TableCell>
                               <TableCell>{formatFreshnessLabel(offer.observedAt)}</TableCell>
                               <TableCell>
                                 <div className="flex items-center gap-2">
@@ -498,6 +515,8 @@ export function AdminPricesPage() {
                                         displayName: offer.displayName,
                                         packageLabel: offer.packageLabel,
                                         priceAmount: String(offer.priceAmount),
+                                        basePriceAmount: offer.basePriceAmount ? String(offer.basePriceAmount) : '',
+                                        promotionalPriceAmount: offer.promotionalPriceAmount ? String(offer.promotionalPriceAmount) : '',
                                       });
                                     }}
                                   >

--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -138,6 +138,11 @@ describe('public pages', () => {
         displayName: 'Cafe Pilao 500g',
         packageLabel: '500 g',
         priceAmount: 15.9,
+        basePriceAmount: 18.9,
+        promotionalPriceAmount: 15.9,
+        regionalAveragePriceAmount: 16.15,
+        comparisonPriceAmount: 16.4,
+        savingsVsComparison: 0.5,
         observedAt: '2026-04-27T10:00:00.000Z',
         sourceLabel: 'Painel admin',
         storeName: 'Mercado Centro',
@@ -151,6 +156,7 @@ describe('public pages', () => {
           neighborhood: 'Cambuí',
           packageLabel: '500 g',
           priceAmount: 16.4,
+          basePriceAmount: 16.4,
           observedAt: '2026-04-27T09:00:00.000Z',
           sourceLabel: 'Painel admin',
           confidenceLevel: 'medium',
@@ -175,6 +181,8 @@ describe('public pages', () => {
       ),
     ).toBeTruthy();
     expect(screen.getByText('Preços do produto na cidade')).toBeTruthy();
+    expect(screen.getByText('R$ 18,90')).toBeTruthy();
+    expect(screen.getByText(/Economize R\$ 0,50/)).toBeTruthy();
     expect(screen.getByText('Mercado Sul')).toBeTruthy();
   });
 });

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -140,6 +140,38 @@ function confidenceBadge(level: ConfidenceLevel) {
   return <Badge variant="destructive">Revisar</Badge>;
 }
 
+function PriceDisplay({
+  priceAmount,
+  basePriceAmount,
+  promotionalPriceAmount,
+  size = 'md',
+}: {
+  priceAmount: number;
+  basePriceAmount?: number | null;
+  promotionalPriceAmount?: number | null;
+  size?: 'md' | 'lg';
+}) {
+  const hasPromotion =
+    promotionalPriceAmount !== undefined &&
+    promotionalPriceAmount !== null &&
+    basePriceAmount !== undefined &&
+    basePriceAmount !== null &&
+    basePriceAmount > promotionalPriceAmount;
+
+  return (
+    <div className="grid gap-1">
+      {hasPromotion ? (
+        <div className="text-sm text-muted-foreground line-through">
+          {formatCurrency(basePriceAmount)}
+        </div>
+      ) : null}
+      <div className={size === 'lg' ? 'text-4xl font-semibold' : 'text-2xl font-semibold'}>
+        {formatCurrency(priceAmount)}
+      </div>
+    </div>
+  );
+}
+
 function cityStatusBadge(city: SupportedCity) {
   if (city.status === 'supported') {
     return <Badge className="bg-lime-100 text-lime-900 hover:bg-lime-100">Disponível</Badge>;
@@ -318,6 +350,9 @@ export function LandingPage() {
       freshness: FreshnessLevel;
       confidence: ConfidenceLevel;
       price: number;
+      basePrice?: number;
+      promotionalPrice?: number;
+      savingsVsRegionalAverage?: number;
     }>
   >([]);
 
@@ -351,6 +386,9 @@ export function LandingPage() {
                   ? 'media'
                   : 'baixa',
             price: offer.priceAmount,
+            basePrice: offer.basePriceAmount,
+            promotionalPrice: offer.promotionalPriceAmount,
+            savingsVsRegionalAverage: offer.savingsVsRegionalAverage,
           })),
         );
       } catch {
@@ -511,7 +549,16 @@ export function LandingPage() {
                 {freshnessBadge(offer.freshness)}
                 {confidenceBadge(offer.confidence)}
               </div>
-              <div className="text-2xl font-semibold">{formatCurrency(offer.price)}</div>
+              <PriceDisplay
+                basePriceAmount={offer.basePrice}
+                priceAmount={offer.price}
+                promotionalPriceAmount={offer.promotionalPrice}
+              />
+              {offer.savingsVsRegionalAverage && offer.savingsVsRegionalAverage > 0 ? (
+                <div className="text-sm text-emerald-700">
+                  {formatCurrency(offer.savingsVsRegionalAverage)} abaixo da média da cidade
+                </div>
+              ) : null}
             </CardContent>
           </Card>
         )) : (
@@ -611,7 +658,16 @@ export function OffersPage() {
                       : 'baixa',
                 )}
               </div>
-              <div className="text-2xl font-semibold">{formatCurrency(offer.priceAmount)}</div>
+              <PriceDisplay
+                basePriceAmount={offer.basePriceAmount}
+                priceAmount={offer.priceAmount}
+                promotionalPriceAmount={offer.promotionalPriceAmount}
+              />
+              {offer.savingsVsRegionalAverage && offer.savingsVsRegionalAverage > 0 ? (
+                <div className="text-sm text-emerald-700">
+                  {formatCurrency(offer.savingsVsRegionalAverage)} abaixo da média da cidade
+                </div>
+              ) : null}
             </CardContent>
             <CardFooter className="justify-end">
               <Button asChild size="sm" variant="outline">
@@ -700,9 +756,22 @@ export function OfferDetailPage() {
                     : 'baixa',
               )}
             </div>
-            <div className="text-4xl font-semibold">
-              {formatCurrency(offer.activeOffer.priceAmount)}
-            </div>
+            <PriceDisplay
+              basePriceAmount={offer.activeOffer.basePriceAmount}
+              priceAmount={offer.activeOffer.priceAmount}
+              promotionalPriceAmount={offer.activeOffer.promotionalPriceAmount}
+              size="lg"
+            />
+            {offer.activeOffer.savingsVsComparison && offer.activeOffer.savingsVsComparison > 0 ? (
+              <p className="text-sm font-medium text-emerald-700">
+                Economize {formatCurrency(offer.activeOffer.savingsVsComparison)} versus o maior preço encontrado para esta variante.
+              </p>
+            ) : null}
+            {offer.activeOffer.regionalAveragePriceAmount ? (
+              <p className="text-sm text-muted-foreground">
+                Média regional desta variante: {formatCurrency(offer.activeOffer.regionalAveragePriceAmount)}.
+              </p>
+            ) : null}
             <p className="text-sm text-muted-foreground">
               Preço observado em {offer.region.name} com evidência rastreável.
             </p>
@@ -727,7 +796,11 @@ export function OfferDetailPage() {
                     <div className="font-medium">{entry.storeName}</div>
                     <div className="text-sm text-muted-foreground">{entry.neighborhood}</div>
                   </div>
-                  <div className="text-lg font-semibold">{formatCurrency(entry.priceAmount)}</div>
+                  <PriceDisplay
+                    basePriceAmount={entry.basePriceAmount}
+                    priceAmount={entry.priceAmount}
+                    promotionalPriceAmount={entry.promotionalPriceAmount}
+                  />
                 </div>
                 <div className="mt-2 text-sm text-muted-foreground">
                   {entry.packageLabel} · {entry.sourceLabel} · {formatDateTime(entry.observedAt)}
@@ -1746,7 +1819,16 @@ export function OptimizationPage() {
                               'Sem loja definida'
                             )}
                           </TableCell>
-                          <TableCell>{formatCurrency(selection.priceAmount ?? selection.estimatedCost ?? 0)}</TableCell>
+                          <TableCell>
+                            <div className="grid gap-1">
+                              <span>{formatCurrency(selection.priceAmount ?? selection.estimatedCost ?? 0)}</span>
+                              {selection.savingsVsComparison && selection.savingsVsComparison > 0 ? (
+                                <span className="text-xs text-emerald-700">
+                                  economiza {formatCurrency(selection.savingsVsComparison)}
+                                </span>
+                              ) : null}
+                            </div>
+                          </TableCell>
                           <TableCell>{selection.sourceLabel ?? 'Sem evidência suficiente'}</TableCell>
                           <TableCell>
                             {selection.observedAt ? formatFreshnessLabel(selection.observedAt) : 'Sem data'}


### PR DESCRIPTION
## Summary

- Extends offers with base/original and promotional prices while keeping `priceAmount` as the effective optimization price.
- Parses receipt lines with original/promotional unit prices and persists them into store offers.
- Compares identical product variants across establishments in the same region and exposes savings versus the highest comparable price plus regional average.
- Persists optimization selection comparison fields and sums estimated savings from variant-level comparisons.
- Updates web offer cards/detail/admin pricing UI and mobile offer rendering for promotional/crossed prices.
- Expands seed data with comparable establishments and promotional offer cases.

## Validation

- `backend`: `npm run db:generate`
- `backend`: `npm run build`
- `backend`: `npm test -- --runTestsByPath test/unit/receipts/receipt-parser.service.spec.ts test/unit/optimization/multi-market-optimizer.service.spec.ts test/unit/pricing/public-pricing.service.spec.ts test/integration/optimization/multi-market-optimization.integration.spec.ts`
- `web`: `npm run build`
- `web`: `npm test -- src/public/public-pages.spec.tsx`

## Notes

- `flutter test` could not run in this shell because `flutter` is not installed or not on PATH.

Issue: #182