### PR TITLE
Serve homolog web as production build

### DIFF
--- a/.github/workflows/deploy-homolog-server.yml
+++ b/.github/workflows/deploy-homolog-server.yml
@@ -224,7 +224,7 @@ jobs:
           docker compose --env-file .env up -d --force-recreate backend web
           docker compose --env-file .env ps
           docker compose --env-file .env exec -T web sh -lc \
-            "printenv | sort | grep -E '^(VITE_|NODE_ENV)'; sed -n '1,35p' vite.config.ts" </dev/null
+            "printenv | sort | grep -E '^(VITE_|NODE_ENV)'; test -d dist && sed -n '1,20p' dist/index.html" </dev/null
           docker image prune -f
           ENDSSH
 

--- a/docker-compose.homolog.yml
+++ b/docker-compose.homolog.yml
@@ -94,7 +94,12 @@ services:
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:3000}
       VITE_ALLOWED_HOSTS: ${VITE_ALLOWED_HOSTS:-pricely.grmeireles.dev}
       VITE_ALLOW_ALL_HOSTS: ${VITE_ALLOW_ALL_HOSTS:-true}
-    command: ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]
+    command:
+      [
+        "sh",
+        "-lc",
+        "npm run build && npm run preview -- --host 0.0.0.0 --port 5173",
+      ]
     ports:
       - "${WEB_PORT:-5173}:5173"
 

--- a/docs/product/stitch-ui-ux-alignment.md
+++ b/docs/product/stitch-ui-ux-alignment.md
@@ -231,6 +231,13 @@ Required behavior:
 The public URL is perceived as slow. Treat performance as a product requirement, not
 only infrastructure.
 
+Initial measurement on 2026-05-10 found the public homolog URL serving Vite dev assets
+(`@vite/client`, `@react-refresh`, `/src/*`, and `/node_modules/.vite/*`). The observed
+first contentful paint was about 4.7s with roughly 60 module requests before the page
+became usable. The first production fix is to serve the web container with
+`npm run build` plus `vite preview` and keep an opt-in Playwright check that fails if
+development assets appear on the public URL again.
+
 Investigation targets:
 
 - initial JS bundle size and route-level code splitting

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,4 +9,4 @@ COPY . .
 
 EXPOSE 5173
 
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]
+CMD ["sh", "-lc", "npm run build && npm run preview -- --host 0.0.0.0 --port 5173"]

--- a/web/e2e/public-performance.spec.ts
+++ b/web/e2e/public-performance.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+
+const publicUrl = process.env.PRICELY_PUBLIC_PERF_URL;
+
+test.skip(
+  !publicUrl,
+  'Set PRICELY_PUBLIC_PERF_URL to run public deployment performance checks.',
+);
+
+test('public deployment is served as a production build', async ({ page }) => {
+  const developmentAssets: string[] = [];
+  const criticalApiDurations: Array<{ url: string; duration: number }> = [];
+
+  page.on('requestfinished', (request) => {
+    const url = request.url();
+
+    if (
+      url.includes('/@vite/client') ||
+      url.includes('/@react-refresh') ||
+      url.includes('/node_modules/.vite/') ||
+      url.includes('/src/')
+    ) {
+      developmentAssets.push(url);
+    }
+
+    if (url.includes('apipricely.grmeireles.dev')) {
+      const timing = request.timing();
+      criticalApiDurations.push({
+        url,
+        duration: timing.responseEnd - timing.startTime,
+      });
+    }
+  });
+
+  await page.goto(publicUrl!, { waitUntil: 'networkidle' });
+
+  const navigation = await page.evaluate(() => {
+    const entry = performance.getEntriesByType(
+      'navigation',
+    )[0] as PerformanceNavigationTiming;
+    const firstContentfulPaint =
+      performance.getEntriesByName('first-contentful-paint')[0]?.startTime ?? 0;
+
+    return {
+      domContentLoaded: entry.domContentLoadedEventEnd,
+      load: entry.loadEventEnd,
+      firstContentfulPaint,
+    };
+  });
+
+  expect(developmentAssets, 'public deploy must not serve Vite dev assets').toEqual(
+    [],
+  );
+  expect(
+    navigation.firstContentfulPaint,
+    `FCP ${Math.round(navigation.firstContentfulPaint)}ms`,
+  ).toBeLessThan(3_000);
+  expect(
+    Math.max(0, ...criticalApiDurations.map((entry) => entry.duration)),
+    'critical API calls should stay responsive',
+  ).toBeLessThan(1_500);
+});

--- a/web/src/routes/app-router.tsx
+++ b/web/src/routes/app-router.tsx
@@ -1,9 +1,168 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, type RouteObject } from 'react-router-dom';
 
