### PR TITLE
Wait for homolog web preview readiness

### DIFF
--- a/.github/workflows/deploy-homolog-server.yml
+++ b/.github/workflows/deploy-homolog-server.yml
@@ -223,8 +223,23 @@ jobs:
 
           docker compose --env-file .env up -d --force-recreate backend web
           docker compose --env-file .env ps
+
+          echo "Waiting for web preview..."
+          for attempt in $(seq 1 30); do
+            if docker compose --env-file .env exec -T web sh -lc \
+              "test -f dist/index.html && node -e \"fetch('http://127.0.0.1:5173').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))\"" </dev/null; then
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "Web preview did not become ready"
+              docker compose --env-file .env logs --tail=120 web
+              exit 1
+            fi
+            sleep 5
+          done
+
           docker compose --env-file .env exec -T web sh -lc \
-            "printenv | sort | grep -E '^(VITE_|NODE_ENV)'; test -d dist && sed -n '1,20p' dist/index.html" </dev/null
+            "printenv | sort | grep -E '^(VITE_|NODE_ENV)'; sed -n '1,20p' dist/index.html" </dev/null
           docker image prune -f
           ENDSSH
 

--- a/docker-compose.homolog.yml
+++ b/docker-compose.homolog.yml
@@ -100,6 +100,16 @@ services:
         "-lc",
         "npm run build && npm run preview -- --host 0.0.0.0 --port 5173",
       ]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"fetch('http://127.0.0.1:5173').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 20s
     ports:
       - "${WEB_PORT:-5173}:5173"
 


### PR DESCRIPTION
## Summary
- wait until the web runtime build creates dist/index.html before reading it in deploy
- add a web container healthcheck against the Vite preview server
- print web env and built index only after preview is reachable

## Validation
- git diff --check
- docker compose -f docker-compose.homolog.yml config --quiet