### PR TITLE
Expand UX and performance planning scope

### DIFF
--- a/docs/product/location-aware-optimization-plan.md
+++ b/docs/product/location-aware-optimization-plan.md
@@ -19,6 +19,30 @@ Receipt-derived offers remain the priority source for the current roadmap. All s
 must preserve offer provenance, observed timestamp, confidence level, and moderation
 state.
 
+## Establishment Location Data
+
+Distance-aware optimization needs establishment location data that is more precise than
+city name but still operationally maintainable.
+
+Required establishment fields:
+
+- street address
+- neighborhood
+- city/region
+- state
+- CEP
+- latitude and longitude
+- geocoding source
+- geocoding precision, such as exact address, CEP centroid, or manual coordinate
+- geocoding updated timestamp
+
+Initial implementation can store latitude/longitude directly in PostgreSQL and compute
+distance with Haversine in the backend domain layer. If volume or query complexity
+increases, move radius filtering to PostGIS while preserving the same API contract.
+
+Seed data should include realistic addresses or CEPs and coordinates for every active
+establishment used in location-aware tests.
+
 ## Final Optimization Modes
 
 ### Local unique

--- a/docs/product/stitch-ui-ux-alignment.md
+++ b/docs/product/stitch-ui-ux-alignment.md
@@ -44,6 +44,89 @@ Recommended scope change: make "create list -> optimize -> shop -> contribute re
 the primary narrative for public web and mobile, and let offers browsing support that
 journey instead of competing with it as a separate surface.
 
+### Checklist Completion and Price Reports
+
+Checklist mode should become the shopper's in-store closing flow instead of only a
+manual purchased-state list.
+
+Required behavior:
+
+- allow the shopper to mark an item as purchased
+- allow the shopper to report that the shelf/register price does not match the app
+  price
+- capture optional reported price, store, note, and evidence path for later review
+- automatically detect when all items are checked
+- offer a "concluir lista" action when the list is complete
+- ask for the total paid as an optional value before finishing
+- route the user to receipt contribution after completion, without requiring it
+
+Recommended scope change: treat checklist completion, price mismatch reports, optional
+paid total, and receipt contribution as one post-shopping feedback loop.
+
+### City Activation and Empty Coverage
+
+Cities without active establishments or without offers need explicit placeholders.
+`active`, `activating`, and `collecting_data` states must not look broken or empty.
+
+Required behavior:
+
+- active city with offers: show offers and active establishment count
+- active city with establishments but no current offers: show coverage empty state and
+  contribution CTA
+- activating city: show "em ativacao", explain that offers are not available yet, and
+  invite contribution or notification interest
+- inactive city: hide from shopper selectors unless admin previewing
+- supported-establishments blocks must show active establishments for cities that have
+  them and an activation placeholder for cities that do not
+
+### Offers by City and Establishment Filtering
+
+The current offer explorer can list the same product multiple times when several
+establishments have the same variant. This makes comparison harder.
+
+Required behavior:
+
+- group public offers by comparable product and variant
+- show the cheapest currently eligible establishment first
+- show "mais barato em" with store, neighborhood, current price, and freshness
+- allow filtering by establishment/store
+- allow opening a comparison panel that lists other establishments for the same
+  product/variant
+- avoid duplicate product cards unless package/variant is materially different
+- show variant image in both offer cards and admin offer rows
+
+Recommended scope change: make public city offers a comparison surface, not a raw
+offer feed.
+
+### Mobile Responsiveness and Sticky Actions
+
+Important actions currently risk being far from the user on long pages. Persistent
+context panels also take too much attention when repeated across the app.
+
+Required behavior:
+
+- replace fixed full-width account/city context blocks with compact contextual headers
+  or collapsible summaries
+- keep primary actions such as save, optimize, finish checklist, and upload receipt in
+  a sticky mobile action bar when the page is long
+- verify landing, offers, list editor, optimization result, checklist, admin tables,
+  and auth/profile pages on mobile widths
+- avoid wide tables on shopper mobile surfaces; use stacked cards instead
+
+### Premium and Entitlement Copy
+
+Premium users should not see copy that explains free-plan limits as if they still
+apply.
+
+Required behavior:
+
+- premium active: show "Premium ativo", unlimited optimization value, billing/status
+  state, and support-safe management copy
+- free user: show monthly token limit, remaining token count, and disabled billing
+  note if checkout is unavailable
+- trialing/past_due/cancelled/expired: show status-specific copy and next action
+- never show "o plano gratuito inclui..." inside a premium-active state
+
 ### Optimization Result Trust
 
 Trust factor is now available but should not be shown as an isolated number. Users need
