### PR TITLE
Add offer confidence copy and receipt admin view

### DIFF
--- a/backend/src/admin/api/admin-dashboard.controller.ts
+++ b/backend/src/admin/api/admin-dashboard.controller.ts
@@ -364,6 +364,11 @@ export class AdminDashboardController {
     return this.adminDashboardService.getProcessingJobDetail(id);
   }
 
+  @Get('receipt-processing')
+  async listReceiptProcessingReviews() {
+    return this.adminDashboardService.listReceiptProcessingReviews();
+  }
+
   @Get('queue-health')
   async queueHealth() {
     return this.adminDashboardService.getQueueHealth();

--- a/backend/src/admin/application/admin-dashboard.service.ts
+++ b/backend/src/admin/application/admin-dashboard.service.ts
@@ -335,6 +335,86 @@ export class AdminDashboardService {
     };
   }
 
+  async listReceiptProcessingReviews() {
+    const receipts = await this.prisma.receiptRecord.findMany({
+      orderBy: [{ updatedAt: 'desc' }, { createdAt: 'desc' }],
+      take: 100,
+      include: {
+        user: {
+          select: {
+            id: true,
+            displayName: true,
+            email: true,
+          },
+        },
+        processingJob: true,
+        lineItems: {
+          select: {
+            matchConfidence: true,
+          },
+        },
+      },
+    });
+
+    const projectedReceipts = receipts.map((receipt) => {
+      const confidences = receipt.lineItems.map((item) =>
+        Number(item.matchConfidence),
+      );
+      const lineItemCount = confidences.length;
+      const highConfidenceLineItemCount = confidences.filter(
+        (confidence) => confidence >= 0.75,
+      ).length;
+      const averageMatchConfidence =
+        lineItemCount === 0
+          ? 0
+          : Number(
+              (
+                confidences.reduce((sum, confidence) => sum + confidence, 0) /
+                lineItemCount
+              ).toFixed(2),
+            );
+
+      return {
+        id: receipt.id,
+        storeName: receipt.storeName,
+        storeCnpj: receipt.storeCnpj,
+        parseStatus: receipt.parseStatus,
+        trustLevel: receipt.trustLevel,
+        moderationStatus: receipt.moderationStatus,
+        rewardEligibilityStatus: receipt.rewardEligibilityStatus,
+        reviewReason: receipt.reviewReason,
+        purchaseDate: receipt.purchaseDate?.toISOString(),
+        createdAt: receipt.createdAt.toISOString(),
+        updatedAt: receipt.updatedAt.toISOString(),
+        owner: receipt.user,
+        processingJob: receipt.processingJob
+          ? {
+              id: receipt.processingJob.id,
+              status: receipt.processingJob.status,
+              attemptCount: receipt.processingJob.attemptCount,
+              failureReason: receipt.processingJob.failureReason,
+              updatedAt: receipt.processingJob.updatedAt.toISOString(),
+            }
+          : null,
+        quality: {
+          lineItemCount,
+          highConfidenceLineItemCount,
+          averageMatchConfidence,
+          usefulDataRatio:
+            lineItemCount === 0
+              ? 0
+              : Number((highConfidenceLineItemCount / lineItemCount).toFixed(2)),
+        },
+      };
+    });
+
+    this.logger.log(
+      `Admin receipt processing requested: ${projectedReceipts.length} records returned`,
+    );
+
+    return projectedReceipts;
+  }
+
   async getQueueHealth() {
     const jobs = await this.prisma.processingJob.findMany({
       select: {

--- a/backend/src/common/contracts/admin.contract.ts
+++ b/backend/src/common/contracts/admin.contract.ts
@@ -88,3 +88,44 @@ export interface AdminUserContract {
     completedAt?: string;
   } | null;
 }
+
+export interface AdminReceiptProcessingContract {
+  id: string;
+  storeName: string | null;
+  storeCnpj: string | null;
+  parseStatus: 'queued' | 'parsed' | 'partial' | 'failed';
+  trustLevel: 'untrusted' | 'pending_review' | 'trusted' | 'rejected';
+  moderationStatus:
+    | 'pending'
+    | 'accepted'
+    | 'quarantined'
+    | 'duplicate'
+    | 'rejected';
+  rewardEligibilityStatus:
+    | 'disabled'
+    | 'ineligible'
+    | 'eligible_pending'
+    | 'granted';
+  reviewReason: string | null;
+  purchaseDate?: string;
+  createdAt: string;
+  updatedAt: string;
+  owner: {
+    id: string;
+    displayName: string;
+    email: string;
+  };
+  processingJob: {
+    id: string;
+    status: 'queued' | 'running' | 'completed' | 'failed' | 'retrying';
+    attemptCount: number;
+    failureReason: string | null;
+    updatedAt: string;
+  } | null;
+  quality: {
+    lineItemCount: number;
+    highConfidenceLineItemCount: number;
+    averageMatchConfidence: number;
+    usefulDataRatio: number;
+  };
+}

--- a/backend/src/stores/infrastructure/store-offer.repository.ts
+++ b/backend/src/stores/infrastructure/store-offer.repository.ts
@@ -318,6 +318,7 @@ export class StoreOfferRepository {
               evidenceCount,
               freshnessDays,
               factor,
+              latestOffer.sourceType,
             ),
           },
         ];
@@ -366,19 +367,38 @@ export class StoreOfferRepository {
     evidenceCount: number,
     freshnessDays: number,
     factor: number,
+    sourceType: string,
   ): string {
+    const sourceLabel = this.trustSourceLabel(sourceType);
     const receiptText =
       evidenceCount === 0
-        ? 'sem nota fiscal recente vinculada; usando evidencia operacional'
+        ? `preco ainda sem nota fiscal aceita; origem ${sourceLabel} sustenta a oferta`
         : evidenceCount === 1
-        ? '1 nota fiscal confiavel'
-        : `${evidenceCount} notas fiscais confiaveis`;
+        ? '1 nota fiscal aceita apoia este preco'
+        : `${evidenceCount} notas fiscais aceitas apoiam este preco`;
     const freshnessText =
       freshnessDays === 0
         ? 'validacao hoje'
         : `ultima validacao ha ${freshnessDays} dias`;
 
-    return `${receiptText}; ${freshnessText}; trust factor ${factor}/100.`;
+    return `${receiptText}; ${freshnessText}; confianca da oferta ${factor}/100.`;
+  }
+
+  private trustSourceLabel(sourceType: string): string {
+    if (sourceType === 'receipt') {
+      return 'nota fiscal';
+    }
+    if (sourceType === 'admin' || sourceType === 'manual') {
+      return 'cadastro administrativo';
+    }
+    if (sourceType === 'flyer') {
+      return 'encarte';
+    }
+    if (sourceType === 'site') {
+      return 'site do estabelecimento';
+    }
+
+    return 'operacional';
   }
 
   private buildMatchingCanonicalNames(input: {

--- a/backend/test/unit/stores/store-offer.repository.spec.ts
+++ b/backend/test/unit/stores/store-offer.repository.spec.ts
@@ -175,6 +175,9 @@ describe('StoreOfferRepository', () => {
       }),
     );
     expect(offers[0].trustFactor).toBeGreaterThanOrEqual(75);
-    expect(offers[0].trustExplanation).toContain('2 notas fiscais confiaveis');
+    expect(offers[0].trustExplanation).toContain(
+      '2 notas fiscais aceitas apoiam este preco',
+    );
+    expect(offers[0].trustExplanation).toContain('confianca da oferta');
   });
 });

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -540,9 +540,9 @@ Premium access and extra optimization credits are support/admin operations for n
 - [~] T204 Rename optimization modes to descriptive user-facing semantics and keep API/backward-compatible aliases where needed in `backend/src/optimization/`, `backend/src/common/contracts/`, `web/src/public/`, and admin diagnostics
 - [~] T205 Persist optimization-specific variant substitutions on the original list while preserving the original `any variant` intent so future optimizations can swap variants again in `backend/src/lists/`, `backend/src/optimization/`, and `web/src/public/`
 - [X] T206 Update item decision math so savings compare selected offer against the second cheapest eligible offer, while city average remains a separate informational metric in `backend/src/optimization/`, `backend/src/common/contracts/optimization.contract.ts`, and `web/src/public/`