-import { dashboardRoute } from './dashboard';
-import { publicRoute } from './public';
+const publicChildren: RouteObject[] = [
+  {
+    index: true,
+    lazy: async () => {
+      const { LandingPage } = await import('@/public/public-pages');
+      return { Component: LandingPage };
+    },
+  },
+  {
+    path: 'ofertas',
+    lazy: async () => {
+      const { OffersPage } = await import('@/public/public-pages');
+      return { Component: OffersPage };
+    },
+  },
+  {
+    path: 'ofertas/:offerId',
+    lazy: async () => {
+      const { OfferDetailPage } = await import('@/public/public-pages');
+      return { Component: OfferDetailPage };
+    },
+  },
+  {
+    path: 'cidades',
+    lazy: async () => {
+      const { CitiesPage } = await import('@/public/public-pages');
+      return { Component: CitiesPage };
+    },
+  },
+  {
+    path: 'entrar',
+    lazy: async () => {
+      const { SignInPage } = await import('@/public/public-pages');
+      return { Component: SignInPage };
+    },
+  },
+  {
+    path: 'criar-conta',
+    lazy: async () => {
+      const { SignUpPage } = await import('@/public/public-pages');
+      return { Component: SignUpPage };
+    },
+  },
+  {
+    path: 'listas',
+    lazy: async () => {
+      const { ListsPage } = await import('@/public/public-pages');
+      return { Component: ListsPage };
+    },
+  },
+  {
+    path: 'listas/:listId',
+    lazy: async () => {
+      const { ListEditorPage } = await import('@/public/public-pages');
+      return { Component: ListEditorPage };
+    },
+  },
+  {
+    path: 'listas/:listId/checklist',
+    lazy: async () => {
+      const { ChecklistPage } = await import('@/public/public-pages');
+      return { Component: ChecklistPage };
+    },
+  },
+  {
+    path: 'otimizacao/:listId',
+    lazy: async () => {
+      const { OptimizationPage } = await import('@/public/public-pages');
+      return { Component: OptimizationPage };
+    },
+  },
+];
+
+const dashboardChildren: RouteObject[] = [
+  {
+    index: true,
+    lazy: async () => {
+      const { AdminOverviewPage } = await import('@/dashboard/dashboard-pages');
+      return { Component: AdminOverviewPage };
+    },
+  },
+  {
+    path: 'regioes',
+    lazy: async () => {
+      const { AdminRegionsPage } = await import('@/dashboard/dashboard-pages');
+      return { Component: AdminRegionsPage };
+    },
+  },
+  {
+    path: 'estabelecimentos',
+    lazy: async () => {
+      const { AdminEstablishmentsPage } = await import(
+        '@/dashboard/dashboard-pages'
+      );
+      return { Component: AdminEstablishmentsPage };
+    },
+  },
+  {
+    path: 'produtos',
+    lazy: async () => {
+      const { AdminCatalogPage } = await import('@/dashboard/dashboard-pages');
+      return { Component: AdminCatalogPage };
+    },
+  },
+  {
+    path: 'ofertas',
+    lazy: async () => {
+      const { AdminOffersPage } = await import('@/dashboard/dashboard-pages');
+      return { Component: AdminOffersPage };
+    },
+  },
+  {
+    path: 'listas',
+    lazy: async () => {
+      const { AdminListsPage } = await import('@/dashboard/dashboard-pages');
+      return { Component: AdminListsPage };
+    },
+  },
+  {
+    path: 'fila',
+    lazy: async () => {
+      const { AdminQueuePage } = await import('@/dashboard/dashboard-pages');
+      return { Component: AdminQueuePage };
+    },
+  },
+  {
+    path: 'fila/:jobId',
+    lazy: async () => {
+      const { AdminQueueDetailPage } = await import('@/dashboard/dashboard-pages');
+      return { Component: AdminQueueDetailPage };
+    },
+  },
+  {
+    path: 'precos',
+    lazy: async () => {
+      const { AdminOffersPage } = await import('@/dashboard/dashboard-pages');
+      return { Component: AdminOffersPage };
+    },
+  },
+  {
+    path: 'catalogo',
+    lazy: async () => {
+      const { AdminCatalogPage } = await import('@/dashboard/dashboard-pages');
+      return { Component: AdminCatalogPage };
+    },
+  },
+];
 
 export const appRouter = createBrowserRouter([
-  publicRoute,
-  dashboardRoute,
+  {
+    path: '/',
+    lazy: async () => {
+      const { PublicLayout } = await import('@/public/public-shell');
+      return { Component: PublicLayout };
+    },
+    children: publicChildren,
+  },
+  {
+    path: '/dashboard',
+    lazy: async () => {
+      const { AdminLayout } = await import('@/dashboard/admin-shell');
+      return { Component: AdminLayout };
+    },
+    children: dashboardChildren,
+  },
 ]);


### PR DESCRIPTION
## Summary
- Switches the homolog web container from Vite dev server to production build + preview serving
- Adds route-level lazy loading so public landing no longer imports dashboard code in the initial bundle
- Adds an opt-in Playwright public performance guard for deployed URLs
- Records the initial public performance finding in the UX alignment plan

## Validation
- npm --prefix web run build
- npm --prefix web run lint
- npm --prefix web run e2e -- public-performance.spec.ts
- npm --prefix web run e2e -- mvp-smoke.spec.ts
- git diff --check