@@ -63,6 +146,30 @@ Recommended scope change: replace raw technical copy in result cards with compac
 "Evidencia da oferta" modules on shopper surfaces and deeper "Decision trace" modules
 for admins.
 
+### Item Decision Accuracy
+
+Optimization results must show the actual selected variant when the user allowed any
+variant. "Qualquer variante" is the request rule, not the final selection.
+
+Required behavior:
+
+- show requested rule separately from selected variant
+- show selected variant, package, store, neighborhood, and price in the primary row
+- update the list after optimization so the checklist reflects selected variants and
+  stores where appropriate
+- compare price against a true metric: lowest eligible alternative, city median, or
+  regional average
+- label the metric explicitly, for example "R$ 1,00 abaixo da media regional" only
+  when the average minus selected price is actually R$ 1,00
+- show average/median separately from the selected-price delta
+- remove nonsensical copy such as "0 notas fiscais confiaveis"
+- use "sem validacoes por nota fiscal ainda" for zero receipt evidence and explain
+  seed/admin data separately
+
+Recommended scope change: define a single shopper-facing comparison rule. Prefer
+"economia vs proxima melhor alternativa elegivel" for item-level decisions and show
+regional average as secondary context.
+
 ### Location-Aware UX
 
 Phase 23 is still pending. Phase 24 should not visually imply nearby-store accuracy
@@ -72,6 +179,9 @@ nearby claims must stay guarded.
 Recommended scope change: design the location widgets now, but implement local mode
 copy as "city/local context" until T170-T177 add coordinates, radius preview, and
 distance-aware explanations.
+
+Location data should use establishment coordinates derived from address/CEP and allow
+future PostGIS indexing without changing the user-facing contract.
 
 ### Receipt Contribution UX
 
@@ -100,6 +210,59 @@ Improve admin hierarchy around:
 Recommended scope change: make admin overview an action queue first and a metrics page
 second. Metrics should support decisions; low-trust and blocked data should rise to
 the top.
+
+### Admin Catalog and Queue Readability
+
+Catalog and operational screens need to reduce raw-id density.
+
+Required behavior:
+
+- split catalog product editing from variant editing or make variants an explicit
+  detail route/tab
+- show variant images in price and offer rows
+- make long variant lists searchable and collapsible
+- replace "go to link" text with an icon button and accessible label
+- summarize operation cards with human-readable status, owner, list name, mode, elapsed
+  time, and next action before raw identifiers
+- move raw IDs and metadata into a detail drawer or expandable technical section
+
+### Public Load Performance
+
+The public URL is perceived as slow. Treat performance as a product requirement, not
+only infrastructure.
+
+Investigation targets:
+
+- initial JS bundle size and route-level code splitting
+- blocking requests on landing, especially regions, impact, offers, and auth/session
+  hydration
+- image weight, remote image latency, and missing dimensions
+- Cloudflare/API latency and cold container startup
+- React render waterfalls from shared context fetching
+- Vite/dev artifacts accidentally reaching public deploy
+
+Success target:
+
+- capture Lighthouse or Playwright navigation timing for the public URL
+- define LCP, TTI, total JS, and critical API latency budgets
+- make landing usable with skeletons even if offers/impact are still loading
+
+### Seed and Test Data Realism
+
+The current seed data is too small for validating comparison, grouping, stale data,
+trust decay, admin operations, and responsive layouts.
+
+Required seed expansion:
+
+- more active and activating cities
+- more establishments per active city, with CNPJ, neighborhood, CEP/address, and
+  coordinates when Phase 23 lands
+- more catalog products and variants across grocery categories
+- enough duplicate comparable offers to validate cheapest-store grouping
+- stale, low-confidence, receipt-derived, admin-seeded, promotional, and unavailable
+  offer scenarios
+- receipt records that exercise accepted, duplicate, quarantined, rejected, and pending
+  review states
 
 ## Design-System Mapping
 