-- [ ] T207 Rename shopper-facing trust copy to `Confianca da oferta`, including source labels for admin/manual/receipt evidence, receipt support count, freshness decay, and clearer no-receipt wording in `backend/src/optimization/`, `backend/src/pricing/`, and `web/src/public/`
+- [X] T207 Rename shopper-facing trust copy to `Confianca da oferta`, including source labels for admin/manual/receipt evidence, receipt support count, freshness decay, and clearer no-receipt wording in `backend/src/optimization/`, `backend/src/pricing/`, and `web/src/public/`
 - [ ] T208 Add gamified receipt contribution rewards with points and token outcomes only after receipt quality scoring confirms useful, correctly processed receipt data in `backend/src/receipts/`, `backend/src/users/`, and `web/src/public/`
-- [ ] T209 Add a dedicated admin receipt-processing queue/detail surface for receipt content, line-item quality, moderation status, and reward readiness in `backend/src/admin/` and `web/src/dashboard/`
+- [X] T209 Add a dedicated admin receipt-processing queue/detail surface for receipt content, line-item quality, moderation status, and reward readiness in `backend/src/admin/` and `web/src/dashboard/`
 - [ ] T210 Add public city-request/contact flow while keeping city creation admin-only in `backend/src/regions/`, `backend/src/admin/`, and `web/src/public/`
 
 ---

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -380,6 +380,47 @@ type AdminProcessingJobDetailResponse = AdminProcessingJobResponse & {
     | null;
 };
 
