### PR TITLE
Add admin user entitlement controls

### DIFF
--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -5,6 +5,7 @@ import { EstablishmentsModule } from '../establishments/establishments.module';
 import { PrismaModule } from '../persistence/prisma.module';
 import { PricingModule } from '../pricing/pricing.module';
 import { RegionsModule } from '../regions/regions.module';
+import { UsersModule } from '../users/users.module';
 import { AdminDashboardService } from './application/admin-dashboard.service';
 import { AdminDashboardController } from './api/admin-dashboard.controller';
 import { AdminAccessController } from './admin-access.controller';
@@ -17,6 +18,7 @@ import { AdminAccessController } from './admin-access.controller';
     CatalogModule,
     PricingModule,
     RegionsModule,
+    UsersModule,
   ],
   providers: [AdminDashboardService],
   controllers: [AdminAccessController, AdminDashboardController],

--- a/backend/src/admin/api/admin-dashboard.controller.ts
+++ b/backend/src/admin/api/admin-dashboard.controller.ts
@@ -5,12 +5,13 @@ import {
   Param,
   Patch,
   Post,
+  Req,
   UploadedFile,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { IsBoolean, IsIn, IsNumber, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+import { IsBoolean, IsIn, IsInt, IsNumber, IsOptional, IsString, MaxLength, Min } from 'class-validator';
 
 import { JwtAuthGuard } from '../../common/auth/jwt-auth.guard';
 import { Roles } from '../../common/auth/roles.decorator';
@@ -21,6 +22,12 @@ type UploadedMediaFile = {
   originalname: string;
   mimetype: string;
   buffer: Buffer;
+};
+
+type AuthenticatedAdminRequest = {
+  user: {
+    id: string;
+  };
 };
 
 class CreateRegionDto {
@@ -321,6 +328,21 @@ class UpdateOfferDto {
   isActive?: boolean;
 }
 
+class UpdateUserPremiumDto {
+  @IsBoolean()
+  enabled!: boolean;
+}
+
+class GrantUserTokensDto {
+  @IsInt()
+  @Min(1)
+  amount!: number;
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}
+
 @Controller('admin')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles('admin')
@@ -350,6 +372,37 @@ export class AdminDashboardController {
   @Get('shopping-lists')
   async listShoppingListAudits() {
     return this.adminDashboardService.listShoppingListAudits();
+  }
+
+  @Get('users')
+  async listUsers() {
+    return this.adminDashboardService.listUsers();
+  }
+
+  @Patch('users/:id/premium')
+  async setUserPremium(
+    @Param('id') id: string,
+    @Body() body: UpdateUserPremiumDto,
+    @Req() request: AuthenticatedAdminRequest,
+  ) {
+    return this.adminDashboardService.setUserPremium(
+      id,
+      body,
+      request.user.id,
+    );
+  }
+
+  @Post('users/:id/tokens')
+  async grantUserTokens(
+    @Param('id') id: string,
+    @Body() body: GrantUserTokensDto,
+    @Req() request: AuthenticatedAdminRequest,
+  ) {
+    return this.adminDashboardService.grantUserOptimizationTokens(
+      id,
+      body,
+      request.user.id,
+    );
   }
 
   @Get('regions')

--- a/backend/src/admin/application/admin-dashboard.service.ts
+++ b/backend/src/admin/application/admin-dashboard.service.ts
@@ -6,6 +6,7 @@ import { EstablishmentsService } from '../../establishments/application/establis
 import { PrismaService } from '../../persistence/prisma.service';
 import { OfferManagementService } from '../../pricing/application/offer-management.service';
 import { RegionsAdminService } from '../../regions/application/regions-admin.service';
+import { EntitlementsService } from '../../users/entitlements.service';
 
 @Injectable()
 export class AdminDashboardService {
@@ -18,6 +19,7 @@ export class AdminDashboardService {
     private readonly catalogProductsService: CatalogProductsService,
     private readonly catalogMediaService: CatalogMediaService,
     private readonly offerManagementService: OfferManagementService,
+    private readonly entitlementsService: EntitlementsService,
   ) {}
 
   async getMetrics() {
@@ -436,6 +438,168 @@ export class AdminDashboardService {
     );
 
     return projected;
+  }
+
+  async listUsers(userIds?: string[]) {
+    const users = await this.prisma.userAccount.findMany({
+      where: userIds?.length
+        ? {
+            id: {
+              in: userIds,
+            },
+          }
+        : undefined,
+      orderBy: [{ updatedAt: 'desc' }, { createdAt: 'desc' }],
+      take: 100,
+      include: {
+        preferredRegion: {
+          select: {
+            id: true,
+            slug: true,
+            name: true,
+            stateCode: true,
+          },
+        },
+        entitlements: {
+          orderBy: [{ createdAt: 'desc' }],
+          take: 1,
+        },
+        optimizationRuns: {
+          orderBy: [{ createdAt: 'desc' }],
+          take: 1,
+          select: {
+            id: true,
+            mode: true,
+            status: true,
+            createdAt: true,
+            completedAt: true,
+          },
+        },
+        _count: {
+          select: {
+            shoppingLists: true,
+            optimizationRuns: true,
+            receiptRecords: true,
+            priceMismatchReports: true,
+          },
+        },
+      },
+    });
+
+    const tokenBalances = await this.prisma.optimizationTokenLedgerEntry.groupBy({
+      by: ['userId'],
+      where: {
+        userId: {
+          in: users.map((user) => user.id),
+        },
+        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+      },
+      _sum: {
+        amount: true,
+      },
+    });
+    const tokenBalanceByUser = new Map(
+      tokenBalances.map((entry) => [
+        entry.userId,
+        Number(entry._sum.amount ?? 0),
+      ]),
+    );
+
+    return users.map((user) => {
+      const latestEntitlement = user.entitlements[0];
+      const hasActivePremium =
+        latestEntitlement?.plan === 'premium' &&
+        ['active', 'trialing'].includes(latestEntitlement.status) &&
+        (!latestEntitlement.endsAt || latestEntitlement.endsAt > new Date());
+      const latestOptimization = user.optimizationRuns[0];
+
+      return {
+        id: user.id,
+        email: user.email,
+        displayName: user.displayName,
+        role: user.role,
+        status: user.status,
+        preferredRegion: user.preferredRegion,
+        lastLoginAt: user.lastLoginAt?.toISOString(),
+        createdAt: user.createdAt.toISOString(),
+        updatedAt: user.updatedAt.toISOString(),
+        counts: {
+          shoppingLists: user._count.shoppingLists,
+          optimizationRuns: user._count.optimizationRuns,
+          receiptRecords: user._count.receiptRecords,
+          priceMismatchReports: user._count.priceMismatchReports,
+        },
+        entitlement: {
+          plan: hasActivePremium ? 'premium' : 'free',
+          status: latestEntitlement?.status ?? 'active',
+          source: latestEntitlement?.source ?? 'monthly_free_refill',
+          availableOptimizationTokens: hasActivePremium
+            ? null
+            : (tokenBalanceByUser.get(user.id) ?? 0),
+          monthlyFreeOptimizationTokens:
+            this.entitlementsService.monthlyFreeTokenCount(),
+          billingEnabled: false,
+          checkoutEnabled: false,
+          lastPaymentAt: null,
+          lastPaymentStatus: 'billing_disabled',
+        },
+        latestOptimization: latestOptimization
+          ? {
+              id: latestOptimization.id,
+              mode: latestOptimization.mode,
+              status: latestOptimization.status,
+              createdAt: latestOptimization.createdAt.toISOString(),
+              completedAt: latestOptimization.completedAt?.toISOString(),
+            }
+          : null,
+      };
+    });
+  }
+
+  async setUserPremium(
+    userId: string,
+    input: { enabled: boolean },
+    adminUserId: string,
+  ) {
+    await this.entitlementsService.setManualPremium({
+      userId,
+      enabled: input.enabled,
+      adminUserId,
+    });
+
+    this.logger.log(
+      `Admin ${adminUserId} ${input.enabled ? 'enabled' : 'disabled'} premium for user ${userId}`,
+    );
+
+    return this.getUserOrThrow(userId);
+  }
+
+  async grantUserOptimizationTokens(
+    userId: string,
+    input: { amount: number; reason?: string },
+    adminUserId: string,
+  ) {
+    await this.entitlementsService.grantAdminOptimizationTokens({
+      userId,
+      amount: input.amount,
+      reason: input.reason,
+      adminUserId,
+    });
+
+    this.logger.log(
+      `Admin ${adminUserId} granted ${input.amount} optimization tokens to user ${userId}`,
+    );
+
+    return this.getUserOrThrow(userId);
+  }
+
+  private async getUserOrThrow(userId: string) {
+    const [found] = await this.listUsers([userId]);
+    if (!found) {
+      throw new NotFoundException(`User ${userId} was not found`);
+    }
+
+    return found;
   }
 
   async listRegions() {

--- a/backend/src/common/contracts/admin.contract.ts
+++ b/backend/src/common/contracts/admin.contract.ts
@@ -47,3 +47,44 @@ export interface AdminShoppingListAuditContract {
     completedAt?: string;
   } | null;
 }
+
+export interface AdminUserContract {
+  id: string;
+  email: string;
+  displayName: string;
+  role: 'customer' | 'admin';
+  status: 'active' | 'suspended';
+  preferredRegion: {
+    id: string;
+    slug: string;
+    name: string;
+    stateCode: string;
+  } | null;
+  lastLoginAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  counts: {
+    shoppingLists: number;
+    optimizationRuns: number;
+    receiptRecords: number;
+    priceMismatchReports: number;
+  };
+  entitlement: {
+    plan: 'free' | 'premium';
+    status: 'active' | 'trialing' | 'past_due' | 'cancelled' | 'expired';
+    source: string;
+    availableOptimizationTokens: number | null;
+    monthlyFreeOptimizationTokens: number;
+    billingEnabled: false;
+    checkoutEnabled: false;
+    lastPaymentAt: string | null;
+    lastPaymentStatus: 'billing_disabled' | 'none' | 'paid' | 'failed';
+  };
+  latestOptimization: {
+    id: string;
+    mode: 'local' | 'global_unique' | 'global_full';
+    status: 'queued' | 'running' | 'completed' | 'failed';
+    createdAt: string;
+    completedAt?: string;
+  } | null;
+}

--- a/backend/src/users/entitlements.service.ts
+++ b/backend/src/users/entitlements.service.ts
@@ -1,4 +1,9 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  Injectable,
+} from '@nestjs/common';
 
 import { PrismaService } from '../persistence/prisma.service';
 
@@ -169,6 +174,79 @@ export class EntitlementsService {
         relatedOptimizationRunId: input.optimizationRunId,
       },
       update: {},
+    });
+  }
+
+  async setManualPremium(input: {
+    userId: string;
+    enabled: boolean;
+    adminUserId: string;
+  }) {
+    if (input.enabled) {
+      const existing = await this.prisma.userEntitlement.findFirst({
+        where: {
+          userId: input.userId,
+          plan: 'premium',
+          status: {
+            in: ['active', 'trialing'],
+          },
+          OR: [{ endsAt: null }, { endsAt: { gt: new Date() } }],
+        },
+      });
+
+      if (existing) {
+        return existing;
+      }
+
+      return this.prisma.userEntitlement.create({
+        data: {
+          userId: input.userId,
+          plan: 'premium',
+          status: 'active',
+          source: 'admin_manual',
+          externalRef: `admin:${input.adminUserId}`,
+        },
+      });
+    }
+
+    await this.prisma.userEntitlement.updateMany({
+      where: {
+        userId: input.userId,
+        plan: 'premium',
+        status: {
+          in: ['active', 'trialing', 'past_due'],
+        },
+      },
+      data: {
+        status: 'cancelled',
+        endsAt: new Date(),
+        externalRef: `admin:${input.adminUserId}:cancelled`,
+      },
+    });
+
+    return null;
+  }
+
+  async grantAdminOptimizationTokens(input: {
+    userId: string;
+    amount: number;
+    adminUserId: string;
+    reason?: string;
+  }) {
+    if (!Number.isInteger(input.amount) || input.amount <= 0) {
+      throw new BadRequestException('Token adjustment amount must be positive');
+    }
+
+    return this.prisma.optimizationTokenLedgerEntry.create({
+      data: {
+        userId: input.userId,
+        action: 'admin_adjustment',
+        amount: input.amount,
+        source: input.reason
+          ? `admin_adjustment:${input.reason}`
+          : 'admin_adjustment',
+        idempotencyKey: `admin-adjustment:${input.userId}:${input.adminUserId}:${Date.now()}`,
+      },
     });
   }
 

--- a/backend/test/unit/admin/admin-dashboard.service.spec.ts
+++ b/backend/test/unit/admin/admin-dashboard.service.spec.ts
@@ -6,7 +6,50 @@ describe('AdminDashboardService', () => {
   it('aggregates metrics, queue health, and processing job projections', async () => {
     const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
     const prisma = {
-      userAccount: { count: jest.fn().mockResolvedValue(12) },
+      userAccount: {
+        count: jest.fn().mockResolvedValue(12),
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'user-1',
+            email: 'cliente1@pricely.local',
+            displayName: 'Cliente 1',
+            role: 'customer',
+            status: 'active',
+            lastLoginAt: new Date('2026-04-27T08:00:00Z'),
+            createdAt: new Date('2026-04-20T08:00:00Z'),
+            updatedAt: new Date('2026-04-27T08:00:00Z'),
+            preferredRegion: {
+              id: 'region-1',
+              slug: 'sao-paulo-sp',
+              name: 'Sao Paulo',
+              stateCode: 'SP',
+            },
+            entitlements: [
+              {
+                plan: 'free',
+                status: 'active',
+                source: 'monthly_free_refill',
+                endsAt: null,
+              },
+            ],
+            optimizationRuns: [
+              {
+                id: 'run-1',
+                mode: 'global_full',
+                status: 'completed',
+                createdAt: new Date('2026-04-27T10:00:00Z'),
+                completedAt: new Date('2026-04-27T10:05:00Z'),
+              },
+            ],
+            _count: {
+              shoppingLists: 3,
+              optimizationRuns: 2,
+              receiptRecords: 1,
+              priceMismatchReports: 4,
+            },
+          },
+        ]),
+      },
       shoppingList: { count: jest.fn().mockResolvedValue(24) },
       optimizationRun: {
         count: jest.fn().mockResolvedValue(18),
@@ -142,6 +185,16 @@ describe('AdminDashboardService', () => {
           },
         ]),
       },
+      optimizationTokenLedgerEntry: {
+        groupBy: jest.fn().mockResolvedValue([
+          {
+            userId: 'user-1',
+            _sum: {
+              amount: 5,
+            },
+          },
+        ]),
+      },
       shoppingList: {
         count: jest.fn().mockResolvedValue(24),
         findMany: jest.fn().mockResolvedValue([
@@ -185,6 +238,11 @@ describe('AdminDashboardService', () => {
       {} as never,
       {} as never,
       {} as never,
+      {
+        monthlyFreeTokenCount: jest.fn().mockReturnValue(2),
+        setManualPremium: jest.fn(),
+        grantAdminOptimizationTokens: jest.fn(),
+      } as never,
     );
 
     await expect(service.getMetrics()).resolves.toEqual({
@@ -301,6 +359,29 @@ describe('AdminDashboardService', () => {
       }),
     ]);
 
+    await expect(service.listUsers()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'user-1',
+        email: 'cliente1@pricely.local',
+        counts: {
+          shoppingLists: 3,
+          optimizationRuns: 2,
+          receiptRecords: 1,
+          priceMismatchReports: 4,
+        },
+        entitlement: expect.objectContaining({
+          plan: 'free',
+          availableOptimizationTokens: 5,
+          billingEnabled: false,
+          lastPaymentStatus: 'billing_disabled',
+        }),
+        latestOptimization: expect.objectContaining({
+          id: 'run-1',
+          mode: 'global_full',
+        }),
+      }),
+    ]);
+
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining('Admin metrics generated'),
     );
@@ -336,6 +417,7 @@ describe('AdminDashboardService', () => {
       {} as never,
       {} as never,
       {} as never,
+      {} as never,
     );
 
     await service.createRegion({
@@ -359,5 +441,77 @@ describe('AdminDashboardService', () => {
     });
     expect(logSpy).toHaveBeenCalledWith('Admin created region campinas-sp (region-1)');
     expect(logSpy).toHaveBeenCalledWith('Admin updated region region-1');
+  });
+
+  it('delegates premium and token adjustments to entitlement service', async () => {
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    const prisma = {
+      userAccount: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'user-1',
+            email: 'cliente1@pricely.local',
+            displayName: 'Cliente 1',
+            role: 'customer',
+            status: 'active',
+            lastLoginAt: null,
+            createdAt: new Date('2026-04-20T08:00:00Z'),
+            updatedAt: new Date('2026-04-27T08:00:00Z'),
+            preferredRegion: null,
+            entitlements: [],
+            optimizationRuns: [],
+            _count: {
+              shoppingLists: 0,
+              optimizationRuns: 0,
+              receiptRecords: 0,
+              priceMismatchReports: 0,
+            },
+          },
+        ]),
+      },
+      optimizationTokenLedgerEntry: {
+        groupBy: jest.fn().mockResolvedValue([]),
+      },
+    };
+    const entitlementsService = {
+      monthlyFreeTokenCount: jest.fn().mockReturnValue(2),
+      setManualPremium: jest.fn().mockResolvedValue(null),
+      grantAdminOptimizationTokens: jest.fn().mockResolvedValue(null),
+    };
+
+    const service = new AdminDashboardService(
+      prisma as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      entitlementsService as never,
+    );
+
+    await service.setUserPremium('user-1', { enabled: true }, 'admin-1');
+    await service.grantUserOptimizationTokens(
+      'user-1',
+      { amount: 3, reason: 'suporte_admin' },
+      'admin-1',
+    );
+
+    expect(entitlementsService.setManualPremium).toHaveBeenCalledWith({
+      userId: 'user-1',
+      enabled: true,
+      adminUserId: 'admin-1',
+    });
+    expect(entitlementsService.grantAdminOptimizationTokens).toHaveBeenCalledWith({
+      userId: 'user-1',
+      amount: 3,
+      reason: 'suporte_admin',
+      adminUserId: 'admin-1',
+    });
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('enabled premium'),
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('granted 3 optimization tokens'),
+    );
   });
 });

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -529,6 +529,24 @@ be tested deeply.
 
 ---
 
