### PR TITLE
Add queue job audit details

### DIFF
--- a/backend/src/admin/api/admin-dashboard.controller.ts
+++ b/backend/src/admin/api/admin-dashboard.controller.ts
@@ -317,6 +317,11 @@ export class AdminDashboardController {
     return this.adminDashboardService.listProcessingJobs();
   }
 
+  @Get('processing-jobs/:id')
+  async getProcessingJobDetail(@Param('id') id: string) {
+    return this.adminDashboardService.getProcessingJobDetail(id);
+  }
+
   @Get('queue-health')
   async queueHealth() {
     return this.adminDashboardService.getQueueHealth();

--- a/backend/src/admin/application/admin-dashboard.service.ts
+++ b/backend/src/admin/application/admin-dashboard.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 
 import { CatalogProductsService } from '../../catalog/application/catalog-products.service';
 import { CatalogMediaService } from '../../catalog/application/catalog-media.service';
@@ -89,6 +89,25 @@ export class AdminDashboardService {
     const jobs = await this.prisma.processingJob.findMany({
       orderBy: [{ updatedAt: 'desc' }, { createdAt: 'desc' }],
       take: 100,
+      include: {
+        optimizationRun: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                displayName: true,
+                email: true,
+              },
+            },
+            shoppingList: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
     });
 
     const projectedJobs = jobs.map((job) => ({
@@ -103,11 +122,117 @@ export class AdminDashboardService {
       createdAt: job.createdAt.toISOString(),
       updatedAt: job.updatedAt.toISOString(),
       finishedAt: job.finishedAt?.toISOString(),
+      owner: job.optimizationRun?.user,
+      shoppingList: job.optimizationRun?.shoppingList,
+      optimizationRun: job.optimizationRun
+        ? {
+            id: job.optimizationRun.id,
+            mode: job.optimizationRun.mode,
+            status: job.optimizationRun.status,
+            createdAt: job.optimizationRun.createdAt.toISOString(),
+            completedAt: job.optimizationRun.completedAt?.toISOString(),
+          }
+        : null,
     }));
 
     this.logger.log(`Admin processing jobs requested: ${projectedJobs.length} records returned`);
 
     return projectedJobs;
+  }
+
+  async getProcessingJobDetail(id: string) {
+    const job = await this.prisma.processingJob.findUnique({
+      where: { id },
+      include: {
+        optimizationRun: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                displayName: true,
+                email: true,
+              },
+            },
+            shoppingList: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+            optimizationSelections: {
+              include: {
+                shoppingListItem: true,
+                productOffer: {
+                  include: {
+                    productVariant: true,
+                    establishment: true,
+                  },
+                },
+              },
+              orderBy: {
+                id: 'asc',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!job) {
+      throw new NotFoundException(`Processing job ${id} was not found`);
+    }
+
+    const optimizationRun = job.optimizationRun;
+
+    return {
+      id: job.id,
+      queueName: job.queueName,
+      jobType: job.jobType,
+      resourceType: job.resourceType,
+      resourceId: job.resourceId,
+      status: job.status,
+      attemptCount: job.attemptCount,
+      failureReason: job.failureReason,
+      createdAt: job.createdAt.toISOString(),
+      updatedAt: job.updatedAt.toISOString(),
+      finishedAt: job.finishedAt?.toISOString(),
+      owner: optimizationRun?.user ?? null,
+      shoppingList: optimizationRun?.shoppingList ?? null,
+      optimizationRun: optimizationRun
+        ? {
+            id: optimizationRun.id,
+            mode: optimizationRun.mode,
+            status: optimizationRun.status,
+            totalEstimatedCost: Number(optimizationRun.totalEstimatedCost ?? 0),
+            estimatedSavings: Number(optimizationRun.estimatedSavings ?? 0),
+            coverageStatus: optimizationRun.coverageStatus,
+            summary: optimizationRun.summary,
+            createdAt: optimizationRun.createdAt.toISOString(),
+            completedAt: optimizationRun.completedAt?.toISOString(),
+            selections: optimizationRun.optimizationSelections.map((selection) => ({
+              id: selection.id,
+              shoppingListItemId: selection.shoppingListItemId,
+              shoppingListItemName: selection.shoppingListItem.requestedName,
+              status: selection.status,
+              estimatedCost: Number(selection.estimatedCost ?? 0),
+              confidenceNotice: selection.confidenceNotice,
+              offer: selection.productOffer
+                ? {
+                    id: selection.productOffer.id,
+                    displayName: selection.productOffer.displayName,
+                    variantName: selection.productOffer.productVariant.displayName,
+                    establishmentName: selection.productOffer.establishment.unitName,
+                    neighborhood: selection.productOffer.establishment.neighborhood,
+                    priceAmount: Number(selection.productOffer.priceAmount),
+                    sourceLabel:
+                      selection.productOffer.sourceReference ?? selection.productOffer.sourceType,
+                    observedAt: selection.productOffer.observedAt.toISOString(),
+                  }
+                : null,
+            })),
+          }
+        : null,
+    };
   }
 
   async getQueueHealth() {

--- a/backend/test/unit/admin/admin-dashboard.service.spec.ts
+++ b/backend/test/unit/admin/admin-dashboard.service.spec.ts
@@ -22,6 +22,66 @@ describe('AdminDashboardService', () => {
       catalogProduct: { count: jest.fn().mockResolvedValue(11) },
       processingJob: {
         count: jest.fn().mockResolvedValue(5),
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'job-1',
+          queueName: 'optimization',
+          jobType: 'optimization',
+          resourceType: 'shopping_list',
+          resourceId: 'list-1',
+          status: 'completed',
+          attemptCount: 1,
+          failureReason: null,
+          createdAt: new Date('2026-04-27T10:00:00Z'),
+          updatedAt: new Date('2026-04-27T10:05:00Z'),
+          finishedAt: new Date('2026-04-27T10:05:00Z'),
+          optimizationRun: {
+            id: 'run-1',
+            mode: 'global_full',
+            status: 'completed',
+            totalEstimatedCost: { toString: () => '82.40' },
+            estimatedSavings: { toString: () => '18.50' },
+            coverageStatus: 'complete',
+            summary: 'Selected cheapest comparable offers.',
+            createdAt: new Date('2026-04-27T10:00:00Z'),
+            completedAt: new Date('2026-04-27T10:05:00Z'),
+            user: {
+              id: 'user-1',
+              displayName: 'Cliente 1',
+              email: 'cliente1@pricely.local',
+            },
+            shoppingList: {
+              id: 'list-1',
+              name: 'Compra mensal',
+            },
+            optimizationSelections: [
+              {
+                id: 'selection-1',
+                shoppingListItemId: 'item-1',
+                status: 'selected',
+                estimatedCost: { toString: () => '19.99' },
+                confidenceNotice: null,
+                shoppingListItem: {
+                  requestedName: 'Arroz',
+                },
+                productOffer: {
+                  id: 'offer-1',
+                  displayName: 'Arroz Camil',
+                  priceAmount: { toString: () => '19.99' },
+                  sourceReference: 'NFCe 1',
+                  sourceType: 'receipt',
+                  observedAt: new Date('2026-04-27T09:00:00Z'),
+                  productVariant: {
+                    displayName: 'Arroz Camil 5kg',
+                  },
+                  establishment: {
+                    unitName: 'Mercado Centro',
+                    neighborhood: 'Centro',
+                  },
+                },
+              },
+            ],
+          },
+        }),
         findMany: jest.fn().mockResolvedValue([
           {
             id: 'job-1',
@@ -35,6 +95,22 @@ describe('AdminDashboardService', () => {
             createdAt: new Date('2026-04-27T10:00:00Z'),
             updatedAt: new Date('2026-04-27T10:01:00Z'),
             finishedAt: null,
+            optimizationRun: {
+              id: 'run-1',
+              mode: 'global_full',
+              status: 'queued',
+              createdAt: new Date('2026-04-27T10:00:00Z'),
+              completedAt: null,
+              user: {
+                id: 'user-1',
+                displayName: 'Cliente 1',
+                email: 'cliente1@pricely.local',
+              },
+              shoppingList: {
+                id: 'list-1',
+                name: 'Compra mensal',
+              },
+            },
           },
           {
             id: 'job-2',
@@ -48,6 +124,7 @@ describe('AdminDashboardService', () => {
             createdAt: new Date('2026-04-27T09:00:00Z'),
             updatedAt: new Date('2026-04-27T09:01:00Z'),
             finishedAt: new Date('2026-04-27T09:01:00Z'),
+            optimizationRun: null,
           },
           {
             id: 'job-3',
@@ -61,6 +138,7 @@ describe('AdminDashboardService', () => {
             createdAt: new Date('2026-04-27T08:00:00Z'),
             updatedAt: new Date('2026-04-27T08:01:00Z'),
             finishedAt: null,
+            optimizationRun: null,
           },
         ]),
       },
@@ -127,6 +205,16 @@ describe('AdminDashboardService', () => {
         queueName: 'optimization',
         status: 'queued',
         createdAt: '2026-04-27T10:00:00.000Z',
+        owner: expect.objectContaining({
+          id: 'user-1',
+        }),
+        shoppingList: expect.objectContaining({
+          id: 'list-1',
+        }),
+        optimizationRun: expect.objectContaining({
+          id: 'run-1',
+          mode: 'global_full',
+        }),
       }),
       expect.objectContaining({
         id: 'job-2',
@@ -139,6 +227,33 @@ describe('AdminDashboardService', () => {
         failureReason: 'timeout',
       }),
     ]);
+
+    await expect(service.getProcessingJobDetail('job-1')).resolves.toEqual(
+      expect.objectContaining({
+        id: 'job-1',
+        owner: expect.objectContaining({
+          id: 'user-1',
+        }),
+        shoppingList: expect.objectContaining({
+          id: 'list-1',
+        }),
+        optimizationRun: expect.objectContaining({
+          id: 'run-1',
+          mode: 'global_full',
+          totalEstimatedCost: 82.4,
+          estimatedSavings: 18.5,
+          selections: [
+            expect.objectContaining({
+              shoppingListItemName: 'Arroz',
+              offer: expect.objectContaining({
+                establishmentName: 'Mercado Centro',
+                priceAmount: 19.99,
+              }),
+            }),
+          ],
+        }),
+      }),
+    );
 
     await expect(service.getQueueHealth()).resolves.toEqual({
       queuedJobs: 2,

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -220,6 +220,49 @@ type AdminProcessingJobResponse = {
   createdAt: string;
   updatedAt: string;
   finishedAt?: string;
+  owner?: {
+    id: string;
+    displayName: string;
+    email: string;
+  } | null;
+  shoppingList?: {
+    id: string;
+    name: string;
+  } | null;
+  optimizationRun?: {
+    id: string;
+    mode: OptimizationModeId;
+    status: 'queued' | 'running' | 'completed' | 'failed';
+    createdAt: string;
+    completedAt?: string;
+  } | null;
+};
+
+type AdminProcessingJobDetailResponse = AdminProcessingJobResponse & {
+  optimizationRun?: (NonNullable<AdminProcessingJobResponse['optimizationRun']> & {
+    totalEstimatedCost: number;
+    estimatedSavings: number;
+    coverageStatus: 'complete' | 'partial' | 'none';
+    summary?: string | null;
+    selections: Array<{
+      id: string;
+      shoppingListItemId: string;
+      shoppingListItemName: string;
+      status: 'selected' | 'review' | 'missing';
+      estimatedCost: number;
+      confidenceNotice?: string | null;
+      offer?: {
+        id: string;
+        displayName: string;
+        variantName: string;
+        establishmentName: string;
+        neighborhood: string;
+        priceAmount: number;
+        sourceLabel: string;
+        observedAt: string;
+      } | null;
+    }>;
+  }) | null;
 };
 
 type AdminQueueHealthResponse = {
@@ -572,6 +615,10 @@ export async function fetchAdminProcessingJobs(token: string) {
   return apiFetch<AdminProcessingJobResponse[]>('/admin/processing-jobs', {}, token);
 }
 
+export async function fetchAdminProcessingJobDetail(token: string, id: string) {
+  return apiFetch<AdminProcessingJobDetailResponse>(`/admin/processing-jobs/${id}`, {}, token);
+}
+
 export async function fetchAdminQueueHealth(token: string) {
   return apiFetch<AdminQueueHealthResponse>('/admin/queue-health', {}, token);
 }
@@ -810,6 +857,7 @@ export type {
   AdminProductResponse,
   AdminProductVariantResponse,
   AdminProcessingJobResponse,
+  AdminProcessingJobDetailResponse,
   AdminQueueHealthResponse,
   AdminRegionResponse,
   OfferDetailApiResponse,

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -28,6 +28,7 @@ vi.mock('@/app/api', () => ({
   fetchAdminMetrics: (...args: unknown[]) => fetchAdminMetrics(...args),
   fetchAdminQueueHealth: (...args: unknown[]) => fetchAdminQueueHealth(...args),
   fetchAdminProcessingJobs: (...args: unknown[]) => fetchAdminProcessingJobs(...args),
+  fetchAdminProcessingJobDetail: vi.fn(),
   fetchAdminRegions: (...args: unknown[]) => fetchAdminRegions(...args),
   fetchAdminEstablishments: (...args: unknown[]) => fetchAdminEstablishments(...args),
   fetchAdminShoppingLists: vi.fn(),

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -1,11 +1,14 @@
 ﻿import { useEffect, useState, type FormEvent } from 'react';
 
+import { useParams } from 'react-router-dom';
+
 import { ChevronDownIcon, ChevronUpIcon, ImageUpIcon, InfoIcon } from 'lucide-react';
 
 import {
   type AdminEstablishmentResponse,
   type AdminMetricsResponse,
   type AdminOfferResponse,
+  type AdminProcessingJobDetailResponse,
   type AdminProcessingJobResponse,
   type AdminProductResponse,
   type AdminProductVariantResponse,
@@ -20,6 +23,7 @@ import {
   fetchAdminEstablishments,
   fetchAdminMetrics,
   fetchAdminOffers,
+  fetchAdminProcessingJobDetail,
   fetchAdminProcessingJobs,
   fetchAdminProducts,
   fetchAdminProductVariants,
@@ -1266,10 +1270,148 @@ export function AdminQueuePage() {
               {job.failureReason ? (
                 <div className="mt-2 text-sm text-muted-foreground">{job.failureReason}</div>
               ) : null}
+              <div className="mt-3 grid gap-1 text-sm text-muted-foreground">
+                {job.owner ? <span>user_id: {job.owner.id}</span> : null}
+                {job.shoppingList ? <span>lista: {job.shoppingList.name}</span> : null}
+                {job.optimizationRun ? (
+                  <span>
+                    run {job.optimizationRun.id} · modo {job.optimizationRun.mode} · solicitado {formatFreshnessLabel(job.createdAt)}
+                  </span>
+                ) : null}
+                {job.finishedAt ? <span>completed: {formatFreshnessLabel(job.finishedAt)}</span> : null}
+              </div>
+              <div className="mt-3">
+                <Button asChild size="sm" variant="outline">
+                  <a href={`/dashboard/fila/${job.id}`} rel="noreferrer" target="_blank">
+                    Go to link
+                  </a>
+                </Button>
+              </div>
             </div>
           ))}
         </CardContent>
       </Card>
+    </div>
+  );
+}
+
+export function AdminQueueDetailPage() {
+  const { jobId = '' } = useParams();
+  const loader = (token: string) => fetchAdminProcessingJobDetail(token, jobId);
+  const { data: job, error } = useAdminData<AdminProcessingJobDetailResponse | null>(
+    loader,
+    null,
+  );
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Falha ao carregar job</AlertTitle>
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!job) {
+    return <Card><CardHeader><CardTitle>Carregando job</CardTitle></CardHeader></Card>;
+  }
+
+  return (
+    <div className="grid gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Detalhe do job</CardTitle>
+          <CardDescription>
+            {job.queueName} · {job.jobType} · tentativa {job.attemptCount}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-2">
+          <div className="rounded-lg border border-border/70 p-4">
+            <div className="text-sm text-muted-foreground">job_id</div>
+            <div className="mt-1 font-medium">{job.id}</div>
+          </div>
+          <div className="rounded-lg border border-border/70 p-4">
+            <div className="text-sm text-muted-foreground">status</div>
+            <div className="mt-1 font-medium">{job.status}</div>
+          </div>
+          <div className="rounded-lg border border-border/70 p-4">
+            <div className="text-sm text-muted-foreground">resource</div>
+            <div className="mt-1 font-medium">{job.resourceType} · {job.resourceId}</div>
+          </div>
+          <div className="rounded-lg border border-border/70 p-4">
+            <div className="text-sm text-muted-foreground">owner</div>
+            <div className="mt-1 font-medium">{job.owner ? `${job.owner.displayName} · ${job.owner.id}` : 'Sem owner vinculado'}</div>
+          </div>
+          <div className="rounded-lg border border-border/70 p-4">
+            <div className="text-sm text-muted-foreground">solicitado</div>
+            <div className="mt-1 font-medium">{formatFreshnessLabel(job.createdAt)}</div>
+          </div>
+          <div className="rounded-lg border border-border/70 p-4">
+            <div className="text-sm text-muted-foreground">completed</div>
+            <div className="mt-1 font-medium">{job.finishedAt ? formatFreshnessLabel(job.finishedAt) : 'Ainda sem conclusão'}</div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {job.optimizationRun ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Otimização</CardTitle>
+            <CardDescription>
+              run {job.optimizationRun.id} · modo {job.optimizationRun.mode} · {job.optimizationRun.coverageStatus}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            <div className="grid gap-3 md:grid-cols-3">
+              <div className="rounded-lg border border-border/70 p-4">
+                <div className="text-sm text-muted-foreground">Custo total</div>
+                <div className="mt-1 text-xl font-semibold">{formatCurrency(job.optimizationRun.totalEstimatedCost)}</div>
+              </div>
+              <div className="rounded-lg border border-border/70 p-4">
+                <div className="text-sm text-muted-foreground">Economia</div>
+                <div className="mt-1 text-xl font-semibold">{formatCurrency(job.optimizationRun.estimatedSavings)}</div>
+              </div>
+              <div className="rounded-lg border border-border/70 p-4">
+                <div className="text-sm text-muted-foreground">Lista</div>
+                <div className="mt-1 text-xl font-semibold">{job.shoppingList?.name ?? job.resourceId}</div>
+              </div>
+            </div>
+            {job.optimizationRun.summary ? (
+              <Alert>
+                <InfoIcon />
+                <AlertTitle>Resumo do thinking</AlertTitle>
+                <AlertDescription>{job.optimizationRun.summary}</AlertDescription>
+              </Alert>
+            ) : null}
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Item</TableHead>
+                  <TableHead>Decisão</TableHead>
+                  <TableHead>Loja</TableHead>
+                  <TableHead>Preço</TableHead>
+                  <TableHead>Fonte</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {job.optimizationRun.selections.map((selection) => (
+                  <TableRow key={selection.id}>
+                    <TableCell>{selection.shoppingListItemName}</TableCell>
+                    <TableCell>{selection.status}</TableCell>
+                    <TableCell>
+                      {selection.offer
+                        ? `${selection.offer.establishmentName} · ${selection.offer.neighborhood}`
+                        : 'Sem oferta selecionada'}
+                    </TableCell>
+                    <TableCell>{formatCurrency(selection.offer?.priceAmount ?? selection.estimatedCost)}</TableCell>
+                    <TableCell>{selection.offer?.sourceLabel ?? selection.confidenceNotice ?? 'Sem fonte'}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      ) : null}
     </div>
   );
 }

--- a/web/src/routes/dashboard.tsx
+++ b/web/src/routes/dashboard.tsx
@@ -5,6 +5,7 @@ import {
   AdminListsPage,
   AdminOffersPage,
   AdminOverviewPage,
+  AdminQueueDetailPage,
   AdminQueuePage,
   AdminRegionsPage,
 } from '@/dashboard/dashboard-pages';
@@ -40,6 +41,10 @@ export const dashboardRoute = {
     {
       path: 'fila',
       element: <AdminQueuePage />,
+    },
+    {
+      path: 'fila/:jobId',
+      element: <AdminQueueDetailPage />,
     },
     {
       path: 'precos',


### PR DESCRIPTION
## Summary

- Enriches admin processing job rows with owner, shopping list, optimization run, mode, request time, completion time, and attempt context.
- Adds `GET /admin/processing-jobs/:id` for detailed optimization job audit data.
- Adds dashboard route `/dashboard/fila/:jobId` with job/run summary and per-selection decision trace.
- Adds a `Go to link` action from queue rows so operations can open a dedicated detail page in another tab.
- Clarifies repeated rows by exposing run id separately from job id and attempt count.

## Validation

- `backend`: `npm run build`
- `backend`: `npm test -- --runTestsByPath test/unit/admin/admin-dashboard.service.spec.ts`
- `web`: `npm run build`
- `web`: `npm test -- src/dashboard/dashboard-pages.spec.tsx`

Issue: #183