@@ -141,6 +304,7 @@ Tasks:
 - make city context persistent and visually prominent without blocking offer browsing
 - make list item cards show image, product, brand rule, quantity, and confidence
 - route users from completed checklist to receipt contribution
+- add checklist price mismatch reporting and optional paid-total capture
 
 ### Lane B: Trust and Evidence Modules
 
@@ -153,6 +317,8 @@ Tasks:
 - create an admin decision evidence component with selected offer, rejected
   alternatives, source, trust decay, and moderation status
 - add report/upload actions for low-trust or stale selections
+- separate requested brand rule from selected optimized variant
+- show true comparison math and remove zero-receipt wording that implies bad data
 
 ### Lane C: Receipt Quality Surfaces
 
@@ -189,11 +355,37 @@ Tasks:
 - make catalog image/variant gaps visible as admin tasks
 - keep raw tables available as detail views, not first-level summaries
 
+### Lane F: Offer Discovery and Data Realism
+
+Goal: make public offer browsing and seed data representative enough for real testing.
+
+Tasks:
+
+- group offers by product/variant and show cheapest eligible establishment first
+- add establishment filtering and comparison panels
+- expand seed data across cities, stores, products, variants, offers, and receipt
+  quality states
+- add city activation placeholders and supported-establishment empty states
+
+### Lane G: Performance and Responsive Quality
+
+Goal: make the public URL feel fast and usable on mobile.
+
+Tasks:
+
+- profile public load with Lighthouse/Playwright navigation timing
+- identify API, bundle, image, and hydration bottlenecks
+- add route-level/code-splitting or request deferral where needed
+- add sticky mobile actions and mobile-first card layouts for dense screens
+
 ## Validation Plan
 
 - Add Playwright screenshots for landing, offers, list editor, optimization result,
   checklist, receipt state, and public city chooser.
+- Add performance assertions or recorded budgets for the public landing URL.
 - Add web unit coverage for evidence modules and stale/low-trust states.
+- Add web coverage for checklist mismatch reporting, optional paid total, city
+  activation placeholders, establishment filters, and grouped offer comparisons.
 - Add dashboard tests for admin action queues and receipt/offer moderation states.
 - Add mobile widget tests or screenshot notes for home, list, optimization result,
   receipt contribution, profile/token state, and dark mode.
@@ -209,3 +401,8 @@ Tasks:
   route or live under queue/list operations.
 - Decide whether "Trust factor" remains the UI label or becomes "Confianca da oferta"
   for shopper-facing copy.
+- Decide whether optimization should update shopping-list items directly or persist a
+  separate optimized-checklist projection that leaves the original requested list
+  untouched.
+- Decide whether item comparison should primarily use next-best eligible alternative,
+  city median, or regional average.

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -467,8 +467,8 @@ payments, and receipt incentives increase risk.
 radius while keeping global optimization limited to the user's selected city/region.
 
 - [X] T169 [P] Add location-aware optimization planning notes covering `local_unique`, `local_multi`, `global_multi`, distance policy, coverage-radius bounds, and privacy constraints in `docs/product/location-aware-optimization-plan.md`