+## Phase 26: MVP Finalization Decisions and Admin Operations
+
+**Purpose**: Finish the web/admin/backend MVP before mobile expansion or paid billing.
+Billing remains disabled until subscription/webhook validation is explicitly resumed.
+Premium access and extra optimization credits are support/admin operations for now.
+
+- [X] T202 Add admin user operations for list/location/optimization/receipt visibility, manual premium activation, disabled-billing payment state, and extra optimization-credit grants in `backend/src/admin/`, `backend/src/users/`, `backend/src/common/contracts/`, and `web/src/dashboard/`
+- [ ] T203 Extend location planning and implementation with user geolocation, establishment geolocation, CEP fallback, a default 5 km radius, and coverage preview before proximity claims in `backend/src/locations/`, `backend/src/users/`, `backend/src/establishments/`, and `web/src/public/`
+- [ ] T204 Rename optimization modes to descriptive user-facing semantics and keep API/backward-compatible aliases where needed in `backend/src/optimization/`, `backend/src/common/contracts/`, `web/src/public/`, and admin diagnostics
+- [ ] T205 Persist optimization-specific variant substitutions on the original list while preserving the original `any variant` intent so future optimizations can swap variants again in `backend/src/lists/`, `backend/src/optimization/`, and `web/src/public/`
+- [ ] T206 Update item decision math so savings compare selected offer against the second cheapest eligible offer, while city average remains a separate informational metric in `backend/src/optimization/`, `backend/src/common/contracts/optimization.contract.ts`, and `web/src/public/`
+- [ ] T207 Rename shopper-facing trust copy to `Confianca da oferta`, including source labels for admin/manual/receipt evidence, receipt support count, freshness decay, and clearer no-receipt wording in `backend/src/optimization/`, `backend/src/pricing/`, and `web/src/public/`
+- [ ] T208 Add gamified receipt contribution rewards with points and token outcomes only after receipt quality scoring confirms useful, correctly processed receipt data in `backend/src/receipts/`, `backend/src/users/`, and `web/src/public/`
+- [ ] T209 Add a dedicated admin receipt-processing queue/detail surface for receipt content, line-item quality, moderation status, and reward readiness in `backend/src/admin/` and `web/src/dashboard/`
+- [ ] T210 Add public city-request/contact flow while keeping city creation admin-only in `backend/src/regions/`, `backend/src/admin/`, and `web/src/public/`
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -434,6 +434,47 @@ type AdminShoppingListAuditResponse = {
   } | null;
 };
 
