### PR TITLE
Fix local pgAdmin default email

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      PGADMIN_DEFAULT_EMAIL: admin@pricely.local
+      PGADMIN_DEFAULT_EMAIL: admin@pricely.example.com
       PGADMIN_DEFAULT_PASSWORD: admin
       PGADMIN_CONFIG_SERVER_MODE: "False"
       PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"


### PR DESCRIPTION
## Summary
- Replace the local pgAdmin default email with a valid development-only domain.

## Validation
- docker compose config --quiet

Fixes #209