### PR TITLE
Fix homolog Vite host validation

### DIFF
--- a/.github/workflows/deploy-homolog-server.yml
+++ b/.github/workflows/deploy-homolog-server.yml
@@ -69,6 +69,7 @@ jobs:
       WEB_APP_URL: ${{ vars.WEB_APP_URL || 'http://localhost:5173' }}
       VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL || 'http://localhost:3000' }}
       VITE_ALLOWED_HOSTS: ${{ vars.VITE_ALLOWED_HOSTS || 'pricely.grmeireles.dev' }}
+      VITE_ALLOW_ALL_HOSTS: ${{ vars.VITE_ALLOW_ALL_HOSTS || 'true' }}
       NODE_ENV: ${{ vars.NODE_ENV || 'development' }}
     steps:
       - name: Checkout
@@ -145,6 +146,7 @@ jobs:
             printf 'WEB_APP_URL=%s\n' "$WEB_APP_URL"
             printf 'VITE_API_BASE_URL=%s\n' "$VITE_API_BASE_URL"
             printf 'VITE_ALLOWED_HOSTS=%s\n' "$VITE_ALLOWED_HOSTS"
+            printf 'VITE_ALLOW_ALL_HOSTS=%s\n' "$VITE_ALLOW_ALL_HOSTS"
             printf 'NODE_ENV=%s\n' "$NODE_ENV"
           } > .deploy/.env
 

--- a/docker-compose.homolog.yml
+++ b/docker-compose.homolog.yml
@@ -92,6 +92,7 @@ services:
     environment:
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:3000}
       VITE_ALLOWED_HOSTS: ${VITE_ALLOWED_HOSTS:-pricely.grmeireles.dev}
+      VITE_ALLOW_ALL_HOSTS: ${VITE_ALLOW_ALL_HOSTS:-true}
     command: ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]
     ports:
       - "${WEB_PORT:-5173}:5173"

--- a/docs/deployment/homolog-server.md
+++ b/docs/deployment/homolog-server.md
@@ -85,6 +85,7 @@ Optional variables:
 - `WEB_APP_URL`
 - `VITE_API_BASE_URL`
 - `VITE_ALLOWED_HOSTS`
+- `VITE_ALLOW_ALL_HOSTS`
 - `NODE_ENV`
 - `USE_TAILSCALE`
 
@@ -108,8 +109,13 @@ Minimum variables:
 DEPLOY_PATH=/srv/stacks/pricely
 VITE_API_BASE_URL=https://<backend-public-url>
 VITE_ALLOWED_HOSTS=pricely.grmeireles.dev
+VITE_ALLOW_ALL_HOSTS=true
 WEB_APP_URL=https://<web-public-url>
 ```
+
+`VITE_ALLOW_ALL_HOSTS=true` is the homolog default because the web container
+runs the Vite development server behind Cloudflare Tunnel. Set it to `false`
+only if every public tunnel host is covered by `VITE_ALLOWED_HOSTS`.
 
 Use `GHCR_TOKEN` instead of `GHCR_PAT` only if the token has package pull access
 for the generated GHCR images.

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,12 +11,13 @@ const allowedHosts = [
     .map((host) => host.trim())
     .filter(Boolean),
 ];
+const allowAllHosts = process.env.VITE_ALLOW_ALL_HOSTS === 'true';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     host: '0.0.0.0',
-    allowedHosts,
+    allowedHosts: allowAllHosts ? true : allowedHosts,
   },
   test: {
     exclude: ['node_modules/**', 'dist/**', 'e2e/**'],


### PR DESCRIPTION
## Summary
- Add VITE_ALLOW_ALL_HOSTS for the homolog web container
- Use Vite allowedHosts=true when the homolog flag is enabled
- Document the homolog tunnel host setting

## Validation
- npm run build --prefix web
- npm run lint --prefix web
- git diff --check

Fixes #234