+type AdminReceiptProcessingResponse = {
+  id: string;
+  storeName?: string | null;
+  storeCnpj?: string | null;
+  parseStatus: 'queued' | 'parsed' | 'partial' | 'failed';
+  trustLevel: 'untrusted' | 'pending_review' | 'trusted' | 'rejected';
+  moderationStatus:
+    | 'pending'
+    | 'accepted'
+    | 'quarantined'
+    | 'duplicate'
+    | 'rejected';
+  rewardEligibilityStatus:
+    | 'disabled'
+    | 'ineligible'
+    | 'eligible_pending'
+    | 'granted';
+  reviewReason?: string | null;
+  purchaseDate?: string;
+  createdAt: string;
+  updatedAt: string;
+  owner: {
+    id: string;
+    displayName: string;
+    email: string;
+  };
+  processingJob?: {
+    id: string;
+    status: 'queued' | 'running' | 'completed' | 'failed' | 'retrying';
+    attemptCount: number;
+    failureReason?: string | null;
+    updatedAt: string;
+  } | null;
+  quality: {
+    lineItemCount: number;
+    highConfidenceLineItemCount: number;
+    averageMatchConfidence: number;
+    usefulDataRatio: number;
+  };
+};
+
 type AdminQueueHealthResponse = {
   queuedJobs: number;
   runningJobs: number;
@@ -915,6 +956,14 @@ export async function fetchAdminProcessingJobDetail(token: string, id: string) {
   );
 }
 
+export async function fetchAdminReceiptProcessing(token: string) {
+  return apiFetch<AdminReceiptProcessingResponse[]>(
+    '/admin/receipt-processing',
+    {},
+    token,
+  );
+}
+
 export async function fetchAdminQueueHealth(token: string) {
   return apiFetch<AdminQueueHealthResponse>('/admin/queue-health', {}, token);
 }