+type AdminUserResponse = {
+  id: string;
+  email: string;
+  displayName: string;
+  role: 'customer' | 'admin';
+  status: 'active' | 'suspended';
+  preferredRegion?: {
+    id: string;
+    slug: string;
+    name: string;
+    stateCode: string;
+  } | null;
+  lastLoginAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  counts: {
+    shoppingLists: number;
+    optimizationRuns: number;
+    receiptRecords: number;
+    priceMismatchReports: number;
+  };
+  entitlement: {
+    plan: 'free' | 'premium';
+    status: 'active' | 'trialing' | 'past_due' | 'cancelled' | 'expired';
+    source: string;
+    availableOptimizationTokens: number | null;
+    monthlyFreeOptimizationTokens: number;
+    billingEnabled: boolean;
+    checkoutEnabled: boolean;
+    lastPaymentAt: string | null;
+    lastPaymentStatus: 'billing_disabled' | 'none' | 'paid' | 'failed';
+  };
+  latestOptimization?: {
+    id: string;
+    mode: OptimizationModeId;
+    status: 'queued' | 'running' | 'completed' | 'failed';
+    createdAt: string;
+    completedAt?: string;
+  } | null;
+};
+
 type AdminEstablishmentResponse = {
   id: string;
   brandName: string;
@@ -807,6 +848,40 @@ export async function fetchAdminShoppingLists(token: string) {
   );
 }
 
