### PR TITLE
Align plan with Stitch UI/UX phase

### DIFF
--- a/specs/001-grocery-optimizer/plan.md
+++ b/specs/001-grocery-optimizer/plan.md
@@ -326,6 +326,22 @@ while sharing auth and domain contracts.
 - Include distance, coverage radius, and candidate-establishment counts in optimization
   explanations so local results remain auditable.
 
+### Phase 24: UI/UX Alignment with Stitch
+
+- Audit the implemented web and mobile MVP against the current Stitch projects before
+  starting broad visual refactors.
+- Keep the existing Stitch projects as the visual/product reference unless the audit
+  finds a material mismatch with the evolved product direction.
+- Map Stitch design-system rules into implementation guidance for web and mobile,
+  including teal/lime palette usage, Manrope/Inter typography, tonal surfaces, 8px
+  radius, no-heavy-divider rule, and tabular price typography.
+- Refactor public web surfaces, admin web surfaces, and mobile surfaces toward the
+  audited Stitch direction while preserving working backend contracts and MVP flows.
+- Include the new location widgets, receipt states, disabled premium/billing states, and
+  persisted optimization explanations in the UI/UX alignment scope.
+- Add screenshot, Playwright, widget, or golden-style validation notes for the key
+  Stitch-aligned surfaces before considering the MVP visually polished.
+
 ## Complexity Tracking
 
 | Violation | Why Needed | Simpler Alternative Rejected Because |


### PR DESCRIPTION
## Summary
- Add Phase 24 to specs/001-grocery-optimizer/plan.md.
- Align the plan with the existing Stitch UI/UX alignment tasks in tasks.md.
- Capture Stitch audit, design tokens, public/admin web, mobile, location widgets, receipt states, premium disabled states, and validation scope.

## Validation
- Searched Phase 24 and Stitch terms across plan.md and tasks.md.
- git diff --check

Fixes #216