### PR TITLE
Allow homolog Vite public host

### DIFF
--- a/.github/workflows/deploy-homolog-server.yml
+++ b/.github/workflows/deploy-homolog-server.yml
@@ -68,6 +68,7 @@ jobs:
       WEB_PORT: ${{ vars.WEB_PORT || '5173' }}
       WEB_APP_URL: ${{ vars.WEB_APP_URL || 'http://localhost:5173' }}
       VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL || 'http://localhost:3000' }}
+      VITE_ALLOWED_HOSTS: ${{ vars.VITE_ALLOWED_HOSTS || 'pricely.grmeireles.dev' }}
       NODE_ENV: ${{ vars.NODE_ENV || 'development' }}
     steps:
       - name: Checkout
@@ -143,6 +144,7 @@ jobs:
             printf 'WEB_PORT=%s\n' "$WEB_PORT"
             printf 'WEB_APP_URL=%s\n' "$WEB_APP_URL"
             printf 'VITE_API_BASE_URL=%s\n' "$VITE_API_BASE_URL"
+            printf 'VITE_ALLOWED_HOSTS=%s\n' "$VITE_ALLOWED_HOSTS"
             printf 'NODE_ENV=%s\n' "$NODE_ENV"
           } > .deploy/.env
 

--- a/docker-compose.homolog.yml
+++ b/docker-compose.homolog.yml
@@ -91,6 +91,7 @@ services:
       - .env.web
     environment:
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:3000}
+      VITE_ALLOWED_HOSTS: ${VITE_ALLOWED_HOSTS:-pricely.grmeireles.dev}
     command: ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]
     ports:
       - "${WEB_PORT:-5173}:5173"

--- a/docs/deployment/homolog-server.md
+++ b/docs/deployment/homolog-server.md
@@ -84,6 +84,7 @@ Optional variables:
 - `WEB_PORT`
 - `WEB_APP_URL`
 - `VITE_API_BASE_URL`
+- `VITE_ALLOWED_HOSTS`
 - `NODE_ENV`
 - `USE_TAILSCALE`
 
@@ -106,6 +107,7 @@ Minimum variables:
 ```text
 DEPLOY_PATH=/srv/stacks/pricely
 VITE_API_BASE_URL=https://<backend-public-url>
+VITE_ALLOWED_HOSTS=pricely.grmeireles.dev
 WEB_APP_URL=https://<web-public-url>
 ```
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,8 +3,16 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'node:path';
 
+const allowedHosts = (process.env.VITE_ALLOWED_HOSTS ?? '')
+  .split(',')
+  .map((host) => host.trim())
+  .filter(Boolean);
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    allowedHosts,
+  },
   test: {
     exclude: ['node_modules/**', 'dist/**', 'e2e/**'],
   },


### PR DESCRIPTION
## Summary
- Configure Vite server.allowedHosts from VITE_ALLOWED_HOSTS
- Inject VITE_ALLOWED_HOSTS into the homolog web service
- Document the deploy variable for Cloudflare-hosted homolog web

## Validation
- npm run build
- npm run lint
- docker compose -f docker-compose.homolog.yml config --quiet
- git diff --check

Fixes #230