### PR TITLE
Add optimization offer trust factor

### DIFF
--- a/backend/src/common/contracts/optimization.contract.ts
+++ b/backend/src/common/contracts/optimization.contract.ts
@@ -20,6 +20,12 @@ export interface OptimizationSelection {
   savingsVsComparison?: number;
   sourceLabel?: string;
   observedAt?: string;
+  trustFactor?: number;
+  trustLevel?: 'high' | 'medium' | 'low';
+  trustEvidenceCount?: number;
+  trustFreshnessDays?: number;
+  trustLastValidatedAt?: string;
+  trustExplanation?: string;
   selectionStatus: 'selected' | 'missing' | 'review';
   confidenceNotice?: string;
   decisionReason?: string;
@@ -44,6 +50,12 @@ export interface OptimizationExplanationPayload {
     estimatedCost?: number;
     savingsVsComparison?: number;
     decisionReason?: string;
+    trustFactor?: number;
+    trustLevel?: 'high' | 'medium' | 'low';
+    trustEvidenceCount?: number;
+    trustFreshnessDays?: number;
+    trustLastValidatedAt?: string;
+    trustExplanation?: string;
   }>;
   rejectedAlternatives: Array<{
     shoppingListItemId: string;

--- a/backend/src/optimization/application/optimization-result.service.ts
+++ b/backend/src/optimization/application/optimization-result.service.ts
@@ -136,6 +136,10 @@ export class OptimizationResultService {
       `Returned optimization run ${latest.id} with status ${latest.status} for shopping list ${shoppingListId}`,
     );
 
+    const trustSnapshots = this.getSelectionTrustSnapshots(
+      latest.explanationPayload as OptimizationExplanationPayload | null,
+    );
+
     return {
       id: latest.id,
       shoppingListId: latest.shoppingListId,
@@ -156,54 +160,97 @@ export class OptimizationResultService {
         undefined,
       createdAt: latest.createdAt.toISOString(),
       completedAt: latest.completedAt?.toISOString(),
-      selections: latest.optimizationSelections.map((selection) => ({
-        id: selection.id,
-        shoppingListItemId: selection.shoppingListItemId,
-        productOfferId: selection.productOfferId ?? undefined,
-        shoppingListItemName: selection.shoppingListItem.requestedName,
-        establishmentName: selection.productOffer?.establishment.unitName,
-        establishmentNeighborhood:
-          selection.productOffer?.establishment.neighborhood,
-        estimatedCost:
-          selection.estimatedCost !== null
-            ? Number(selection.estimatedCost)
-            : undefined,
-        priceAmount:
-          selection.productOffer?.priceAmount !== undefined
-            ? Number(selection.productOffer.priceAmount)
-            : undefined,
-        comparisonPriceAmount:
-          selection.comparisonPriceAmount !== null
-            ? Number(selection.comparisonPriceAmount)
-            : undefined,
-        regionalAveragePriceAmount:
-          selection.regionalAveragePriceAmount !== null
-            ? Number(selection.regionalAveragePriceAmount)
-            : undefined,
-        savingsVsComparison:
-          selection.savingsVsComparison !== null
-            ? Number(selection.savingsVsComparison)
-            : undefined,
-        sourceLabel: selection.productOffer?.sourceReference ?? undefined,
-        observedAt: selection.productOffer?.observedAt.toISOString(),
-        selectionStatus:
-          selection.status === 'selected'
-            ? 'selected'
-            : selection.status === 'missing'
-              ? 'missing'
-              : 'review',
-        confidenceNotice: selection.confidenceNotice ?? undefined,
-        decisionReason: selection.confidenceNotice
-          ? 'selected_with_data_quality_warning'
-          : selection.status === 'selected'
-            ? 'selected_confirmed_offer'
-            : 'not_selected',
-        rejectedReason:
-          selection.status === 'missing'
-            ? 'no_confirmed_offer_available'
-            : undefined,
-      })),
+      selections: latest.optimizationSelections.map((selection) => {
+        const trustSnapshot = trustSnapshots.get(
+          this.selectionTrustSnapshotKey(
+            selection.shoppingListItemId,
+            selection.productOfferId ?? undefined,
+          ),
+        );
+
+        return {
+          id: selection.id,
+          shoppingListItemId: selection.shoppingListItemId,
+          productOfferId: selection.productOfferId ?? undefined,
+          shoppingListItemName: selection.shoppingListItem.requestedName,
+          establishmentName: selection.productOffer?.establishment.unitName,
+          establishmentNeighborhood:
+            selection.productOffer?.establishment.neighborhood,
+          estimatedCost:
+            selection.estimatedCost !== null
+              ? Number(selection.estimatedCost)
+              : undefined,
+          priceAmount:
+            selection.productOffer?.priceAmount !== undefined
+              ? Number(selection.productOffer.priceAmount)
+              : undefined,
+          comparisonPriceAmount:
+            selection.comparisonPriceAmount !== null
+              ? Number(selection.comparisonPriceAmount)
+              : undefined,
+          regionalAveragePriceAmount:
+            selection.regionalAveragePriceAmount !== null
+              ? Number(selection.regionalAveragePriceAmount)
+              : undefined,
+          savingsVsComparison:
+            selection.savingsVsComparison !== null
+              ? Number(selection.savingsVsComparison)
+              : undefined,
+          sourceLabel: selection.productOffer?.sourceReference ?? undefined,
+          observedAt: selection.productOffer?.observedAt.toISOString(),
+          trustFactor: trustSnapshot?.trustFactor,
+          trustLevel: trustSnapshot?.trustLevel,
+          trustEvidenceCount: trustSnapshot?.trustEvidenceCount,
+          trustFreshnessDays: trustSnapshot?.trustFreshnessDays,
+          trustLastValidatedAt: trustSnapshot?.trustLastValidatedAt,
+          trustExplanation: trustSnapshot?.trustExplanation,
+          selectionStatus:
+            selection.status === 'selected'
+              ? 'selected'
+              : selection.status === 'missing'
+                ? 'missing'
+                : 'review',
+          confidenceNotice: selection.confidenceNotice ?? undefined,
+          decisionReason: selection.confidenceNotice
+            ? 'selected_with_data_quality_warning'
+            : selection.status === 'selected'
+              ? 'selected_confirmed_offer'
+              : 'not_selected',
+          rejectedReason:
+            selection.status === 'missing'
+              ? 'no_confirmed_offer_available'
+              : undefined,
+        };
+      }),
     };
+  }
+
+  private getSelectionTrustSnapshots(
+    explanationPayload?: OptimizationExplanationPayload | null,
+  ) {
+    return new Map(
+      (explanationPayload?.selectedOffers ?? []).map((offer) => [
+        this.selectionTrustSnapshotKey(
+          offer.shoppingListItemId,
+          offer.productOfferId,
+        ),
+        {
+          trustFactor: offer.trustFactor,
+          trustLevel: offer.trustLevel,
+          trustEvidenceCount: offer.trustEvidenceCount,
+          trustFreshnessDays: offer.trustFreshnessDays,
+          trustLastValidatedAt: offer.trustLastValidatedAt,
+          trustExplanation: offer.trustExplanation,
+        },
+      ]),
+    );
+  }
+
+  private selectionTrustSnapshotKey(
+    shoppingListItemId: string,
+    productOfferId?: string,
+  ): string {
+    return `${shoppingListItemId}:${productOfferId ?? 'none'}`;
   }
 
   private async resolveDefaultRegionId(): Promise<string | null> {

--- a/backend/src/optimization/domain/multi-market-optimizer.service.ts
+++ b/backend/src/optimization/domain/multi-market-optimizer.service.ts
@@ -195,8 +195,15 @@ export class MultiMarketOptimizerService {
       ),
       sourceLabel: cheapestOffer.sourceReceiptLineItemId,
       observedAt: cheapestOffer.observedAt,
+      trustFactor: cheapestOffer.trustFactor,
+      trustLevel: cheapestOffer.trustLevel,
+      trustEvidenceCount: cheapestOffer.trustEvidenceCount,
+      trustFreshnessDays: cheapestOffer.trustFreshnessDays,
+      trustLastValidatedAt: cheapestOffer.trustLastValidatedAt,
+      trustExplanation: cheapestOffer.trustExplanation,
       confidenceNotice:
-        cheapestOffer.confidenceScore < 0.75
+        cheapestOffer.confidenceScore < 0.75 ||
+        (cheapestOffer.trustFactor !== undefined && cheapestOffer.trustFactor < 60)
           ? 'Selected from low-confidence market evidence.'
           : undefined,
       decisionReason: selectedStoreId
@@ -391,6 +398,12 @@ export class MultiMarketOptimizerService {
             estimatedCost: selection.estimatedCost,
             savingsVsComparison: selection.savingsVsComparison,
             decisionReason: selection.decisionReason,
+            trustFactor: selection.trustFactor,
+            trustLevel: selection.trustLevel,
+            trustEvidenceCount: selection.trustEvidenceCount,
+            trustFreshnessDays: selection.trustFreshnessDays,
+            trustLastValidatedAt: selection.trustLastValidatedAt,
+            trustExplanation: selection.trustExplanation,
           };
         }),
       rejectedAlternatives: shoppingList.items.flatMap((item) =>

--- a/backend/src/optimization/domain/optimization-selection.entity.ts
+++ b/backend/src/optimization/domain/optimization-selection.entity.ts
@@ -17,6 +17,12 @@ export interface OptimizationSelectionEntity {
   savingsVsComparison?: number;
   sourceLabel?: string;
   observedAt?: string;
+  trustFactor?: number;
+  trustLevel?: 'high' | 'medium' | 'low';
+  trustEvidenceCount?: number;
+  trustFreshnessDays?: number;
+  trustLastValidatedAt?: string;
+  trustExplanation?: string;
   selectionStatus: SelectionStatus;
   confidenceNotice?: string;
   decisionReason?: string;
@@ -41,6 +47,12 @@ export interface OptimizationExplanationPayload {
     estimatedCost?: number;
     savingsVsComparison?: number;
     decisionReason?: string;
+    trustFactor?: number;
+    trustLevel?: 'high' | 'medium' | 'low';
+    trustEvidenceCount?: number;
+    trustFreshnessDays?: number;
+    trustLastValidatedAt?: string;
+    trustExplanation?: string;
   }>;
   rejectedAlternatives: Array<{
     shoppingListItemId: string;

--- a/backend/src/stores/domain/store-offer.entity.ts
+++ b/backend/src/stores/domain/store-offer.entity.ts
@@ -20,6 +20,12 @@ export interface StoreOfferEntity {
   quantityContext?: string;
   availabilityStatus: StoreOfferAvailabilityStatus;
   confidenceScore: number;
+  trustFactor?: number;
+  trustLevel?: 'high' | 'medium' | 'low';
+  trustEvidenceCount?: number;
+  trustFreshnessDays?: number;
+  trustLastValidatedAt?: string;
+  trustExplanation?: string;
   sourceReceiptLineItemId: string;
   observedAt: string;
 }

--- a/backend/src/stores/infrastructure/store-offer.repository.ts
+++ b/backend/src/stores/infrastructure/store-offer.repository.ts
@@ -5,6 +5,24 @@ import { PrismaService } from '../../persistence/prisma.service';
 import { ProductNormalizerService } from '../../catalog/application/product-normalizer.service';
 import { type StoreOfferEntity } from '../domain/store-offer.entity';
 
+type ProductOfferWithRelations = Prisma.ProductOfferGetPayload<{
+  include: {
+    catalogProduct: true;
+    productVariant: true;
+    establishment: true;
+    receiptRecord: true;
+  };
+}>;
+
+interface OfferTrustProfile {
+  factor: number;
+  level: 'high' | 'medium' | 'low';
+  evidenceCount: number;
+  freshnessDays: number;
+  lastValidatedAt: string;
+  explanation: string;
+}
+
 @Injectable()
 export class StoreOfferRepository {
   constructor(
@@ -105,57 +123,14 @@ export class StoreOfferRepository {
         catalogProduct: true,
         productVariant: true,
         establishment: true,
+        receiptRecord: true,
       },
     });
+    const trustProfiles = this.buildTrustProfiles(activeOffers);
 
     return activeOffers
       .map((offer) => {
-        const normalizedProductName = this.productNormalizerService.normalize(
-          offer.catalogProduct.name,
-        ).canonicalName;
-        const matchingCanonicalNames = this.buildMatchingCanonicalNames({
-          catalogProductName: offer.catalogProduct.name,
-          variantName: offer.productVariant.displayName,
-          brandName: offer.productVariant.brandName,
-          displayName: offer.displayName,
-        });
-
-        return {
-          id: offer.id,
-          catalogProductId: offer.catalogProductId,
-          productVariantId: offer.productVariantId,
-          brandName: offer.productVariant.brandName ?? undefined,
-          variantName: offer.productVariant.displayName,
-          storeId: offer.establishmentId,
-          storeName: offer.establishment.unitName,
-          canonicalName: normalizedProductName,
-          matchingCanonicalNames,
-          displayName: offer.displayName,
-          price: Number(offer.priceAmount),
-          basePrice:
-            offer.basePriceAmount !== null
-              ? Number(offer.basePriceAmount)
-              : Number(offer.priceAmount),
-          promotionalPrice:
-            offer.promotionalPriceAmount !== null
-              ? Number(offer.promotionalPriceAmount)
-              : undefined,
-          quantityContext: offer.packageLabel,
-          availabilityStatus:
-            offer.availabilityStatus === 'available'
-              ? 'available'
-              : offer.availabilityStatus === 'unavailable'
-                ? 'unavailable'
-                : 'uncertain',
-          confidenceScore:
-            offer.confidenceLevel === 'high'
-              ? 0.95
-              : offer.confidenceLevel === 'medium'
-                ? 0.7
-                : 0.45,
-          sourceReceiptLineItemId: offer.sourceReference ?? offer.sourceType,
-          observedAt: offer.observedAt.toISOString(),
-        } satisfies StoreOfferEntity;
+        return this.toStoreOfferEntity(offer, trustProfiles);
       })
       .filter((offer) =>
         (offer.matchingCanonicalNames ?? [offer.canonicalName]).some((name) =>
@@ -203,57 +178,14 @@ export class StoreOfferRepository {
         catalogProduct: true,
         productVariant: true,
         establishment: true,
+        receiptRecord: true,
       },
     });
+    const trustProfiles = this.buildTrustProfiles(activeOffers);
 
     return activeOffers
       .map((offer) => {
-        const normalizedProductName = this.productNormalizerService.normalize(
-          offer.catalogProduct.name,
-        ).canonicalName;
-        const matchingCanonicalNames = this.buildMatchingCanonicalNames({
-          catalogProductName: offer.catalogProduct.name,
-          variantName: offer.productVariant.displayName,
-          brandName: offer.productVariant.brandName,
-          displayName: offer.displayName,
-        });
-
-        return {
-          id: offer.id,
-          catalogProductId: offer.catalogProductId,
-          productVariantId: offer.productVariantId,
-          brandName: offer.productVariant.brandName ?? undefined,
-          variantName: offer.productVariant.displayName,
-          storeId: offer.establishmentId,
-          storeName: offer.establishment.unitName,
-          canonicalName: normalizedProductName,
-          matchingCanonicalNames,
-          displayName: offer.displayName,
-          price: Number(offer.priceAmount),
-          basePrice:
-            offer.basePriceAmount !== null
-              ? Number(offer.basePriceAmount)
-              : Number(offer.priceAmount),
-          promotionalPrice:
-            offer.promotionalPriceAmount !== null
-              ? Number(offer.promotionalPriceAmount)
-              : undefined,
-          quantityContext: offer.packageLabel,
-          availabilityStatus:
-            offer.availabilityStatus === 'available'
-              ? 'available'
-              : offer.availabilityStatus === 'unavailable'
-                ? 'unavailable'
-                : 'uncertain',
-          confidenceScore:
-            offer.confidenceLevel === 'high'
-              ? 0.95
-              : offer.confidenceLevel === 'medium'
-                ? 0.7
-                : 0.45,
-          sourceReceiptLineItemId: offer.sourceReference ?? offer.sourceType,
-          observedAt: offer.observedAt.toISOString(),
-        } satisfies StoreOfferEntity;
+        return this.toStoreOfferEntity(offer, trustProfiles);
       })
       .filter(
         (offer) =>
@@ -262,6 +194,189 @@ export class StoreOfferRepository {
             canonicalNames.has(name),
           ),
       );
+  }
+
+  private toStoreOfferEntity(
+    offer: ProductOfferWithRelations,
+    trustProfiles: Map<string, OfferTrustProfile>,
+  ): StoreOfferEntity {
+    const normalizedProductName = this.productNormalizerService.normalize(
+      offer.catalogProduct.name,
+    ).canonicalName;
+    const matchingCanonicalNames = this.buildMatchingCanonicalNames({
+      catalogProductName: offer.catalogProduct.name,
+      variantName: offer.productVariant.displayName,
+      brandName: offer.productVariant.brandName,
+      displayName: offer.displayName,
+    });
+    const trustProfile = trustProfiles.get(this.buildTrustProfileKey(offer));
+
+    return {
+      id: offer.id,
+      catalogProductId: offer.catalogProductId,
+      productVariantId: offer.productVariantId,
+      brandName: offer.productVariant.brandName ?? undefined,
+      variantName: offer.productVariant.displayName,
+      storeId: offer.establishmentId,
+      storeName: offer.establishment.unitName,
+      canonicalName: normalizedProductName,
+      matchingCanonicalNames,
+      displayName: offer.displayName,
+      price: Number(offer.priceAmount),
+      basePrice:
+        offer.basePriceAmount !== null
+          ? Number(offer.basePriceAmount)
+          : Number(offer.priceAmount),
+      promotionalPrice:
+        offer.promotionalPriceAmount !== null
+          ? Number(offer.promotionalPriceAmount)
+          : undefined,
+      quantityContext: offer.packageLabel,
+      availabilityStatus:
+        offer.availabilityStatus === 'available'
+          ? 'available'
+          : offer.availabilityStatus === 'unavailable'
+            ? 'unavailable'
+            : 'uncertain',
+      confidenceScore: this.confidenceScoreForLevel(offer.confidenceLevel),
+      trustFactor: trustProfile?.factor,
+      trustLevel: trustProfile?.level,
+      trustEvidenceCount: trustProfile?.evidenceCount,
+      trustFreshnessDays: trustProfile?.freshnessDays,
+      trustLastValidatedAt: trustProfile?.lastValidatedAt,
+      trustExplanation: trustProfile?.explanation,
+      sourceReceiptLineItemId: offer.sourceReference ?? offer.sourceType,
+      observedAt: offer.observedAt.toISOString(),
+    };
+  }
+
+  private buildTrustProfiles(
+    offers: ProductOfferWithRelations[],
+  ): Map<string, OfferTrustProfile> {
+    const now = new Date();
+    const profiles = new Map<
+      string,
+      { offers: ProductOfferWithRelations[]; trustedReceiptIds: Set<string> }
+    >();
+
+    for (const offer of offers) {
+      const key = this.buildTrustProfileKey(offer);
+      const profile = profiles.get(key) ?? {
+        offers: [],
+        trustedReceiptIds: new Set<string>(),
+      };
+
+      profile.offers.push(offer);
+      if (this.isTrustedReceiptEvidence(offer)) {
+        profile.trustedReceiptIds.add(offer.receiptRecordId as string);
+      }
+      profiles.set(key, profile);
+    }
+
+    return new Map(
+      [...profiles.entries()].map(([key, profile]) => {
+        const latestOffer = profile.offers.reduce((latest, offer) =>
+          offer.observedAt > latest.observedAt ? offer : latest,
+        );
+        const evidenceCount = profile.trustedReceiptIds.size;
+        const freshnessDays = Math.max(
+          0,
+          Math.floor(
+            (now.getTime() - latestOffer.observedAt.getTime()) /
+              (1000 * 60 * 60 * 24),
+          ),
+        );
+        const baseConfidence = this.confidenceScoreForLevel(
+          latestOffer.confidenceLevel,
+        );
+        const evidenceScore = Math.min(1, evidenceCount / 5);
+        const freshnessScore = this.freshnessScore(freshnessDays);
+        const adminFallback =
+          evidenceCount === 0 && latestOffer.sourceType !== 'receipt' ? 0.2 : 0;
+        const factor = Math.round(
+          100 *
+            Math.min(
+              1,
+              baseConfidence * 0.4 +
+                evidenceScore * 0.35 +
+                freshnessScore * 0.25 +
+                adminFallback,
+            ),
+        );
+        const level =
+          factor >= 75 ? 'high' : factor >= 50 ? 'medium' : 'low';
+
+        return [
+          key,
+          {
+            factor,
+            level,
+            evidenceCount,
+            freshnessDays,
+            lastValidatedAt: latestOffer.observedAt.toISOString(),
+            explanation: this.buildTrustExplanation(
+              evidenceCount,
+              freshnessDays,
+              factor,
+            ),
+          },
+        ];
+      }),
+    );
+  }
+
+  private buildTrustProfileKey(offer: {
+    productVariantId: string;
+    establishmentId: string;
+  }): string {
+    return `${offer.productVariantId}:${offer.establishmentId}`;
+  }
+
+  private isTrustedReceiptEvidence(offer: ProductOfferWithRelations): boolean {
+    return Boolean(
+      offer.receiptRecordId &&
+        offer.receiptRecord &&
+        offer.receiptRecord.trustLevel === 'trusted' &&
+        offer.receiptRecord.moderationStatus === 'accepted',
+    );
+  }
+
+  private confidenceScoreForLevel(level: 'high' | 'medium' | 'low'): number {
+    if (level === 'high') {
+      return 0.95;
+    }
+    if (level === 'medium') {
+      return 0.7;
+    }
+    return 0.45;
+  }
+
+  private freshnessScore(freshnessDays: number): number {
+    if (freshnessDays <= 14) {
+      return 1;
+    }
+    if (freshnessDays >= 90) {
+      return 0.25;
+    }
+
+    return Number((1 - ((freshnessDays - 14) / 76) * 0.75).toFixed(2));
+  }
+
+  private buildTrustExplanation(
+    evidenceCount: number,
+    freshnessDays: number,
+    factor: number,
+  ): string {
+    const receiptText =
+      evidenceCount === 1
+        ? '1 nota fiscal confiavel'
+        : `${evidenceCount} notas fiscais confiaveis`;
+    const freshnessText =
+      freshnessDays === 0
+        ? 'validacao hoje'
+        : `ultima validacao ha ${freshnessDays} dias`;
+
+    return `${receiptText}; ${freshnessText}; trust factor ${factor}/100.`;
   }
 
   private buildMatchingCanonicalNames(input: {

--- a/backend/test/unit/optimization/multi-market-optimizer.service.spec.ts
+++ b/backend/test/unit/optimization/multi-market-optimizer.service.spec.ts
@@ -440,4 +440,48 @@ describe('MultiMarketOptimizerService', () => {
       confidenceNotice: 'Selected from low-confidence market evidence.',
     });
   });
+
+  it('carries offer trust factor evidence into optimization decisions', () => {
+    const list = createList();
+    list.items = [list.items[0]];
+
+    const result = service.optimize(
+      list,
+      [
+        createOffer({
+          id: 'offer-trusted',
+          catalogProductId: 'product-arroz',
+          storeId: 'store-a',
+          storeName: 'Mercado A',
+          canonicalName: 'arroz',
+          displayName: 'Arroz validado',
+          price: 8.49,
+          sourceReceiptLineItemId: 'receipt-derived',
+          observedAt: new Date().toISOString(),
+          trustFactor: 82,
+          trustLevel: 'high',
+          trustEvidenceCount: 4,
+          trustFreshnessDays: 2,
+          trustLastValidatedAt: new Date().toISOString(),
+          trustExplanation:
+            '4 notas fiscais confiaveis; ultima validacao ha 2 dias; trust factor 82/100.',
+        }),
+      ],
+      'global_full',
+    );
+
+    expect(result.selections[0]).toMatchObject({
+      selectionStatus: 'selected',
+      trustFactor: 82,
+      trustLevel: 'high',
+      trustEvidenceCount: 4,
+      trustFreshnessDays: 2,
+    });
+    expect(result.explanationPayload?.selectedOffers[0]).toEqual(
+      expect.objectContaining({
+        trustFactor: 82,
+        trustEvidenceCount: 4,
+      }),
+    );
+  });
 });

--- a/backend/test/unit/stores/store-offer.repository.spec.ts
+++ b/backend/test/unit/stores/store-offer.repository.spec.ts
@@ -31,6 +31,8 @@ describe('StoreOfferRepository', () => {
             sourceReference: 'Seed comparativo',
             sourceType: 'admin',
             observedAt: new Date('2026-05-07T00:00:00.000Z'),
+            receiptRecordId: null,
+            receiptRecord: null,
           },
           {
             id: 'offer-cafe',
@@ -57,6 +59,8 @@ describe('StoreOfferRepository', () => {
             sourceReference: 'Seed local',
             sourceType: 'admin',
             observedAt: new Date('2026-05-07T00:00:00.000Z'),
+            receiptRecordId: null,
+            receiptRecord: null,
           },
         ]),
       },
@@ -83,5 +87,94 @@ describe('StoreOfferRepository', () => {
       'camil arroz camil tipo 1',
     );
     expect(offers[1].matchingCanonicalNames).toContain('pilao cafe pilao');
+  });
+
+  it('adds a decaying trust factor from trusted receipt evidence for the same store variant', async () => {
+    const prisma = {
+      productOffer: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'offer-recent',
+            catalogProductId: 'product-arroz',
+            productVariantId: 'variant-arroz-camil',
+            catalogProduct: {
+              name: 'Arroz tipo 1 5kg',
+            },
+            productVariant: {
+              displayName: 'Arroz Camil tipo 1 5kg',
+              brandName: 'Camil',
+            },
+            establishmentId: 'store-1',
+            establishment: {
+              unitName: 'Unidade Pinheiros',
+            },
+            displayName: 'Arroz Camil tipo 1 5kg',
+            packageLabel: '5 kg',
+            priceAmount: '21.90',
+            basePriceAmount: '21.90',
+            promotionalPriceAmount: null,
+            availabilityStatus: 'available',
+            confidenceLevel: 'high',
+            sourceReference: 'receipt-line-1',
+            sourceType: 'receipt',
+            observedAt: new Date(),
+            receiptRecordId: 'receipt-1',
+            receiptRecord: {
+              trustLevel: 'trusted',
+              moderationStatus: 'accepted',
+            },
+          },
+          {
+            id: 'offer-second-receipt',
+            catalogProductId: 'product-arroz',
+            productVariantId: 'variant-arroz-camil',
+            catalogProduct: {
+              name: 'Arroz tipo 1 5kg',
+            },
+            productVariant: {
+              displayName: 'Arroz Camil tipo 1 5kg',
+              brandName: 'Camil',
+            },
+            establishmentId: 'store-1',
+            establishment: {
+              unitName: 'Unidade Pinheiros',
+            },
+            displayName: 'Arroz Camil tipo 1 5kg',
+            packageLabel: '5 kg',
+            priceAmount: '22.10',
+            basePriceAmount: '22.10',
+            promotionalPriceAmount: null,
+            availabilityStatus: 'available',
+            confidenceLevel: 'high',
+            sourceReference: 'receipt-line-2',
+            sourceType: 'receipt',
+            observedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
+            receiptRecordId: 'receipt-2',
+            receiptRecord: {
+              trustLevel: 'trusted',
+              moderationStatus: 'accepted',
+            },
+          },
+        ]),
+      },
+    };
+    const normalizer = new ProductNormalizerService();
+    const repository = new StoreOfferRepository(prisma as never, normalizer);
+
+    const offers = await repository.findByListItems([
+      {
+        catalogProductId: 'product-arroz',
+      },
+    ]);
+
+    expect(offers[0]).toEqual(
+      expect.objectContaining({
+        trustEvidenceCount: 2,
+        trustLevel: 'high',
+        trustFreshnessDays: 0,
+      }),
+    );
+    expect(offers[0].trustFactor).toBeGreaterThanOrEqual(75);
+    expect(offers[0].trustExplanation).toContain('2 notas fiscais confiaveis');
   });
 });