-- [ ] T170 [P] Extend the data model and API contracts for establishment coordinates, user location preferences, coverage preview, candidate-establishment counts, and location-aware optimization request fields in `specs/001-grocery-optimizer/data-model.md` and `specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml`
-- [ ] T171 Add Prisma schema and migration support for establishment latitude/longitude, user location preferences, optimization-run location snapshots, and selection distance fields in `backend/prisma/schema.prisma`
+- [ ] T170 [P] Extend the data model and API contracts for establishment address/CEP, geocoded coordinates, user location preferences, coverage preview, candidate-establishment counts, and location-aware optimization request fields in `specs/001-grocery-optimizer/data-model.md` and `specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml`
+- [ ] T171 Add Prisma schema and migration support for establishment address/CEP, latitude/longitude, geocoding metadata, user location preferences, optimization-run location snapshots, and selection distance fields in `backend/prisma/schema.prisma`
 - [ ] T172 [P] Add backend unit tests for distance calculation, radius filtering, city-bound global filtering, and no-location/no-coverage edge cases in `backend/test/unit/optimization/` and `backend/test/unit/locations/`
 - [ ] T173 Implement location preference services and coverage preview endpoints with explicit user-provided coordinates only in `backend/src/locations/`, `backend/src/users/`, and `backend/src/common/contracts/`
 - [ ] T174 Refactor optimization candidate generation to support `local_unique`, `local_multi`, and `global_multi` semantics with distance-aware explanations in `backend/src/optimization/`
@@ -495,16 +495,37 @@ rules into implementation tasks against the real product.
 
 - [X] T178 [P] Audit implemented web/mobile/admin flows against the current product and document product, IA, visual-system, trust-evidence, receipt, and interaction gaps in `docs/product/stitch-ui-ux-alignment.md`
 - [X] T179 [P] Map design-system rules into implementation-ready tokens and component rules for web and mobile, including teal/lime/amber/coral status roles, tonal surfaces, 8px radius, action badges, and tabular price typography in `docs/product/stitch-ui-ux-alignment.md`
-- [ ] T180 Split the broad Phase 24 refactor into issue-sized shopper lanes for `create list -> optimize -> shop -> contribute receipt`, including next-best-action strips, persistent city context, richer list item cards, and checklist-to-receipt handoff in `web/src/public/` and `mobile/lib/features/`
-- [ ] T181 Render persisted optimization explanations as shopper evidence modules with trust factor, source type, receipt count, freshness decay, confidence notice, and report/upload actions in `web/src/public/` and `mobile/lib/features/optimization/`
+- [ ] T180 Split the broad Phase 24 refactor into issue-sized shopper lanes for `create list -> optimize -> shop -> contribute receipt`, including next-best-action strips, compact persistent city context, richer list item cards, sticky mobile actions, checklist completion, optional paid-total capture, price-mismatch reports, and checklist-to-receipt handoff in `web/src/public/` and `mobile/lib/features/`
+- [ ] T181 Render persisted optimization explanations as shopper evidence modules with trust factor, source type, receipt/observation count, freshness decay, confidence notice, selected variant, true comparison math, and report/upload actions in `web/src/public/` and `mobile/lib/features/optimization/`
 - [ ] T182 Render admin decision evidence modules with selected offers, rejected alternatives, trust decay, receipt provenance, moderation status, and source labels in `web/src/dashboard/`
 - [ ] T183 Refactor receipt contribution surfaces so accepted, pending-review, duplicate, rejected, and low-confidence outcomes are visual and actionable without promising token rewards before T162 in `web/src/public/`, `web/src/dashboard/`, and `mobile/lib/features/receipts/`
 - [ ] T184 Add Phase 23-ready location widgets as explicit city/location/radius preview states, keeping proximity claims disabled until T170-T177 add persisted coordinates and distance-aware optimization in `web/src/public/` and `mobile/lib/features/`
 - [ ] T185 Refactor admin overview into an action-first operations surface that elevates stale offers, low-trust offers, failed jobs, quarantined receipts, catalog image gaps, and city coverage issues in `web/src/dashboard/`
