### PR TITLE
Default homolog Vite allowed host

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,14 +3,19 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'node:path';
 
-const allowedHosts = (process.env.VITE_ALLOWED_HOSTS ?? '')
-  .split(',')
-  .map((host) => host.trim())
-  .filter(Boolean);
+const defaultAllowedHosts = ['pricely.grmeireles.dev'];
+const allowedHosts = [
+  ...defaultAllowedHosts,
+  ...(process.env.VITE_ALLOWED_HOSTS ?? '')
+    .split(',')
+    .map((host) => host.trim())
+    .filter(Boolean),
+];
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
+    host: '0.0.0.0',
     allowedHosts,
   },
   test: {


### PR DESCRIPTION
## Summary
- Add pricely.grmeireles.dev as a default Vite allowed host
- Keep VITE_ALLOWED_HOSTS for additional public hostnames
- Set Vite dev server host in config to match the container command

## Validation
- npm run build
- npm run lint
- git diff --check

Fixes #232