### PR TITLE
Fix optimization result persistence and PT-BR copy

### DIFF
--- a/web/src/app/pricely-context.tsx
+++ b/web/src/app/pricely-context.tsx
@@ -11,6 +11,7 @@ import {
   createShoppingList,
   fetchPublicRegions,
   fetchMe,
+  fetchLatestOptimization,
   fetchShoppingLists,
   mapProfile,
   mapShoppingList,
@@ -76,6 +77,9 @@ interface PricelyContextValue {
     listId: string,
     mode: OptimizationModeId,
   ) => Promise<OptimizationResultApiResponse>;
+  loadLatestOptimization: (
+    listId: string,
+  ) => Promise<OptimizationResultApiResponse | null>;
 }
 
 const STORAGE_KEY = 'pricely-web-state-v2';
@@ -409,6 +413,34 @@ export function PricelyProvider({ children }: PropsWithChildren) {
         );
         setPreferredMode(mode);
         return result;
+      },
+      loadLatestOptimization: async (listId) => {
+        if (!token) {
+          return null;
+        }
+
+        try {
+          const result = await fetchLatestOptimization(token, listId);
+          setOptimizationResults((current) => ({
+            ...current,
+            [listId]: result,
+          }));
+          setLists((current) =>
+            current.map((list) =>
+              list.id === listId
+                ? {
+                    ...list,
+                    lastMode: result.mode,
+                    expectedSavings:
+                      result.estimatedSavings ?? list.expectedSavings,
+                  }
+                : list,
+            ),
+          );
+          return result;
+        } catch {
+          return null;
+        }
       },
     }),
     [

--- a/web/src/public/optimization-page.spec.tsx
+++ b/web/src/public/optimization-page.spec.tsx
@@ -8,6 +8,8 @@ import { OptimizationPage } from './public-pages';
 
 const runOptimization = vi.fn();
 const setPreferredMode = vi.fn();
+const loadLatestOptimization = vi.fn();
+let optimizationResults: Record<string, unknown> = {};
 
 vi.mock('@/app/pricely-context', () => ({
   usePricely: () => ({
@@ -16,7 +18,8 @@ vi.mock('@/app/pricely-context', () => ({
     preferredMode: 'global_full',
     runOptimization,
     setPreferredMode,
-    optimizationResults: {},
+    loadLatestOptimization,
+    optimizationResults,
     lists: [
       {
         id: 'list-1',
@@ -33,6 +36,8 @@ describe('OptimizationPage', () => {
   beforeEach(() => {
     runOptimization.mockReset();
     setPreferredMode.mockReset();
+    loadLatestOptimization.mockReset();
+    optimizationResults = {};
   });
 
   afterEach(() => {
@@ -65,5 +70,56 @@ describe('OptimizationPage', () => {
       screen.getByText('Busca o menor custo total item a item na cidade selecionada.'),
     ).toBeTruthy();
     expect(screen.queryByText(/backend/i)).toBeNull();
+    expect(loadLatestOptimization).toHaveBeenCalledWith('list-1');
+  });
+
+  it('loads the latest persisted result and renders shopper-facing PT-BR evidence copy', async () => {
+    optimizationResults = {
+      'list-1': {
+        id: 'run-1',
+        shoppingListId: 'list-1',
+        mode: 'global_full',
+        status: 'completed',
+        totalEstimatedCost: 21.9,
+        estimatedSavings: 1,
+        coverageStatus: 'complete',
+        createdAt: '2026-05-08T10:00:00.000Z',
+        completedAt: '2026-05-08T10:00:10.000Z',
+        selections: [
+          {
+            id: 'selection-1',
+            shoppingListItemId: 'item-1',
+            shoppingListItemName: 'Cafe Pilao 500g',
+            establishmentName: 'Mercado Centro',
+            establishmentNeighborhood: 'Centro',
+            priceAmount: 21.9,
+            comparisonPriceAmount: 22.9,
+            regionalAveragePriceAmount: 22.9,
+            savingsVsComparison: 1,
+            sourceLabel: 'nota fiscal do usuario',
+            observedAt: '2026-05-08T09:00:00.000Z',
+            selectionStatus: 'selected',
+            decisionReason: 'selected_confirmed_offer',
+          },
+        ],
+      },
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/otimizacao/list-1']}>
+        <Routes>
+          <Route path="/otimizacao/:listId" element={<OptimizationPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Completa')).toBeTruthy();
+    expect(screen.getByText('Oferta selecionada')).toBeTruthy();
+    expect(screen.getByText('Oferta confirmada selecionada')).toBeTruthy();
+    expect(
+      screen.getByText('R$ 1,00 abaixo da média regional (R$ 22,90)'),
+    ).toBeTruthy();
+    expect(screen.queryByText(/selected_confirmed_offer/i)).toBeNull();
+    expect(screen.queryByText(/selected/i)).toBeNull();
   });
 });

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -220,6 +220,107 @@ function listStatusTone(status: ShoppingListItem['status']) {
   return 'text-rose-700';
 }
 
+function coverageStatusLabel(status: 'complete' | 'partial' | 'none') {
+  if (status === 'complete') {
+    return 'Completa';
+  }
+  if (status === 'partial') {
+    return 'Parcial';
+  }
+
+  return 'Sem cobertura';
+}
+
+function selectionStatusLabel(status: 'selected' | 'missing' | 'review') {
+  if (status === 'selected') {
+    return 'Oferta selecionada';
+  }
+  if (status === 'review') {
+    return 'Revisar evidência';
+  }
+
+  return 'Sem oferta confirmada';
+}
+
+function rejectedReasonLabel(reason?: string) {
+  if (!reason) {
+    return '';
+  }
+
+  const labels: Record<string, string> = {
+    no_confirmed_offer_available: 'sem oferta confirmada',
+    no_active_available_offer: 'sem oferta ativa disponível',
+    single_store_constraint: 'fora da loja escolhida',
+    missing_normalized_product: 'produto precisa de revisão',
+  };
+
+  return labels[reason] ?? 'sem evidência suficiente';
+}
+
+function confidenceNoticeLabel(notice?: string) {
+  if (!notice) {
+    return undefined;
+  }
+
+  const normalized = notice.toLowerCase();
+  if (normalized.includes('no confirmed offer')) {
+    return 'Ainda não há oferta confirmada para este item.';
+  }
+  if (normalized.includes('selected store does not have')) {
+    return 'A loja selecionada ainda não tem oferta confirmada para este item.';
+  }
+  if (normalized.includes('low-confidence')) {
+    return 'Evidência de preço com confiança baixa.';
+  }
+  if (normalized.includes('could not be normalized')) {
+    return 'O item precisa de revisão antes de confiar no resultado.';
+  }
+
+  return notice;
+}
+
+function decisionReasonLabel(reason?: string) {
+  if (!reason) {
+    return undefined;
+  }
+
+  const labels: Record<string, string> = {
+    selected_confirmed_offer: 'Oferta confirmada selecionada',
+    selected_with_data_quality_warning:
+      'Oferta selecionada com alerta de qualidade',
+    no_confirmed_offer: 'Sem oferta confirmada',
+    not_selected: 'Não selecionado',
+  };
+
+  return labels[reason] ?? undefined;
+}
+
+function savingsComparisonLabel(selection: {
+  savingsVsComparison?: number;
+  comparisonPriceAmount?: number;
+  regionalAveragePriceAmount?: number;
+}) {
+  const savings = selection.savingsVsComparison ?? 0;
+
+  if (savings <= 0) {
+    return null;
+  }
+
+  if (selection.regionalAveragePriceAmount !== undefined) {
+    return `${formatCurrency(savings)} abaixo da média regional (${formatCurrency(
+      selection.regionalAveragePriceAmount,
+    )})`;
+  }
+
+  if (selection.comparisonPriceAmount !== undefined) {
+    return `${formatCurrency(savings)} abaixo do maior preço encontrado (${formatCurrency(
+      selection.comparisonPriceAmount,
+    )})`;
+  }
+
+  return `${formatCurrency(savings)} de economia estimada nas ofertas disponíveis`;
+}
+
 function RequireAuthentication({
   children,
   title,
@@ -1904,12 +2005,16 @@ export function OptimizationPage() {
   const {
     lists,
     optimizationResults,
+    loadLatestOptimization,
     preferredMode,
     runOptimization,
     setPreferredMode,
   } = usePricely();
   const [error, setError] = useState<string | null>(null);
   const [isRunning, setIsRunning] = useState(false);
+  const [latestLoadAttemptedFor, setLatestLoadAttemptedFor] = useState<
+    string | null
+  >(null);
   const list = lists.find((entry) => entry.id === listId);
   const result = optimizationResults[listId];
   const activeMode = result?.mode ?? list?.lastMode ?? preferredMode;
@@ -1921,6 +2026,15 @@ export function OptimizationPage() {
   const isStaleProcessing =
     isProcessingResult &&
     Date.now() - new Date(result.createdAt).getTime() > 30_000;
+
+  useEffect(() => {
+    if (!list || result || latestLoadAttemptedFor === listId) {
+      return;
+    }
+
+    setLatestLoadAttemptedFor(listId);
+    void loadLatestOptimization(listId);
+  }, [latestLoadAttemptedFor, list, listId, loadLatestOptimization, result]);
 
   const handleRun = async (mode: OptimizationModeId) => {
     setError(null);
@@ -2081,7 +2195,9 @@ export function OptimizationPage() {
                 <Card>
                   <CardHeader>
                     <CardDescription>Cobertura</CardDescription>
-                    <CardTitle>{result.coverageStatus}</CardTitle>
+                    <CardTitle>
+                      {coverageStatusLabel(result.coverageStatus)}
+                    </CardTitle>
                   </CardHeader>
                 </Card>
               </div>
@@ -2147,12 +2263,18 @@ export function OptimizationPage() {
                                 </span>
                                 {selection.confidenceNotice ? (
                                   <span className="text-xs text-muted-foreground">
-                                    {selection.confidenceNotice}
+                                    {confidenceNoticeLabel(
+                                      selection.confidenceNotice,
+                                    )}
                                   </span>
                                 ) : null}
-                                {selection.decisionReason ? (
+                                {decisionReasonLabel(
+                                  selection.decisionReason,
+                                ) ? (
                                   <span className="text-xs text-muted-foreground">
-                                    {selection.decisionReason}
+                                    {decisionReasonLabel(
+                                      selection.decisionReason,
+                                    )}
                                   </span>
                                 ) : null}
                               </div>
@@ -2183,10 +2305,7 @@ export function OptimizationPage() {
                               {selection.savingsVsComparison &&
                               selection.savingsVsComparison > 0 ? (
                                 <span className="text-xs text-emerald-700">
-                                  economiza{' '}
-                                  {formatCurrency(
-                                    selection.savingsVsComparison,
-                                  )}
+                                  {savingsComparisonLabel(selection)}
                                 </span>
                               ) : null}
                             </div>
@@ -2210,9 +2329,11 @@ export function OptimizationPage() {
                                     : 'missing',
                               )}
                             >
-                              {selection.selectionStatus}
+                              {selectionStatusLabel(selection.selectionStatus)}
                               {selection.rejectedReason
-                                ? ` · ${selection.rejectedReason}`
+                                ? ` · ${rejectedReasonLabel(
+                                    selection.rejectedReason,
+                                  )}`
                                 : ''}
                             </span>
                           </TableCell>


### PR DESCRIPTION
## Summary
- Load the latest persisted optimization run when opening the optimization result page
- Replace internal English selection/coverage codes with PT-BR shopper-facing labels
- Show item savings with the comparison basis, prioritizing regional average when available

## Validation
- npm test -- --run src/public/optimization-page.spec.tsx
- npm run build
- npm run lint
- git diff --check

Fixes #222