### PR TITLE
Match branded textual list items to catalog offers

### DIFF
--- a/backend/src/optimization/domain/multi-market-optimizer.service.ts
+++ b/backend/src/optimization/domain/multi-market-optimizer.service.ts
@@ -513,7 +513,9 @@ export class MultiMarketOptimizerService {
         offer.catalogProductId === item.catalogProductId) ||
       (!item.catalogProductId &&
         item.normalizedName &&
-        offer.canonicalName === item.normalizedName),
+        (offer.matchingCanonicalNames ?? [offer.canonicalName]).includes(
+          item.normalizedName,
+        )),
     );
   }
 

--- a/backend/src/stores/domain/store-offer.entity.ts
+++ b/backend/src/stores/domain/store-offer.entity.ts
@@ -12,6 +12,7 @@ export interface StoreOfferEntity {
   storeId: string;
   storeName: string;
   canonicalName: string;
+  matchingCanonicalNames?: string[];
   displayName: string;
   price: number;
   basePrice?: number;

--- a/backend/src/stores/infrastructure/store-offer.repository.ts
+++ b/backend/src/stores/infrastructure/store-offer.repository.ts
@@ -113,6 +113,12 @@ export class StoreOfferRepository {
         const normalizedProductName = this.productNormalizerService.normalize(
           offer.catalogProduct.name,
         ).canonicalName;
+        const matchingCanonicalNames = this.buildMatchingCanonicalNames({
+          catalogProductName: offer.catalogProduct.name,
+          variantName: offer.productVariant.displayName,
+          brandName: offer.productVariant.brandName,
+          displayName: offer.displayName,
+        });
 
         return {
           id: offer.id,
@@ -123,6 +129,7 @@ export class StoreOfferRepository {
           storeId: offer.establishmentId,
           storeName: offer.establishment.unitName,
           canonicalName: normalizedProductName,
+          matchingCanonicalNames,
           displayName: offer.displayName,
           price: Number(offer.priceAmount),
           basePrice:
@@ -150,7 +157,11 @@ export class StoreOfferRepository {
           observedAt: offer.observedAt.toISOString(),
         } satisfies StoreOfferEntity;
       })
-      .filter((offer) => canonicalNames.includes(offer.canonicalName));
+      .filter((offer) =>
+        (offer.matchingCanonicalNames ?? [offer.canonicalName]).some((name) =>
+          canonicalNames.includes(name),
+        ),
+      );
   }
 
   async findByListItems(
@@ -200,6 +211,12 @@ export class StoreOfferRepository {
         const normalizedProductName = this.productNormalizerService.normalize(
           offer.catalogProduct.name,
         ).canonicalName;
+        const matchingCanonicalNames = this.buildMatchingCanonicalNames({
+          catalogProductName: offer.catalogProduct.name,
+          variantName: offer.productVariant.displayName,
+          brandName: offer.productVariant.brandName,
+          displayName: offer.displayName,
+        });
 
         return {
           id: offer.id,
@@ -210,6 +227,7 @@ export class StoreOfferRepository {
           storeId: offer.establishmentId,
           storeName: offer.establishment.unitName,
           canonicalName: normalizedProductName,
+          matchingCanonicalNames,
           displayName: offer.displayName,
           price: Number(offer.priceAmount),
           basePrice:
@@ -240,8 +258,38 @@ export class StoreOfferRepository {
       .filter(
         (offer) =>
           (offer.catalogProductId && catalogProductIds.has(offer.catalogProductId)) ||
-          canonicalNames.has(offer.canonicalName),
+          (offer.matchingCanonicalNames ?? [offer.canonicalName]).some((name) =>
+            canonicalNames.has(name),
+          ),
       );
+  }
+
+  private buildMatchingCanonicalNames(input: {
+    catalogProductName: string;
+    variantName?: string | null;
+    brandName?: string | null;
+    displayName: string;
+  }): string[] {
+    const candidates = [
+      input.catalogProductName,
+      input.variantName,
+      input.displayName,
+      input.brandName && input.variantName
+        ? `${input.brandName} ${input.variantName}`
+        : undefined,
+      input.brandName && input.displayName
+        ? `${input.brandName} ${input.displayName}`
+        : undefined,
+    ];
+
+    return [
+      ...new Set(
+        candidates
+          .filter((candidate): candidate is string => Boolean(candidate))
+          .map((candidate) => this.productNormalizerService.normalize(candidate).canonicalName)
+          .filter(Boolean),
+      ),
+    ];
   }
 
   private async resolveEstablishment(offer: StoreOfferEntity) {

--- a/backend/test/unit/stores/store-offer.repository.spec.ts
+++ b/backend/test/unit/stores/store-offer.repository.spec.ts
@@ -1,0 +1,87 @@
+import { ProductNormalizerService } from '../../../src/catalog/application/product-normalizer.service';
+import { StoreOfferRepository } from '../../../src/stores/infrastructure/store-offer.repository';
+
+describe('StoreOfferRepository', () => {
+  it('matches textual list items against branded offer variants when catalog ids are missing', async () => {
+    const prisma = {
+      productOffer: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'offer-arroz',
+            catalogProductId: 'product-arroz',
+            productVariantId: 'variant-arroz-camil',
+            catalogProduct: {
+              name: 'Arroz tipo 1 5kg',
+            },
+            productVariant: {
+              displayName: 'Arroz Camil tipo 1 5kg',
+              brandName: 'Camil',
+            },
+            establishmentId: 'store-1',
+            establishment: {
+              unitName: 'Unidade Pinheiros',
+            },
+            displayName: 'Arroz Camil tipo 1 5kg',
+            packageLabel: '5 kg',
+            priceAmount: '21.90',
+            basePriceAmount: '21.90',
+            promotionalPriceAmount: null,
+            availabilityStatus: 'available',
+            confidenceLevel: 'high',
+            sourceReference: 'Seed comparativo',
+            sourceType: 'admin',
+            observedAt: new Date('2026-05-07T00:00:00.000Z'),
+          },
+          {
+            id: 'offer-cafe',
+            catalogProductId: 'product-cafe',
+            productVariantId: 'variant-cafe-pilao',
+            catalogProduct: {
+              name: 'Cafe torrado',
+            },
+            productVariant: {
+              displayName: 'Cafe Pilao 500g',
+              brandName: 'Pilao',
+            },
+            establishmentId: 'store-1',
+            establishment: {
+              unitName: 'Unidade Pinheiros',
+            },
+            displayName: 'Cafe Pilao 500g',
+            packageLabel: '500 g',
+            priceAmount: '15.90',
+            basePriceAmount: '18.90',
+            promotionalPriceAmount: '15.90',
+            availabilityStatus: 'available',
+            confidenceLevel: 'high',
+            sourceReference: 'Seed local',
+            sourceType: 'admin',
+            observedAt: new Date('2026-05-07T00:00:00.000Z'),
+          },
+        ]),
+      },
+    };
+    const normalizer = new ProductNormalizerService();
+    const repository = new StoreOfferRepository(prisma as never, normalizer);
+
+    const offers = await repository.findByListItems([
+      {
+        normalizedName: normalizer.normalize('Camil · Arroz Camil tipo 1 5kg')
+          .canonicalName,
+      },
+      {
+        normalizedName: normalizer.normalize('Pilao · Cafe Pilao 500g')
+          .canonicalName,
+      },
+    ]);
+
+    expect(offers.map((offer) => offer.id)).toEqual([
+      'offer-arroz',
+      'offer-cafe',
+    ]);
+    expect(offers[0].matchingCanonicalNames).toContain(
+      'camil arroz camil tipo 1',
+    );
+    expect(offers[1].matchingCanonicalNames).toContain('pilao cafe pilao');
+  });
+});


### PR DESCRIPTION
## Summary
- Add offer matching aliases from catalog product, variant, display, and brand-qualified names.
- Keep catalogProductId matching as the primary path while improving text fallback.
- Add unit coverage for branded list text without catalog IDs.

## Validation
- npm test -- --runTestsByPath test/unit/stores/store-offer.repository.spec.ts
- npm test -- --runTestsByPath test/unit/optimization/multi-market-optimizer.service.spec.ts
- npm run lint
- npm run build

Fixes #211