@@ -1241,6 +1290,7 @@ export type {
   AdminProcessingJobResponse,
   AdminProcessingJobDetailResponse,
   AdminQueueHealthResponse,
+  AdminReceiptProcessingResponse,
   AdminRegionResponse,
   OfferDetailApiResponse,
   OptimizationResultApiResponse,

--- a/web/src/dashboard/admin-shell.tsx
+++ b/web/src/dashboard/admin-shell.tsx
@@ -6,6 +6,7 @@ import {
   MapPinnedIcon,
   MoonStarIcon,
   PackageSearchIcon,
+  ReceiptTextIcon,
   ShieldCheckIcon,
   StoreIcon,
   SunMediumIcon,
@@ -70,6 +71,11 @@ const adminNav = [
     to: '/dashboard/usuarios',
     label: 'Usuarios',
     icon: UsersIcon,
+  },
+  {
+    to: '/dashboard/notas',
+    label: 'Notas fiscais',
+    icon: ReceiptTextIcon,
   },
   {
     to: '/dashboard/fila',

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -9,6 +9,7 @@ import {
   AdminOverviewPage,
   AdminPricesPage,
   AdminQueuePage,
+  AdminReceiptsPage,
   AdminRegionsPage,
   AdminUsersPage,
 } from './dashboard-pages';
@@ -16,6 +17,7 @@ import {
 const fetchAdminMetrics = vi.fn();
 const fetchAdminQueueHealth = vi.fn();
 const fetchAdminProcessingJobs = vi.fn();
+const fetchAdminReceiptProcessing = vi.fn();
 const fetchAdminRegions = vi.fn();
 const fetchAdminEstablishments = vi.fn();
 const fetchAdminOffers = vi.fn();
@@ -44,6 +46,8 @@ vi.mock('@/app/api', () => ({
   fetchAdminProcessingJobs: (...args: unknown[]) =>
     fetchAdminProcessingJobs(...args),
   fetchAdminProcessingJobDetail: vi.fn(),
+  fetchAdminReceiptProcessing: (...args: unknown[]) =>
+    fetchAdminReceiptProcessing(...args),
   fetchAdminRegions: (...args: unknown[]) => fetchAdminRegions(...args),
   fetchAdminEstablishments: (...args: unknown[]) =>
     fetchAdminEstablishments(...args),
@@ -72,6 +76,7 @@ describe('Admin dashboard pages', () => {
     fetchAdminMetrics.mockReset();
     fetchAdminQueueHealth.mockReset();
     fetchAdminProcessingJobs.mockReset();
+    fetchAdminReceiptProcessing.mockReset();
     fetchAdminRegions.mockReset();
     fetchAdminEstablishments.mockReset();
     fetchAdminOffers.mockReset();
@@ -341,6 +346,50 @@ describe('Admin dashboard pages', () => {
     render(<AdminEstablishmentsPage />);
     expect(await screen.findByText('Unidades por cidade')).toBeTruthy();
     expect(screen.getAllByText('Unidade Pinheiros').length).toBeGreaterThan(0);
+  });
+
+  it('renders receipt processing quality and review actions', async () => {
+    fetchAdminReceiptProcessing.mockResolvedValue([
+      {
+        id: 'receipt-1',
+        storeName: 'Mercado Centro',
+        storeCnpj: '00.000.000/0001-00',
+        parseStatus: 'parsed',
+        trustLevel: 'trusted',
+        moderationStatus: 'accepted',
+        rewardEligibilityStatus: 'eligible_pending',
+        reviewReason: null,
+        purchaseDate: '2026-05-09T10:00:00.000Z',
+        createdAt: '2026-05-09T10:05:00.000Z',
+        updatedAt: '2026-05-09T10:06:00.000Z',
+        owner: {
+          id: 'user-1',
+          displayName: 'Cliente Teste',
+          email: 'cliente@pricely.local',
+        },
+        processingJob: {
+          id: 'job-1',
+          status: 'completed',
+          attemptCount: 1,
+          failureReason: null,
+          updatedAt: '2026-05-09T10:06:00.000Z',
+        },
+        quality: {
+          lineItemCount: 4,
+          highConfidenceLineItemCount: 3,
+          averageMatchConfidence: 0.83,
+          usefulDataRatio: 0.75,
+        },
+      },
+    ]);
+
+    render(<AdminReceiptsPage />);
+
+    expect(await screen.findByText('Notas fiscais processadas')).toBeTruthy();
+    expect(screen.getAllByText('Mercado Centro').length).toBeGreaterThan(0);
+    expect(screen.getByText('3/4 itens fortes')).toBeTruthy();
+    expect(screen.getByText('eligible_pending')).toBeTruthy();
+    expect(screen.getByText('Ver leitura')).toBeTruthy();
   });
 
   it('renders admin users and supports premium and token actions', async () => {

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -24,6 +24,7 @@ import {
   type AdminProductResponse,
   type AdminProductVariantResponse,
   type AdminQueueHealthResponse,
+  type AdminReceiptProcessingResponse,
   type AdminRegionResponse,
   type AdminShoppingListAuditResponse,
   type AdminUserResponse,
@@ -40,6 +41,7 @@ import {
   fetchAdminProducts,
   fetchAdminProductVariants,
   fetchAdminQueueHealth,
+  fetchAdminReceiptProcessing,
   fetchAdminRegions,
   fetchAdminShoppingLists,
   fetchAdminUsers,
@@ -154,6 +156,31 @@ function JobResourceIcon({ job }: { job: AdminProcessingJobResponse }) {
   }
 
   return <ListChecksIcon className="size-4" />;
+}
+
+function receiptModerationLabel(
+  status: AdminReceiptProcessingResponse['moderationStatus'],
+) {
+  const labels: Record<
+    AdminReceiptProcessingResponse['moderationStatus'],
+    string
+  > = {
+    accepted: 'Aceita',
+    duplicate: 'Duplicada',
+    pending: 'Pendente',
+    quarantined: 'Em revisão',
+    rejected: 'Rejeitada',
+  };
+
+  return labels[status];
+}
+
+function receiptQualityLabel(receipt: AdminReceiptProcessingResponse) {
+  if (receipt.quality.lineItemCount === 0) {
+    return 'Sem itens extraídos';
+  }
+
+  return `${receipt.quality.highConfidenceLineItemCount}/${receipt.quality.lineItemCount} itens fortes`;
 }
 
 export function AdminOverviewPage() {
@@ -2213,6 +2240,159 @@ export function AdminListsPage() {
   );
 }
 
+export function AdminReceiptsPage() {
+  const { data: receipts, error } = useAdminData<
+    AdminReceiptProcessingResponse[]
+  >(fetchAdminReceiptProcessing, []);
+
+  const pendingReviewCount = receipts.filter((receipt) =>
+    ['pending', 'quarantined'].includes(receipt.moderationStatus),
+  ).length;
+  const acceptedCount = receipts.filter(
+    (receipt) => receipt.moderationStatus === 'accepted',
+  ).length;
+  const rewardReadyCount = receipts.filter(
+    (receipt) => receipt.rewardEligibilityStatus === 'eligible_pending',
+  ).length;
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Falha ao carregar notas fiscais</AlertTitle>
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="grid gap-4">
+      <div className="grid gap-3 md:grid-cols-3">
+        <Card className="border-border/70 bg-card/90 shadow-sm">
+          <CardHeader>
+            <CardTitle>Pendentes</CardTitle>
+            <CardDescription>Notas que ainda exigem revisão.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-semibold">{pendingReviewCount}</div>
+          </CardContent>
+        </Card>
+        <Card className="border-border/70 bg-card/90 shadow-sm">
+          <CardHeader>
+            <CardTitle>Aceitas</CardTitle>
+            <CardDescription>Notas úteis para reforçar preços.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-semibold">{acceptedCount}</div>
+          </CardContent>
+        </Card>
+        <Card className="border-border/70 bg-card/90 shadow-sm">
+          <CardHeader>
+            <CardTitle>Rewards prontos</CardTitle>
+            <CardDescription>
+              Elegíveis após qualidade, sem billing automático.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-semibold">{rewardReadyCount}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="border-border/70 bg-card/90 shadow-sm">
+        <CardHeader>
+          <CardTitle>Notas fiscais processadas</CardTitle>
+          <CardDescription>
+            Conteúdo, qualidade de leitura, moderação e prontidão de reward.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3">
+          {receipts.length === 0 ? (
+            <div className="rounded-lg border border-border/70 bg-background/80 p-4 text-sm text-muted-foreground">
+              Nenhuma nota fiscal recebida ainda.
+            </div>
+          ) : null}
+          {receipts.map((receipt) => (
+            <div
+              key={receipt.id}
+              className="rounded-lg border border-border/70 bg-background/80 p-4"
+            >
+              <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <ReceiptTextIcon className="size-4 text-muted-foreground" />
+                    <span className="font-medium">
+                      {receipt.storeName ?? 'Loja não identificada'}
+                    </span>
+                    <Badge
+                      variant={
+                        receipt.moderationStatus === 'accepted'
+                          ? 'secondary'
+                          : receipt.moderationStatus === 'rejected'
+                            ? 'destructive'
+                            : 'outline'
+                      }
+                    >
+                      {receiptModerationLabel(receipt.moderationStatus)}
+                    </Badge>
+                  </div>
+                  <div className="mt-1 text-sm text-muted-foreground">
+                    {receipt.owner.displayName || receipt.owner.email} ·{' '}
+                    {receipt.storeCnpj ?? 'CNPJ não identificado'} · recebida{' '}
+                    {formatFreshnessLabel(receipt.createdAt)}
+                  </div>
+                </div>
+                {receipt.processingJob ? (
+                  <Button asChild size="sm" variant="outline">
+                    <a href={`/dashboard/fila/${receipt.processingJob.id}`}>
+                      Ver leitura
+                      <ExternalLinkIcon className="size-4" />
+                    </a>
+                  </Button>
+                ) : null}
+              </div>
+
+              <div className="mt-4 grid gap-3 md:grid-cols-4">
+                <div className="rounded-md border border-border/70 p-3">
+                  <div className="text-xs text-muted-foreground">Leitura</div>
+                  <div className="mt-1 font-medium">{receipt.parseStatus}</div>
+                </div>
+                <div className="rounded-md border border-border/70 p-3">
+                  <div className="text-xs text-muted-foreground">
+                    Qualidade
+                  </div>
+                  <div className="mt-1 font-medium">
+                    {receiptQualityLabel(receipt)}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    média {Math.round(receipt.quality.averageMatchConfidence * 100)}%
+                  </div>
+                </div>
+                <div className="rounded-md border border-border/70 p-3">
+                  <div className="text-xs text-muted-foreground">
+                    Confiança
+                  </div>
+                  <div className="mt-1 font-medium">{receipt.trustLevel}</div>
+                </div>
+                <div className="rounded-md border border-border/70 p-3">
+                  <div className="text-xs text-muted-foreground">Reward</div>
+                  <div className="mt-1 font-medium">
+                    {receipt.rewardEligibilityStatus}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-3 text-sm text-muted-foreground">
+                {receipt.reviewReason ??
+                  'Sem motivo de revisão registrado para esta nota.'}
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 export function AdminQueuePage() {
   const { data: metrics } = useAdminData<AdminMetricsResponse | null>(
     fetchAdminMetrics,
@@ -2516,7 +2696,8 @@ export function AdminQueueDetailPage() {
                         </Badge>
                         {selection.offer?.confidenceLevel ? (
                           <span className="text-xs text-muted-foreground">
-                            Trust {selection.offer.confidenceLevel}
+                            Confiança da oferta{' '}
+                            {selection.offer.confidenceLevel}
                           </span>
                         ) : null}
                       </div>

--- a/web/src/public/optimization-page.spec.tsx
+++ b/web/src/public/optimization-page.spec.tsx
@@ -105,7 +105,7 @@ describe('OptimizationPage', () => {
             trustEvidenceCount: 3,
             trustFreshnessDays: 1,
             trustExplanation:
-              '3 notas fiscais confiaveis; ultima validacao ha 1 dias; trust factor 78/100.',
+              '3 notas fiscais aceitas apoiam este preco; ultima validacao ha 1 dias; confianca da oferta 78/100.',
             selectionStatus: 'selected',
             decisionReason: 'selected_confirmed_offer',
           },
@@ -125,7 +125,7 @@ describe('OptimizationPage', () => {
     expect(screen.getByText('Oferta selecionada')).toBeTruthy();
     expect(screen.getByText('Oferta confirmada selecionada')).toBeTruthy();
     expect(screen.getByText('Selecionado: Cafe Pilao 500g · 500 g')).toBeTruthy();
-    expect(screen.getByText('Trust alto')).toBeTruthy();
+    expect(screen.getByText('Confiança alta')).toBeTruthy();
     expect(screen.getByText('78/100')).toBeTruthy();
     expect(screen.getByText(/segundo menor elegivel/)).toBeTruthy();
     expect(screen.queryByText(/selected_confirmed_offer/i)).toBeNull();

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -162,15 +162,15 @@ function trustFactorBadge(level?: 'high' | 'medium' | 'low') {
   if (level === 'high') {
     return (
       <Badge className="bg-emerald-100 text-emerald-900 hover:bg-emerald-100">
-        Trust alto
+        Confiança alta
       </Badge>
     );
   }
   if (level === 'medium') {
-    return <Badge variant="secondary">Trust médio</Badge>;
+    return <Badge variant="secondary">Confiança média</Badge>;
   }
 
-  return <Badge variant="destructive">Trust baixo</Badge>;
+  return <Badge variant="destructive">Confiança baixa</Badge>;
 }
 
 function trustEvidenceLabel(selection: {
@@ -180,16 +180,21 @@ function trustEvidenceLabel(selection: {
   const evidenceCount = selection.trustEvidenceCount ?? 0;
   const receiptText =
     evidenceCount === 0
-      ? 'Sem nota fiscal recente vinculada; usando evidência operacional'
+      ? 'Preço ainda sem nota fiscal aceita; origem operacional sustenta a oferta'
       : evidenceCount === 1
-      ? '1 nota valida'
-      : `${evidenceCount} notas validas`;
+      ? '1 nota fiscal aceita apoia este preço'
+      : `${evidenceCount} notas fiscais aceitas apoiam este preço`;
 
   if (selection.trustFreshnessDays === undefined) {
     return receiptText;
   }
 
-  return `${receiptText} · revalidado ha ${selection.trustFreshnessDays}d`;
+  const freshnessText =
+    selection.trustFreshnessDays === 0
+      ? 'validado hoje'
+      : `última validação há ${selection.trustFreshnessDays}d`;
+
+  return `${receiptText} · ${freshnessText}`;
 }
 
 function PriceDisplay({

--- a/web/src/routes/app-router.tsx
+++ b/web/src/routes/app-router.tsx
@@ -126,6 +126,13 @@ const dashboardChildren: RouteObject[] = [
     },
   },
   {
+    path: 'notas',
+    lazy: async () => {
+      const { AdminReceiptsPage } = await import('@/dashboard/dashboard-pages');
+      return { Component: AdminReceiptsPage };
+    },
+  },
+  {
     path: 'fila',
     lazy: async () => {
       const { AdminQueuePage } = await import('@/dashboard/dashboard-pages');

--- a/web/src/routes/dashboard.tsx
+++ b/web/src/routes/dashboard.tsx
@@ -7,6 +7,7 @@ import {
   AdminOverviewPage,
   AdminQueueDetailPage,
   AdminQueuePage,
+  AdminReceiptsPage,
   AdminRegionsPage,
   AdminUsersPage,
 } from '@/dashboard/dashboard-pages';
@@ -42,6 +43,10 @@ export const dashboardRoute = {
     {
       path: 'usuarios',
       element: <AdminUsersPage />,
+    },
+    {
+      path: 'notas',
+      element: <AdminReceiptsPage />,
     },
     {
       path: 'fila',


### PR DESCRIPTION
## Summary
- rename trust-factor wording to oferta confidence copy with clearer receipt/source explanations
- add admin receipt-processing endpoint with quality/moderation/reward-readiness metrics
- add dedicated admin Notas fiscais page and route with queue-detail links

## Validation
- backend: npm test -- --runTestsByPath test/unit/admin/admin-dashboard.service.spec.ts test/unit/receipts/receipt-contribution-quality.service.spec.ts
- backend: npm run lint
- backend: npm run build
- web: npm test -- dashboard-pages.spec.tsx optimization-page.spec.tsx
- web: npm run lint
- web: npm run build