-- [ ] T186 Refactor public web surfaces toward the audited direction for landing, city selection, offers explorer, offer detail, lists, list editor, optimization result, receipt states, location widgets, and disabled premium gate in `web/src/public/`
-- [ ] T187 Refactor mobile surfaces toward the audited direction for onboarding/home, list, location widgets, optimization results by mode, receipt contribution, profile/value, error states, and dark-mode parity in `mobile/lib/features/`
-- [ ] T188 Add visual regression/screenshot validation for key aligned web flows with Playwright and keep existing MVP E2E coverage green in `web/e2e/`
-- [ ] T189 Add mobile widget/golden or screenshot-oriented validation notes for key aligned mobile flows in `mobile/test/` and `docs/product/stitch-ui-ux-alignment.md`
+- [ ] T186 Refactor public city and offer surfaces so activating cities have explicit placeholders, supported-establishment sections show active stores or activation states, offers are grouped by product/variant with cheapest eligible establishment first, and establishment filters/comparison panels replace duplicate offer cards in `web/src/public/` and `web/src/app/`
+- [ ] T187 Refactor public web surfaces toward the audited direction for landing, city selection, offers explorer, offer detail, lists, list editor, optimization result, receipt states, location widgets, premium/free entitlement copy, and disabled billing gate in `web/src/public/`
+- [ ] T188 Refactor mobile surfaces toward the audited direction for onboarding/home, list, location widgets, optimization results by mode, receipt contribution, profile/value, error states, and dark-mode parity in `mobile/lib/features/`
+- [ ] T189 Refactor admin catalog and offer operations so variants are managed through a dedicated detail route/tab, long variant lists are searchable/collapsible, variant images appear in price/offer rows, and raw IDs move behind detail affordances in `web/src/dashboard/`
+- [ ] T190 Refactor admin list operations and queue health cards so they show human-readable owner, list, mode, elapsed time, status, and icon actions before technical job/resource IDs in `web/src/dashboard/`
+- [ ] T191 Add visual regression/screenshot validation for key aligned web flows with Playwright and keep existing MVP E2E coverage green in `web/e2e/`
+- [ ] T192 Add mobile widget/golden or screenshot-oriented validation notes for key aligned mobile flows in `mobile/test/` and `docs/product/stitch-ui-ux-alignment.md`
+
+---
+
+## Phase 25: Public Performance, Responsive QA, and Rich Demo Data
+
+**Purpose**: Make the public homolog URL fast enough for real shoppers and expand demo
+data so offer grouping, trust evidence, city activation, stale data, and admin flows can
+be tested deeply.
+
+- [ ] T193 Profile the public `https://pricely.grmeireles.dev/` load path with Lighthouse or Playwright navigation timing, capturing LCP, TTI, JS payload, critical API latency, image timing, and Cloudflare/API response timing in `web/e2e/` and `docs/product/stitch-ui-ux-alignment.md`
+- [ ] T194 Reduce public landing and shell load latency by auditing bundle size, route-level loading, context fetch waterfalls, image dimensions/weights, skeleton states, and unnecessary initial API calls in `web/src/public/`, `web/src/app/`, and `web/src/routes/`
+- [ ] T195 Add mobile responsiveness QA for landing, city chooser, offers, offer comparison, list editor, optimization result, checklist, profile/entitlement, admin tables, and auth screens in `web/e2e/` and `web/src/`
+- [ ] T196 Expand seed data with additional cities across active, activating, and collecting-data states in `backend/prisma/seed.js`
+- [ ] T197 Expand seed data with more establishments per active city, including CNPJ, neighborhood, address/CEP, and future-ready latitude/longitude placeholders in `backend/prisma/seed.js`
+- [ ] T198 Expand seed data with broader catalog products, variants, package sizes, images, aliases, categories, and enough repeated comparable products to stress product/variant management in `backend/prisma/seed.js`
+- [ ] T199 Expand seed data with duplicate comparable offers across establishments, promotional/base price cases, stale offers, low-confidence offers, unavailable offers, seeded/admin-derived offers, and receipt-derived trust evidence in `backend/prisma/seed.js`
+- [ ] T200 Expand seed data with receipt records and processing jobs covering accepted, pending-review, duplicate, quarantined, rejected, low-confidence, and reward-disabled states in `backend/prisma/seed.js`
+- [ ] T201 Add backend/web tests that verify seed coverage for city activation placeholders, grouped offer comparisons, trust evidence, stale/low-confidence data, and admin queue/readability scenarios in `backend/test/` and `web/e2e/`
 
 ---
 
