### PR TITLE
Fix CI regressions and plan monetization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - homolog
@@ -10,6 +11,13 @@ on:
       - homolog
       - phase/**
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend:
     runs-on: ubuntu-latest
@@ -18,15 +26,20 @@ jobs:
         working-directory: backend
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: backend/package-lock.json
-      - run: npm ci
-      - run: npm run build
-      - run: npm run lint
-      - run: npm run test
+      - name: Install backend dependencies
+        run: npm ci
+      - name: Build backend
+        run: npm run build
+      - name: Lint backend
+        run: npm run lint
+      - name: Test backend
+        run: npm run test
 
   web:
     runs-on: ubuntu-latest
@@ -35,12 +48,17 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: web/package-lock.json
-      - run: npm ci
-      - run: npm run build
-      - run: npm run lint
-      - run: npm run test
+      - name: Install web dependencies
+        run: npm ci
+      - name: Build web
+        run: npm run build
+      - name: Lint web
+        run: npm run lint
+      - name: Test web
+        run: npm run test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,13 @@ on:
     branches:
       - homolog
 
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   terraform-plan:
     runs-on: ubuntu-latest

--- a/backend/test/integration/admin/admin-dashboard.integration.spec.ts
+++ b/backend/test/integration/admin/admin-dashboard.integration.spec.ts
@@ -104,6 +104,11 @@ class AdminPrismaMock {
     count: async () => 7,
     aggregate: async () => ({ _sum: { estimatedSavings: 88.4 } }),
   };
+  readonly $queryRaw = jest.fn().mockResolvedValue([
+    {
+      totalEstimatedSavings: 88.4,
+    },
+  ]);
   readonly receiptRecord = { count: async () => 0 };
   readonly processingJob = { count: async () => 3 };
   readonly region = {

--- a/backend/test/integration/admin/admin-processing.integration.spec.ts
+++ b/backend/test/integration/admin/admin-processing.integration.spec.ts
@@ -68,6 +68,11 @@ class AdminProcessingPrismaMock {
       },
     }),
   };
+  readonly $queryRaw = jest.fn().mockResolvedValue([
+    {
+      totalEstimatedSavings: 0,
+    },
+  ]);
   readonly receiptRecord = { count: async () => 0 };
   readonly region = {
     count: async () => 1,

--- a/backend/test/integration/auth/shared-auth.integration.spec.ts
+++ b/backend/test/integration/auth/shared-auth.integration.spec.ts
@@ -117,6 +117,12 @@ class PrismaUserAccountMock {
       return null;
     },
   };
+
+  readonly $queryRaw = jest.fn().mockResolvedValue([
+    {
+      totalEstimatedSavings: 0,
+    },
+  ]);
 }
 
 describe('Shared auth integration', () => {
@@ -137,6 +143,7 @@ describe('Shared auth integration', () => {
         optimizationRun: userAccountMock.optimizationRun,
         receiptRecord: userAccountMock.receiptRecord,
         region: userAccountMock.region,
+        $queryRaw: userAccountMock.$queryRaw,
       })
       .compile();
 

--- a/backend/test/support/us1-app.factory.ts
+++ b/backend/test/support/us1-app.factory.ts
@@ -860,6 +860,31 @@ class PrismaUserAccountMock {
     },
   };
 
+  async $queryRaw() {
+    const latestCompletedByList = new Map<string, any>();
+
+    for (const run of this.optimizationRuns.values()) {
+      if (run.status !== 'completed' || run.estimatedSavings === null) {
+        continue;
+      }
+
+      const existing = latestCompletedByList.get(run.shoppingListId);
+      if (
+        !existing ||
+        new Date(run.createdAt).getTime() > new Date(existing.createdAt).getTime()
+      ) {
+        latestCompletedByList.set(run.shoppingListId, run);
+      }
+    }
+
+    const totalEstimatedSavings = [...latestCompletedByList.values()].reduce(
+      (total, run) => total + Number(run.estimatedSavings ?? 0),
+      0,
+    );
+
+    return [{ totalEstimatedSavings }];
+  }
+
   readonly optimizationSelection = {
     deleteMany: async ({ where }: { where: { optimizationRunId: string } }) => {
       const retained = this.optimizationSelections.filter(

--- a/docs/product/phase-18-monetization-plan.md
+++ b/docs/product/phase-18-monetization-plan.md
@@ -1,0 +1,134 @@
+# Phase 18: Monetization Plan
+
+## Recommendation
+
+Use a hybrid freemium model:
+
+- Free users receive a small monthly optimization-token allowance.
+- Premium users pay a recurring subscription for unlimited list optimizations under
+  fair-use limits.
+- Extra one-off token packs can be added later for users who do not want a recurring
+  plan.
+
+This is stronger than a pure token model for Pricely because the core value is repeated
+weekly or monthly grocery savings. Users need to experience real savings before paying,
+but heavy users and households need predictability instead of thinking about every
+optimization as a micro-purchase.
+
+## Why This Model Fits Pricely
+
+- Optimization has a real marginal cost: pricing data lookups, queue work, matching,
+  and future AI/OR computations.
+- The app can show a clear value equation: "you saved R$ X this month" versus a premium
+  price.
+- Free tokens create a product-led trial without hiding the product behind a hard
+  paywall.
+- Premium unlimited keeps the main shopper workflow simple.
+- Token packs give a fallback for low-frequency users who reject subscriptions.
+
+## Market Signals Used
+
+- Stripe supports credit-based and usage-based billing patterns for prepaid or
+  promotional credits, which maps cleanly to optimization tokens:
+  https://docs.stripe.com/billing/subscriptions/usage-based/billing-credits
+- Stripe also documents credit-based pricing as a usage-based billing use case:
+  https://docs.stripe.com/billing/subscriptions/usage-based/use-cases/credits-based-pricing-model
+- RevenueCat's 2025 subscription report highlights hybrid monetization, combining
+  subscriptions with consumable purchases, as an important subscription-app strategy:
+  https://www.revenuecat.com/state-of-subscription-apps-2025/
+- Grocery and comparison-shopping businesses commonly combine multiple revenue streams
+  such as subscriptions, advertising, affiliate/referral revenue, sponsored placement,
+  and retailer partnerships:
+  https://sacra.com/research/instacart/
+  https://wecantrack.com/insights/how-do-comparison-sites-make-money/
+
+## Initial Plan Tiers
+
+### Free
+
+- Monthly token refill, capped so users cannot hoard unlimited free runs.
+- Enough tokens to optimize one or two realistic shopping lists per month.
+- Can earn bonus tokens by sharing valid receipts or reporting offer corrections after
+  abuse controls exist.
+- Shows exact savings delivered by previous optimizations and explains what premium
+  unlocks only when the user hits a natural limit.
+
+### Premium
+
+- Recurring monthly and yearly plans.
+- Unlimited optimization runs with fair-use controls.
+- Priority optimization queue later if queue load becomes material.
+- Price alerts, promo alerts, saved comparison history, household sharing, and richer
+  checklist/offline features can become premium benefits.
+
+### Token Packs
+
+- Optional second phase.
+- Good for users who only do a large monthly shop and do not want a subscription.
+- Must be backed by a ledger, not a mutable counter, so refunds, grants, chargebacks,
+  and failed optimizations stay auditable.
+
+## Technical Architecture
+
+### Data Model
+
+- Add `UserEntitlement` or `SubscriptionEntitlement` for plan state:
+  `free`, `premium`, `trialing`, `past_due`, `cancelled`.
+- Add `OptimizationTokenLedger` as append-only rows:
+  `grant`, `consume`, `refund`, `expire`, `admin_adjustment`.
+- Add `OptimizationTokenGrant` or scheduled refill metadata:
+  `periodStart`, `periodEnd`, `expiresAt`, `source`.
+- Add idempotency keys tied to optimization run IDs so retries do not double-charge a
+  token.
+- Keep a derived balance only as a cached projection. The ledger remains the source of
+  truth.
+
+### Optimization Flow
+
+1. User requests optimization.
+2. Backend checks premium entitlement.
+3. If not premium, backend atomically reserves or consumes one token in the same logical
+   command that creates the optimization run.
+4. If the run fails before producing a user-visible result, backend refunds the token
+   through a ledger entry.
+5. Re-running the same list creates a new optimization run and consumes a new token
+   unless the request is an idempotent retry of the same run.
+
+### Billing
+
+- Start with internal entitlements and ledger so product behavior is testable before
+  payment integration.
+- Add Stripe subscriptions for premium.
+- Add Stripe credit/usage-based billing only after the internal ledger rules are stable.
+- For mobile store distribution, account for App Store and Play Store subscription
+  requirements before routing mobile users to web billing.
+
+## Product Rules
+
+- Never show fake savings by summing repeated optimizations of the same list. Continue
+  using latest completed optimization per list for accumulated savings.
+- Show "premium pays for itself" only when real savings in the user's city/list support
+  it.
+- Keep sponsored offers visually distinct from organic cheapest offers.
+- Do not let retailer monetization override optimization ranking unless the UI labels it
+  clearly.
+
+## Metrics
+
+- Free token activation rate.
+- Optimization-to-list-created rate.
+- Token limit hit rate.
+- Premium conversion after first real saving.
+- Premium churn by delivered savings.
+- Average compute cost per optimization.
+- Refund rate for failed optimizations.
+- Receipt contribution rate and fraud rate.
+
+## Open Decisions
+
+- Free monthly token count.
+- Premium fair-use threshold.
+- Whether bonus receipt tokens launch before or after abuse scoring.
+- Whether annual premium includes extra benefits beyond discount.
+- Whether B2B retailer analytics waits until the consumer optimization product is
+  trusted and privacy-reviewed.

--- a/specs/001-grocery-optimizer/plan.md
+++ b/specs/001-grocery-optimizer/plan.md
@@ -241,6 +241,27 @@ while sharing auth and domain contracts.
 - Plan Terraform modules for future production infrastructure without blocking local MVP
   delivery.
 
+### Phase 17: CI Workflow Reliability and Security
+
+- Treat GitHub Actions failures as production-blocking regressions for `homolog`.
+- Inspect real Actions logs before changing workflow YAML.
+- Keep workflow permissions minimal and avoid agentic/AI actions on untrusted events.
+- Preserve backend and web quality gates as build, lint, and test.
+- Add mobile CI only after Flutter setup is explicit and stable in the runner.
+
+### Phase 18: Monetization and Entitlements
+
+- Use a hybrid freemium model: free optimization tokens, premium unlimited
+  optimizations with fair-use controls, and optional future token packs.
+- Model optimization tokens as an append-only ledger with idempotent consume/refund
+  semantics instead of a mutable counter.
+- Keep savings claims tied to real latest-completed-per-list savings so repeated
+  optimizations do not inflate value.
+- Plan Stripe subscription and credit-based billing integration after internal
+  entitlement rules are testable.
+- Keep sponsored retailer monetization separate from organic cheapest-result ranking
+  unless clearly labeled.
+
 ## Complexity Tracking
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -273,6 +273,22 @@ web, and mobile.
 - [ ] T105 Plan Railway deployment topology and environment requirements in `docs/`
 - [ ] T106 Plan Terraform modules for future production infrastructure in `infra/terraform/` and `docs/`
 
+## Phase 17: CI Workflow Reliability and Security
+
+- [X] T108 Inspect failing GitHub Actions runs on `homolog` and classify whether the failures come from workflow YAML or code regressions in `.github/workflows/`, `backend/test/`, and `web/src/`
+- [X] T109 Patch backend and web regressions that broke CI after phase merges in `backend/test/` and `web/src/app/`
+- [X] T110 Harden CI workflow defaults with manual dispatch, explicit step names, concurrency, and read-only permissions in `.github/workflows/ci.yml` and `.github/workflows/deploy.yml`
+- [ ] T111 Add a dedicated mobile CI job with Flutter setup, analyzer, tests, and optional APK build once runner setup is stable in `.github/workflows/ci.yml`
+
+## Phase 18: Monetization and Entitlements
+
+- [X] T112 Research and document the recommended hybrid monetization model for optimization tokens, premium unlimited access, and future token packs in `docs/product/phase-18-monetization-plan.md`
+- [ ] T113 Add backend entitlement and token-ledger schema with idempotent consume/refund semantics in `backend/prisma/schema.prisma` and `backend/src/users/`
+- [ ] T114 Gate optimization-run creation by premium entitlement or available optimization tokens in `backend/src/optimization/` and `backend/src/jobs/`
+- [ ] T115 Add monthly free-token refill scheduling and abuse-safe bonus-token planning for receipt contributions in `backend/src/jobs/`
+- [ ] T116 Add premium/token UI states for web and mobile without blocking first-run value discovery in `web/src/public/`, `web/src/app/`, and `mobile/lib/`
+- [ ] T117 Plan Stripe subscription and credit-based billing integration after internal ledger tests pass in `docs/` and future billing modules
+
 ---
 
 ## Phase 9: UX Flow Polish and Stitch Fidelity Hardening

--- a/web/src/app/pricely-context.tsx
+++ b/web/src/app/pricely-context.tsx
@@ -139,7 +139,9 @@ export function PricelyProvider({ children }: PropsWithChildren) {
           })),
         );
       } catch {
-        setCities(supportedCities);
+        if (!disposed) {
+          setCities(supportedCities);
+        }
       }
     };
 


### PR DESCRIPTION
## Summary

- Fixes the homolog CI failures by updating Prisma test doubles for the new latest-savings raw query path.
- Prevents the web region bootstrap promise from setting state after provider unmount during Vitest teardown.
- Hardens GitHub Actions with manual dispatch, explicit step names, read-only permissions, and concurrency.
- Adds Phase 17/18 specs and a monetization plan for optimization tokens, premium entitlements, and future Stripe billing.

## Validation

- backend: npm run build
- backend: npm run lint
- backend: npm run test
- web: npm run build
- web: npm run lint
- web: npm run test
- git diff --check
- workflow static audit: no AI agent actions, pull_request_target, issue_comment, contents: write, or secrets blocks found

Refs #189
Refs #190