### PR TITLE
Add responsive QA coverage

### DIFF
--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -519,7 +519,7 @@ be tested deeply.
 
 - [X] T193 Profile the public `https://pricely.grmeireles.dev/` load path with Lighthouse or Playwright navigation timing, capturing LCP, TTI, JS payload, critical API latency, image timing, and Cloudflare/API response timing in `web/e2e/` and `docs/product/stitch-ui-ux-alignment.md`
 - [X] T194 Reduce public landing and shell load latency by auditing bundle size, route-level loading, context fetch waterfalls, image dimensions/weights, skeleton states, and unnecessary initial API calls in `web/src/public/`, `web/src/app/`, and `web/src/routes/`
-- [ ] T195 Add mobile responsiveness QA for landing, city chooser, offers, offer comparison, list editor, optimization result, checklist, profile/entitlement, admin tables, and auth screens in `web/e2e/` and `web/src/`
+- [X] T195 Add mobile responsiveness QA for landing, city chooser, offers, offer comparison, list editor, optimization result, checklist, profile/entitlement, admin tables, and auth screens in `web/e2e/` and `web/src/`
 - [X] T196 Expand seed data with additional cities across active, activating, and collecting-data states in `backend/prisma/seed.js`
 - [X] T197 Expand seed data with more establishments per active city, including CNPJ, neighborhood, address/CEP, and future-ready latitude/longitude placeholders in `backend/prisma/seed.js`
 - [~] T198 Expand seed data with broader catalog products, variants, package sizes, images, aliases, categories, and enough repeated comparable products to stress product/variant management in `backend/prisma/seed.js`