@@ -527,6 +548,7 @@ rules into implementation tasks against the real product.
 - **Security, QA, and release hardening (Phase 22)**: Runs across Phases 18-21 before broader production/payment rollout
 - **Location-aware optimization (Phase 23)**: Depends on Phase 20 solver separation/explainability and Phase 15 establishment data; must complete before local optimization is marketed as proximity-aware
 - **UI/UX alignment (Phase 24)**: Depends on Phases 20-23 so the implemented product, explanation payloads, and location direction can drive the final web/mobile experience
+- **Public performance and rich demo data (Phase 25)**: Can run alongside Phase 24, but seed expansion should avoid changing production behavior outside demo/test data and performance fixes must preserve public API contracts
 
 ### User Story Dependencies
 
@@ -554,7 +576,8 @@ rules into implementation tasks against the real product.
 - Phase 20 optimization tests can run before solver refactor as the red phase for the operations-research implementation
 - Phase 22 security checklists and E2E scaffolding can run in parallel with billing and receipt work
 - Phase 23 documentation/contracts, backend distance tests, and web/mobile design work can run in parallel after the mode names and privacy constraints are accepted
-- Phase 24 audit and token mapping are complete; next implementation should start with the shopper-flow lane and trust/evidence modules before broad visual refactors
+- Phase 24 audit and token mapping are complete; next implementation should start with the shopper-flow lane, trust/evidence modules, offer grouping, and performance profiling before broad visual refactors
+- Phase 25 performance profiling and seed expansion can run in parallel with Phase 24 UI work because they touch mostly `web/e2e/`, `web/src/app/`, and `backend/prisma/seed.js`
 
 ---
 
@@ -582,6 +605,7 @@ rules into implementation tasks against the real product.
 8. Improve optimization explainability and receipt incentives after monetization foundations are safe
 9. Add Phase 23 location-aware optimization before claiming local results are based on nearby establishments
 10. Run Phase 24 UI/UX alignment before treating the MVP as a polished product surface
+11. Run Phase 25 performance and seed realism before using homolog as a serious product-review or investor-demo environment
 
 ### Parallel Team Strategy
 
@@ -591,7 +615,8 @@ With multiple contributors:
 2. One contributor focuses on backend catalog/region/admin modules
 3. One contributor focuses on web/mobile integration against stabilized contracts
 4. For Phases 18-23, split work into entitlement/billing, optimization science, receipt quality, location/privacy, frontend UX, and security/QA lanes
-5. For Phase 24, split work into audit/design tokens, public web, admin web, mobile, and visual validation lanes
+5. For Phase 24, split work into audit/design tokens, shopper flow, trust evidence, offer discovery, admin readability, mobile, and visual validation lanes
+6. For Phase 25, split work into performance profiling, public web load fixes, responsive QA, seed catalog/city/offer expansion, and seed receipt/queue scenarios
 
 ---
 
@@ -600,6 +625,6 @@ With multiple contributors:
 - Total tasks are ordered for execution, not just grouped by subsystem
 - Every user story remains independently testable
 - File paths are intentionally explicit so the task list is immediately executable
-- Suggested next execution scope: T180-T182, covering shopper-flow narrative, shopper trust evidence, and admin decision evidence before broad visual refactors
+- Suggested next execution scope: T180-T181 and T193, covering shopper-flow narrative, shopper trust evidence, and public URL performance profiling before broad visual refactors
 - Do not start Phase 19 Stripe work before Phase 18 token-ledger tests pass
 - Do not connect receipt rewards to the token ledger until T162 is explicitly unlocked


### PR DESCRIPTION
## Summary
- Adds planning for checklist price mismatch reports, list completion, optional paid total, and receipt handoff
- Adds public performance investigation, mobile responsiveness, richer seed data, city activation placeholders, grouped offer comparisons, premium copy, and admin readability scope
- Extends location planning with address/CEP, coordinates, and geocoding metadata

## Validation
- git diff --check