+export async function fetchAdminUsers(token: string) {
+  return apiFetch<AdminUserResponse[]>('/admin/users', {}, token);
+}
+
+export async function setAdminUserPremium(
+  token: string,
+  id: string,
+  enabled: boolean,
+) {
+  return apiFetch<AdminUserResponse>(
+    `/admin/users/${id}/premium`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ enabled }),
+    },
+    token,
+  );
+}
+
+export async function grantAdminUserTokens(
+  token: string,
+  id: string,
+  input: { amount: number; reason?: string },
+) {
+  return apiFetch<AdminUserResponse>(
+    `/admin/users/${id}/tokens`,
+    {
+      method: 'POST',
+      body: JSON.stringify(input),
+    },
+    token,
+  );
+}
+
 export async function createAdminRegion(
   token: string,
   input: Record<string, unknown>,
@@ -1070,6 +1145,7 @@ export function mapShoppingList(
 
 export type {
   AdminShoppingListAuditResponse,
+  AdminUserResponse,
   AdminEstablishmentResponse,
   AdminMetricsResponse,
   AdminOfferResponse,

--- a/web/src/dashboard/admin-shell.tsx
+++ b/web/src/dashboard/admin-shell.tsx
@@ -9,6 +9,7 @@ import {
   ShieldCheckIcon,
   StoreIcon,
   SunMediumIcon,
+  UsersIcon,
   WorkflowIcon,
 } from 'lucide-react';
 
@@ -64,6 +65,11 @@ const adminNav = [
     to: '/dashboard/listas',
     label: 'Operacoes de listas',
     icon: ListChecksIcon,
+  },
+  {
+    to: '/dashboard/usuarios',
+    label: 'Usuarios',
+    icon: UsersIcon,
   },
   {
     to: '/dashboard/fila',

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -10,6 +10,7 @@ import {
   AdminPricesPage,
   AdminQueuePage,
   AdminRegionsPage,
+  AdminUsersPage,
 } from './dashboard-pages';
 
 const fetchAdminMetrics = vi.fn();
@@ -20,6 +21,9 @@ const fetchAdminEstablishments = vi.fn();
 const fetchAdminOffers = vi.fn();
 const fetchAdminProducts = vi.fn();
 const fetchAdminProductVariants = vi.fn();
+const fetchAdminUsers = vi.fn();
+const setAdminUserPremium = vi.fn();
+const grantAdminUserTokens = vi.fn();
 
 vi.mock('@/app/pricely-context', () => ({
   usePricely: () => ({
@@ -44,6 +48,9 @@ vi.mock('@/app/api', () => ({
   fetchAdminEstablishments: (...args: unknown[]) =>
     fetchAdminEstablishments(...args),
   fetchAdminShoppingLists: vi.fn(),
+  fetchAdminUsers: (...args: unknown[]) => fetchAdminUsers(...args),
+  setAdminUserPremium: (...args: unknown[]) => setAdminUserPremium(...args),
+  grantAdminUserTokens: (...args: unknown[]) => grantAdminUserTokens(...args),
   updateAdminRegion: vi.fn(),
   createAdminRegion: vi.fn(),
   createAdminEstablishment: vi.fn(),
@@ -70,6 +77,9 @@ describe('Admin dashboard pages', () => {
     fetchAdminOffers.mockReset();
     fetchAdminProducts.mockReset();
     fetchAdminProductVariants.mockReset();
+    fetchAdminUsers.mockReset();
+    setAdminUserPremium.mockReset();
+    grantAdminUserTokens.mockReset();
   });
 
   afterEach(() => {
@@ -331,5 +341,70 @@ describe('Admin dashboard pages', () => {
     render(<AdminEstablishmentsPage />);
     expect(await screen.findByText('Unidades por cidade')).toBeTruthy();
     expect(screen.getAllByText('Unidade Pinheiros').length).toBeGreaterThan(0);
+  });
+
+  it('renders admin users and supports premium and token actions', async () => {
+    fetchAdminUsers.mockResolvedValue([
+      {
+        id: 'user-1',
+        email: 'cliente@pricely.local',
+        displayName: 'Cliente Teste',
+        role: 'customer',
+        status: 'active',
+        preferredRegion: {
+          id: 'region-1',
+          slug: 'sao-paulo-sp',
+          name: 'Sao Paulo',
+          stateCode: 'SP',
+        },
+        lastLoginAt: '2026-05-10T04:00:00.000Z',
+        createdAt: '2026-05-01T04:00:00.000Z',
+        updatedAt: '2026-05-10T04:00:00.000Z',
+        counts: {
+          shoppingLists: 4,
+          optimizationRuns: 3,
+          receiptRecords: 2,
+          priceMismatchReports: 1,
+        },
+        entitlement: {
+          plan: 'free',
+          status: 'active',
+          source: 'monthly_free_refill',
+          availableOptimizationTokens: 2,
+          monthlyFreeOptimizationTokens: 2,
+          billingEnabled: false,
+          checkoutEnabled: false,
+          lastPaymentAt: null,
+          lastPaymentStatus: 'billing_disabled',
+        },
+        latestOptimization: null,
+      },
+    ]);
+    setAdminUserPremium.mockResolvedValue({});
+    grantAdminUserTokens.mockResolvedValue({});
+
+    render(<AdminUsersPage />);
+
+    expect((await screen.findAllByText('Usuarios')).length).toBeGreaterThan(0);
+    expect(screen.getByText('Cliente Teste')).toBeTruthy();
+    expect(screen.getByText('Sao Paulo - SP')).toBeTruthy();
+    expect(screen.getByText('2 creditos disponiveis')).toBeTruthy();
+    expect(screen.getByText('Billing desativado')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Ativar premium'));
+    await waitFor(() =>
+      expect(setAdminUserPremium).toHaveBeenCalledWith('token', 'user-1', true),
+    );
+
+    fireEvent.change(screen.getByLabelText('Creditos extras para Cliente Teste'), {
+      target: { value: '3' },
+    });
+    fireEvent.click(screen.getByText('Adicionar'));
+    await waitFor(() =>
+      expect(grantAdminUserTokens).toHaveBeenCalledWith('token', 'user-1', {
+        amount: 3,
+        reason: 'suporte_admin',
+      }),
+    );
   });
 });

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -12,6 +12,7 @@ import {
   ListChecksIcon,
   ReceiptTextIcon,
   SparklesIcon,
+  UserCogIcon,
 } from 'lucide-react';
 
 import {
@@ -25,6 +26,7 @@ import {
   type AdminQueueHealthResponse,
   type AdminRegionResponse,
   type AdminShoppingListAuditResponse,
+  type AdminUserResponse,
   createAdminEstablishment,
   createAdminOffer,
   createAdminProduct,
@@ -40,6 +42,9 @@ import {
   fetchAdminQueueHealth,
   fetchAdminRegions,
   fetchAdminShoppingLists,
+  fetchAdminUsers,
+  grantAdminUserTokens,
+  setAdminUserPremium,
   updateAdminOffer,
   updateAdminEstablishment,
   updateAdminProduct,
@@ -1835,6 +1840,237 @@ export function AdminEstablishmentsPage() {
 }
 
 export const AdminOffersPage = AdminPricesPage;
+
+function adminUserLocationLabel(user: AdminUserResponse) {
+  if (!user.preferredRegion) {
+    return 'Cidade nao definida';
+  }
+
+  return `${user.preferredRegion.name} - ${user.preferredRegion.stateCode}`;
+}
+
+function adminUserPlanLabel(user: AdminUserResponse) {
+  if (user.entitlement.plan === 'premium') {
+    return 'Premium manual ativo';
+  }
+
+  return `${user.entitlement.availableOptimizationTokens ?? 0} creditos disponiveis`;
+}
+
+export function AdminUsersPage() {
+  const { accessToken } = usePricely();
+  const { data: users, error, reload } = useAdminData<AdminUserResponse[]>(
+    fetchAdminUsers,
+    [],
+  );
+  const [tokenAmounts, setTokenAmounts] = useState<Record<string, string>>({});
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handlePremiumToggle = async (user: AdminUserResponse) => {
+    if (!accessToken) {
+      return;
+    }
+
+    await setAdminUserPremium(
+      accessToken,
+      user.id,
+      user.entitlement.plan !== 'premium',
+    );
+    setMessage(
+      user.entitlement.plan === 'premium'
+        ? 'Premium manual removido.'
+        : 'Premium manual ativado.',
+    );
+    await reload();
+  };
+
+  const handleTokenGrant = async (user: AdminUserResponse) => {
+    if (!accessToken) {
+      return;
+    }
+
+    const amount = Number(tokenAmounts[user.id] ?? 0);
+    if (!Number.isInteger(amount) || amount <= 0) {
+      setMessage('Informe uma quantidade positiva de creditos.');
+      return;
+    }
+
+    await grantAdminUserTokens(accessToken, user.id, {
+      amount,
+      reason: 'suporte_admin',
+    });
+    setTokenAmounts((current) => ({ ...current, [user.id]: '' }));
+    setMessage(`${amount} creditos adicionados para ${user.displayName}.`);
+    await reload();
+  };
+
+  return (
+    <div className="grid gap-4">
+      <Card className="border-border/70 bg-card/90 shadow-sm">
+        <CardHeader>
+          <CardTitle>Usuarios</CardTitle>
+          <CardDescription>
+            Operacao de acesso, premium manual e creditos enquanto o billing
+            permanece desativado.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4">
+          {error ? (
+            <Alert variant="destructive">
+              <AlertTitle>Falha ao carregar usuarios</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : null}
+          {message ? (
+            <Alert>
+              <InfoIcon />
+              <AlertTitle>Alteracao aplicada</AlertTitle>
+              <AlertDescription>{message}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <div className="grid gap-3 md:grid-cols-4">
+            <div className="rounded-lg border border-border/70 p-4">
+              <div className="text-sm text-muted-foreground">Usuarios</div>
+              <div className="text-2xl font-semibold">{users.length}</div>
+            </div>
+            <div className="rounded-lg border border-border/70 p-4">
+              <div className="text-sm text-muted-foreground">Premium</div>
+              <div className="text-2xl font-semibold">
+                {users.filter((user) => user.entitlement.plan === 'premium').length}
+              </div>
+            </div>
+            <div className="rounded-lg border border-border/70 p-4">
+              <div className="text-sm text-muted-foreground">Listas</div>
+              <div className="text-2xl font-semibold">
+                {users.reduce((sum, user) => sum + user.counts.shoppingLists, 0)}
+              </div>
+            </div>
+            <div className="rounded-lg border border-border/70 p-4">
+              <div className="text-sm text-muted-foreground">Notas fiscais</div>
+              <div className="text-2xl font-semibold">
+                {users.reduce((sum, user) => sum + user.counts.receiptRecords, 0)}
+              </div>
+            </div>
+          </div>
+
+          <div className="overflow-hidden rounded-lg border border-border/70">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Usuario</TableHead>
+                  <TableHead>Localidade</TableHead>
+                  <TableHead>Uso</TableHead>
+                  <TableHead>Plano</TableHead>
+                  <TableHead>Ultimo pagamento</TableHead>
+                  <TableHead>Acoes</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.map((user) => (
+                  <TableRow key={user.id}>
+                    <TableCell>
+                      <div className="font-medium">{user.displayName}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {user.email}
+                      </div>
+                      <div className="mt-1 flex items-center gap-2">
+                        <Badge variant="secondary">{user.role}</Badge>
+                        <Badge variant="outline">{user.status}</Badge>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm">{adminUserLocationLabel(user)}</div>
+                      <div className="text-xs text-muted-foreground">
+                        ultimo acesso{' '}
+                        {user.lastLoginAt
+                          ? formatFreshnessLabel(user.lastLoginAt)
+                          : 'nao registrado'}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm">
+                        {user.counts.shoppingLists} listas ·{' '}
+                        {user.counts.optimizationRuns} otimizacoes
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {user.counts.receiptRecords} notas ·{' '}
+                        {user.counts.priceMismatchReports} reports
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <UserCogIcon className="size-4 text-muted-foreground" />
+                        <span className="font-medium">
+                          {adminUserPlanLabel(user)}
+                        </span>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        Origem {user.entitlement.source}; billing desativado
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm">
+                        {user.entitlement.lastPaymentAt ?? 'Sem cobranca ativa'}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {user.entitlement.lastPaymentStatus === 'billing_disabled'
+                          ? 'Billing desativado'
+                          : user.entitlement.lastPaymentStatus}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col gap-2">
+                        <Button
+                          onClick={() => void handlePremiumToggle(user)}
+                          size="sm"
+                          type="button"
+                          variant={
+                            user.entitlement.plan === 'premium'
+                              ? 'outline'
+                              : 'default'
+                          }
+                        >
+                          {user.entitlement.plan === 'premium'
+                            ? 'Remover premium'
+                            : 'Ativar premium'}
+                        </Button>
+                        <div className="flex items-center gap-2">
+                          <Input
+                            aria-label={`Creditos extras para ${user.displayName}`}
+                            className="h-9 w-24"
+                            min="1"
+                            onChange={(event) =>
+                              setTokenAmounts((current) => ({
+                                ...current,
+                                [user.id]: event.target.value,
+                              }))
+                            }
+                            placeholder="+2"
+                            type="number"
+                            value={tokenAmounts[user.id] ?? ''}
+                          />
+                          <Button
+                            onClick={() => void handleTokenGrant(user)}
+                            size="sm"
+                            type="button"
+                            variant="outline"
+                          >
+                            Adicionar
+                          </Button>
+                        </div>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
 
 export function AdminListsPage() {
   const { data: metrics } = useAdminData<AdminMetricsResponse | null>(

--- a/web/src/routes/app-router.tsx
+++ b/web/src/routes/app-router.tsx
@@ -119,6 +119,13 @@ const dashboardChildren: RouteObject[] = [
     },
   },
   {
+    path: 'usuarios',
+    lazy: async () => {
+      const { AdminUsersPage } = await import('@/dashboard/dashboard-pages');
+      return { Component: AdminUsersPage };
+    },
+  },
+  {
     path: 'fila',
     lazy: async () => {
       const { AdminQueuePage } = await import('@/dashboard/dashboard-pages');

--- a/web/src/routes/dashboard.tsx
+++ b/web/src/routes/dashboard.tsx
@@ -8,6 +8,7 @@ import {
   AdminQueueDetailPage,
   AdminQueuePage,
   AdminRegionsPage,
+  AdminUsersPage,
 } from '@/dashboard/dashboard-pages';
 
 export const dashboardRoute = {
@@ -37,6 +38,10 @@ export const dashboardRoute = {
     {
       path: 'listas',
       element: <AdminListsPage />,
+    },
+    {
+      path: 'usuarios',
+      element: <AdminUsersPage />,
     },
     {
       path: 'fila',


### PR DESCRIPTION
## Summary
- add admin users endpoint with plan, location, usage, payment-state and token visibility
- add manual premium and optimization-credit actions while billing stays disabled
- add dashboard users page and route plus Phase 26 planning tasks

## Validation
- npm test -- --runTestsByPath test/unit/admin/admin-dashboard.service.spec.ts (backend)
- npm test -- dashboard-pages.spec.tsx (web)
- npm run lint (backend)
- npm run lint (web)
- npm run build (backend)
- npm run build (web)