--- a/web/e2e/mvp-smoke.spec.ts
+++ b/web/e2e/mvp-smoke.spec.ts
@@ -99,6 +99,13 @@ const optimizationResult = {
       savingsVsComparison: 1.5,
       sourceLabel: 'Recibo de usuario',
       observedAt: '2026-05-05T09:30:00.000Z',
+      trustFactor: 82,
+      trustLevel: 'high',
+      trustEvidenceCount: 4,
+      trustFreshnessDays: 3,
+      trustLastValidatedAt: '2026-05-05T09:30:00.000Z',
+      trustExplanation:
+        '4 notas fiscais confiaveis; ultima validacao ha 3 dias; trust factor 82/100.',
       selectionStatus: 'selected',
       confidenceNotice: 'Preco observado em recibo recente.',
       decisionReason: 'selected_confirmed_offer',
@@ -348,6 +355,8 @@ test('MVP shopper flow covers sign-in, city, list, optimization, checklist, and 
   await page.getByText('Usar este modo').first().click();
   await expect(page.getByText('Decisões por item')).toBeVisible();
   await expect(page.getByText('Oferta confirmada selecionada')).toBeVisible();
+  await expect(page.getByText('Trust alto')).toBeVisible();
+  await expect(page.getByText('82/100', { exact: true })).toBeVisible();
 
   await page.goto('/listas/list-1/checklist');
   await expect(page.getByRole('heading', { name: 'Checklist de compra' })).toBeVisible();

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -84,6 +84,12 @@ type OptimizationResultApiResponse = {
     savingsVsComparison?: number;
     sourceLabel?: string;
     observedAt?: string;
+    trustFactor?: number;
+    trustLevel?: 'high' | 'medium' | 'low';
+    trustEvidenceCount?: number;
+    trustFreshnessDays?: number;
+    trustLastValidatedAt?: string;
+    trustExplanation?: string;
     selectionStatus: 'selected' | 'missing' | 'review';
     confidenceNotice?: string;
     decisionReason?: string;

--- a/web/src/public/optimization-page.spec.tsx
+++ b/web/src/public/optimization-page.spec.tsx
@@ -98,6 +98,12 @@ describe('OptimizationPage', () => {
             savingsVsComparison: 1,
             sourceLabel: 'nota fiscal do usuario',
             observedAt: '2026-05-08T09:00:00.000Z',
+            trustFactor: 78,
+            trustLevel: 'high',
+            trustEvidenceCount: 3,
+            trustFreshnessDays: 1,
+            trustExplanation:
+              '3 notas fiscais confiaveis; ultima validacao ha 1 dias; trust factor 78/100.',
             selectionStatus: 'selected',
             decisionReason: 'selected_confirmed_offer',
           },
@@ -116,6 +122,8 @@ describe('OptimizationPage', () => {
     expect(screen.getByText('Completa')).toBeTruthy();
     expect(screen.getByText('Oferta selecionada')).toBeTruthy();
     expect(screen.getByText('Oferta confirmada selecionada')).toBeTruthy();
+    expect(screen.getByText('Trust alto')).toBeTruthy();
+    expect(screen.getByText('78/100')).toBeTruthy();
     expect(
       screen.getByText('R$ 1,00 abaixo da média regional (R$ 22,90)'),
     ).toBeTruthy();

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -158,6 +158,38 @@ function confidenceBadge(level: ConfidenceLevel) {
   return <Badge variant="destructive">Revisar</Badge>;
 }
 
+function trustFactorBadge(level?: 'high' | 'medium' | 'low') {
+  if (level === 'high') {
+    return (
+      <Badge className="bg-emerald-100 text-emerald-900 hover:bg-emerald-100">
+        Trust alto
+      </Badge>
+    );
+  }
+  if (level === 'medium') {
+    return <Badge variant="secondary">Trust médio</Badge>;
+  }
+
+  return <Badge variant="destructive">Trust baixo</Badge>;
+}
+
+function trustEvidenceLabel(selection: {
+  trustEvidenceCount?: number;
+  trustFreshnessDays?: number;
+}) {
+  const evidenceCount = selection.trustEvidenceCount ?? 0;
+  const receiptText =
+    evidenceCount === 1
+      ? '1 nota valida'
+      : `${evidenceCount} notas validas`;
+
+  if (selection.trustFreshnessDays === undefined) {
+    return receiptText;
+  }
+
+  return `${receiptText} · revalidado ha ${selection.trustFreshnessDays}d`;
+}
+
 function PriceDisplay({
   priceAmount,
   basePriceAmount,
@@ -2311,8 +2343,26 @@ export function OptimizationPage() {
                             </div>
                           </TableCell>
                           <TableCell>
-                            {selection.sourceLabel ??
-                              'Sem evidência suficiente'}
+                            <div className="flex flex-col items-start gap-1">
+                              <span>
+                                {selection.sourceLabel ??
+                                  'Sem evidência suficiente'}
+                              </span>
+                              {selection.trustFactor !== undefined ? (
+                                <>
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    {trustFactorBadge(selection.trustLevel)}
+                                    <span className="text-xs text-muted-foreground">
+                                      {selection.trustFactor}/100
+                                    </span>
+                                  </div>
+                                  <span className="text-xs text-muted-foreground">
+                                    {selection.trustExplanation ??
+                                      trustEvidenceLabel(selection)}
+                                  </span>
+                                </>
+                              ) : null}
+                            </div>
                           </TableCell>
                           <TableCell>
                             {selection.observedAt


### PR DESCRIPTION
## Summary
- calculates offer trust factor from trusted receipt evidence, freshness decay, and existing confidence level
- carries trust snapshots through optimization explanation payload and API contracts
- renders trust factor evidence in the optimization decisions table

## Validation
- npm --prefix backend run build
- npm --prefix web run build
- npm --prefix backend run lint
- npm --prefix web run lint
- npm --prefix backend test
- npm --prefix web test
- npm --prefix web run e2e