--- a/web/e2e/responsive-qa.spec.ts
+++ b/web/e2e/responsive-qa.spec.ts
@@ -1,0 +1,382 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const region = {
+  id: 'sao-paulo-sp',
+  slug: 'sao-paulo-sp',
+  name: 'Sao Paulo',
+  stateCode: 'SP',
+  implantationStatus: 'active',
+  activeEstablishmentCount: 2,
+  offerCoverageStatus: 'live',
+};
+
+const list = {
+  id: 'list-1',
+  name: 'Compra responsiva',
+  preferredRegionId: 'sao-paulo-sp',
+  status: 'ready',
+  lastMode: 'global_full',
+  latestEstimatedSavings: 12.4,
+  latestOptimizationStatus: 'completed',
+  latestOptimizedAt: '2026-05-10T10:00:00.000Z',
+  createdAt: '2026-05-10T09:00:00.000Z',
+  updatedAt: '2026-05-10T10:00:00.000Z',
+  items: [
+    {
+      id: 'item-1',
+      requestedName: 'Cafe torrado 500g',
+      catalogProductId: 'catalog-1',
+      brandPreferenceMode: 'any',
+      preferredBrandNames: [],
+      imageUrl: '/uploads/cafe.png',
+      quantity: 1,
+      unitLabel: 'un',
+      purchaseStatus: 'pending',
+      resolutionStatus: 'matched',
+    },
+  ],
+};
+
+const offer = {
+  id: 'offer-1',
+  catalogProductId: 'catalog-1',
+  productVariantId: 'variant-1',
+  productName: 'Cafe torrado',
+  variantName: 'Cafe Pilao 500g',
+  displayName: 'Cafe Pilao 500g',
+  imageUrl: '/uploads/cafe.png',
+  packageLabel: '500 g',
+  priceAmount: 15.9,
+  basePriceAmount: 18.9,
+  promotionalPriceAmount: 15.9,
+  savingsVsRegionalAverage: 1.2,
+  sourceLabel: 'Seed responsivo',
+  observedAt: '2026-05-10T08:00:00.000Z',
+  storeName: 'Mercado Centro',
+  neighborhood: 'Centro',
+  confidenceLevel: 'high',
+};
+
+async function mockResponsiveApi(page: Page) {
+  await page.route('http://localhost:3000/**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+    const method = request.method();
+    const authHeader = request.headers().authorization ?? '';
+
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({
+        status,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      });
+
+    if (path === '/regions') {
+      return json([
+        region,
+        {
+          id: 'campinas-sp',
+          slug: 'campinas-sp',
+          name: 'Campinas',
+          stateCode: 'SP',
+          implantationStatus: 'activating',
+          activeEstablishmentCount: 0,
+          offerCoverageStatus: 'collecting_data',
+        },
+      ]);
+    }
+
+    if (path === '/regions/impact') {
+      return json({ totalEstimatedSavings: 450, optimizedListsCount: 32 });
+    }
+
+    if (path === '/regions/sao-paulo-sp/offers') {
+      return json({
+        region,
+        activeEstablishmentCount: 2,
+        offerCoverageStatus: 'live',
+        offers: [offer],
+        groupedOffers: [
+          {
+            id: 'variant-1',
+            catalogProductId: 'catalog-1',
+            productVariantId: 'variant-1',
+            productName: 'Cafe torrado',
+            variantName: 'Cafe Pilao 500g',
+            imageUrl: '/uploads/cafe.png',
+            packageLabel: '500 g',
+            bestOffer: offer,
+            alternativeOffers: [],
+            offers: [offer],
+            establishmentCount: 1,
+            cheapestPriceAmount: 15.9,
+            averagePriceAmount: 15.9,
+            highestPriceAmount: 15.9,
+          },
+        ],
+      });
+    }
+
+    if (path === '/auth/me') {
+      const isAdmin = authHeader.includes('admin-token');
+      return json({
+        id: isAdmin ? 'admin-1' : 'user-1',
+        email: isAdmin ? 'admin@pricely.test' : 'cliente@pricely.test',
+        displayName: isAdmin ? 'Admin Pricely' : 'Cliente Pricely',
+        role: isAdmin ? 'admin' : 'customer',
+        preferredRegionSlug: 'sao-paulo-sp',
+        profileStats: {
+          totalEstimatedSavings: 12.4,
+          shoppingListsCount: 1,
+          completedOptimizationRuns: 1,
+          contributionsCount: 0,
+          receiptSubmissionsCount: 0,
+          offerReportsCount: 0,
+        },
+        entitlement: {
+          plan: isAdmin ? 'premium' : 'free',
+          status: 'active',
+          availableOptimizationTokens: isAdmin ? 99 : 2,
+          monthlyFreeOptimizationTokens: 2,
+          billingEnabled: false,
+          checkoutEnabled: false,
+        },
+      });
+    }
+
+    if (path === '/shopping-lists' && method === 'GET') {
+      return json([list]);
+    }
+
+    if (path === '/shopping-lists/list-1') {
+      return json(list);
+    }
+
+    if (path === '/shopping-lists/list-1/optimizations/latest') {
+      return json({
+        id: 'run-1',
+        shoppingListId: 'list-1',
+        mode: 'global_full',
+        status: 'completed',
+        totalEstimatedCost: 15.9,
+        estimatedSavings: 1.2,
+        coverageStatus: 'complete',
+        explanationSummary: 'Oferta confirmada com dados recentes.',
+        createdAt: '2026-05-10T10:00:00.000Z',
+        completedAt: '2026-05-10T10:00:02.000Z',
+        selections: [
+          {
+            id: 'selection-1',
+            shoppingListItemId: 'item-1',
+            shoppingListItemName: 'Cafe torrado 500g',
+            selectedVariantName: 'Cafe Pilao 500g',
+            selectedPackageLabel: '500 g',
+            establishmentName: 'Mercado Centro',
+            establishmentNeighborhood: 'Centro',
+            estimatedCost: 15.9,
+            priceAmount: 15.9,
+            regionalAveragePriceAmount: 17.1,
+            savingsVsComparison: 1.2,
+            sourceLabel: 'Seed responsivo',
+            observedAt: '2026-05-10T08:00:00.000Z',
+            trustFactor: 82,
+            trustLevel: 'high',
+            trustEvidenceCount: 2,
+            trustFreshnessDays: 1,
+            selectionStatus: 'selected',
+            decisionReason: 'selected_confirmed_offer',
+          },
+        ],
+      });
+    }
+
+    if (path === '/admin/metrics') {
+      return json({
+        activeUsers: 12,
+        shoppingListsCount: 8,
+        optimizationRunsCount: 5,
+        activeRegions: 1,
+        activeEstablishments: 2,
+        activeOffers: 20,
+        productCount: 10,
+        queuedJobs: 1,
+        globalEstimatedSavings: 450,
+      });
+    }
+
+    if (path === '/admin/queue-health') {
+      return json({
+        queuedJobs: 1,
+        runningJobs: 0,
+        failedJobs: 0,
+        completedJobs: 3,
+        jobsByStatus: { queued: 1, completed: 3 },
+        queues: ['optimization'],
+        recentFailures: [],
+      });
+    }
+
+    if (path === '/admin/processing-jobs') {
+      return json([
+        {
+          id: 'job-1',
+          queueName: 'optimization',
+          jobType: 'optimization.run',
+          resourceType: 'shopping_list',
+          resourceId: 'list-1',
+          status: 'completed',
+          attemptCount: 1,
+          createdAt: '2026-05-10T10:00:00.000Z',
+          updatedAt: '2026-05-10T10:03:00.000Z',
+          finishedAt: '2026-05-10T10:03:00.000Z',
+          owner: {
+            id: 'user-1',
+            displayName: 'Cliente Pricely',
+            email: 'cliente@pricely.test',
+          },
+          shoppingList: { id: 'list-1', name: 'Compra responsiva' },
+          optimizationRun: {
+            id: 'run-1',
+            mode: 'global_full',
+            status: 'completed',
+            createdAt: '2026-05-10T10:00:00.000Z',
+            completedAt: '2026-05-10T10:03:00.000Z',
+          },
+        },
+      ]);
+    }
+
+    if (path === '/admin/catalog-products') {
+      return json([
+        {
+          id: 'catalog-1',
+          slug: 'cafe-torrado',
+          name: 'Cafe torrado',
+          category: 'mercearia',
+          defaultUnit: 'un',
+          imageUrl: null,
+          isActive: true,
+          aliases: [{ id: 'alias-1', alias: 'cafe' }],
+          productVariants: [],
+          _count: { productOffers: 1 },
+        },
+      ]);
+    }
+
+    if (path === '/admin/product-variants') {
+      return json([
+        {
+          id: 'variant-1',
+          catalogProductId: 'catalog-1',
+          slug: 'cafe-pilao-500g',
+          displayName: 'Cafe Pilao 500g',
+          brandName: 'Pilao',
+          variantLabel: null,
+          packageLabel: '500 g',
+          imageUrl: '/uploads/cafe.png',
+          isActive: true,
+        },
+      ]);
+    }
+
+    if (path === '/admin/offers') {
+      return json([]);
+    }
+
+    return json({ message: `Unhandled ${method} ${path}` }, 404);
+  });
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () =>
+          document.documentElement.scrollWidth <=
+          document.documentElement.clientWidth + 1,
+      ),
+    )
+    .toBe(true);
+}
+
+for (const viewport of [
+  { name: 'mobile', width: 390, height: 844 },
+  { name: 'desktop', width: 1366, height: 900 },
+]) {
+  test.describe(`responsive QA ${viewport.name}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.setViewportSize(viewport);
+      await mockResponsiveApi(page);
+      await page.addInitScript(() => {
+        window.localStorage.setItem(
+          'pricely-web-state-v2',
+          JSON.stringify({ cityId: 'sao-paulo-sp' }),
+        );
+      });
+    });
+
+    test('keeps public shopper surfaces usable without horizontal overflow', async ({
+      page,
+    }) => {
+      await page.addInitScript(() => {
+        window.localStorage.setItem('pricely-auth-token', 'customer-token');
+      });
+
+      await page.goto('/');
+      await expect(
+        page.getByRole('heading', {
+          name: 'Decida sua compra por cidade, lista e preço observado.',
+        }),
+      ).toBeVisible();
+      await expectNoHorizontalOverflow(page);
+
+      await page.goto('/cidades');
+      await expect(
+        page.getByRole('heading', { name: 'Cidades suportadas' }),
+      ).toBeVisible();
+      await expect(page.getByText(/Campinas/)).toBeVisible();
+      await expectNoHorizontalOverflow(page);
+
+      await page.goto('/ofertas');
+      await expect(page.getByText('Filtro por estabelecimento')).toBeVisible();
+      await expect(page.getByText('Cafe Pilao 500g').first()).toBeVisible();
+      await expectNoHorizontalOverflow(page);
+
+      await page.goto('/listas');
+      await expect(page.getByText('Compra responsiva')).toBeVisible();
+      await expectNoHorizontalOverflow(page);
+
+      await page.goto('/listas/list-1/checklist');
+      await expect(
+        page.getByRole('heading', { name: 'Checklist de compra' }),
+      ).toBeVisible();
+      await expectNoHorizontalOverflow(page);
+
+      await page.goto('/otimizacao/list-1');
+      await expect(page.getByText('Decisões por item')).toBeVisible();
+      await expect(
+        page.getByText(/Selecionado: Cafe Pilao 500g/),
+      ).toBeVisible();
+      await expectNoHorizontalOverflow(page);
+    });
+
+    test('keeps admin tables and operations readable without horizontal overflow', async ({
+      page,
+    }) => {
+      await page.addInitScript(() => {
+        window.localStorage.setItem('pricely-auth-token', 'admin-token');
+      });
+
+      await page.goto('/dashboard/fila');
+      await expect(page.getByText('Lista: Compra responsiva')).toBeVisible();
+      await expect(page.getByLabel('Abrir detalhe do job job-1')).toBeVisible();
+      await expectNoHorizontalOverflow(page);
+
+      await page.goto('/dashboard/catalogo');
+      await expect(page.getByLabel('Buscar no catalogo')).toBeVisible();
+      await expect(page.getByText('1 variantes')).toBeVisible();
+      await expectNoHorizontalOverflow(page);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add Playwright responsive QA for mobile and desktop public shopper surfaces
- cover city chooser, grouped offers, lists, checklist, optimization decisions, admin queue, and admin catalog
- assert key pages avoid document-level horizontal overflow

## Validation
- npm --prefix web run e2e -- responsive-qa.spec.ts
- npm --prefix web run lint
- npm --prefix web run build
- git diff --check