### PR TITLE
Grant rewards for trusted receipt contributions

### DIFF
--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -678,8 +678,8 @@ async function main() {
         duplicateKey: 'seed-accepted-receipt',
         trustLevel: 'trusted',
         moderationStatus: 'accepted',
-        rewardEligibilityStatus: 'disabled',
-        reviewReason: 'receipt_rewards_disabled',
+        rewardEligibilityStatus: 'granted',
+        reviewReason: 'receipt_reward_granted',
         establishmentId: establishment.id,
       },
       lineItems: [

--- a/backend/src/admin/application/admin-dashboard.service.ts
+++ b/backend/src/admin/application/admin-dashboard.service.ts
@@ -405,6 +405,9 @@ export class AdminDashboardService {
               ? 0
               : Number((highConfidenceLineItemCount / lineItemCount).toFixed(2)),
         },
+        reward: this.receiptRewardProjection(
+          receipt.rewardEligibilityStatus,
+        ),
       };
     });
 
@@ -413,6 +416,29 @@ export class AdminDashboardService {
     );
 
     return projectedReceipts;
+  }
+
+  private receiptRewardProjection(status: string) {
+    if (status === 'granted') {
+      return {
+        points: 100,
+        optimizationTokens: 1,
+        label: '100 pontos + 1 credito concedido',
+      };
+    }
+    if (status === 'eligible_pending') {
+      return {
+        points: 100,
+        optimizationTokens: 1,
+        label: '100 pontos + 1 credito pendente',
+      };
+    }
+
+    return {
+      points: 0,
+      optimizationTokens: 0,
+      label: 'Sem reward',
+    };
   }
 
   async getQueueHealth() {

--- a/backend/src/common/contracts/admin.contract.ts
+++ b/backend/src/common/contracts/admin.contract.ts
@@ -128,4 +128,9 @@ export interface AdminReceiptProcessingContract {
     averageMatchConfidence: number;
     usefulDataRatio: number;
   };
+  reward: {
+    points: number;
+    optimizationTokens: number;
+    label: string;
+  };
 }

--- a/backend/src/common/contracts/receipt.contract.ts
+++ b/backend/src/common/contracts/receipt.contract.ts
@@ -48,6 +48,9 @@ export interface ReceiptRecord {
     | 'ineligible'
     | 'eligible_pending'
     | 'granted';
+  rewardPoints?: number;
+  rewardOptimizationTokens?: number;
+  rewardMessage?: string;
   reviewReason?: string;
   jobId?: string;
   processingStatus?: 'queued' | 'running' | 'completed' | 'failed' | 'retrying';

--- a/backend/src/receipts/application/receipt-contribution-quality.service.ts
+++ b/backend/src/receipts/application/receipt-contribution-quality.service.ts
@@ -90,9 +90,13 @@ export class ReceiptContributionQualityService {
       duplicateKey,
       trustLevel: 'trusted',
       moderationStatus: 'accepted',
-      rewardEligibilityStatus: 'disabled',
-      reviewReason: 'receipt_rewards_disabled',
-      logs: ['quality:trusted_receipt', 'reward:disabled_for_mvp'],
+      rewardEligibilityStatus: 'eligible_pending',
+      reviewReason: 'receipt_reward_ready',
+      logs: [
+        'quality:trusted_receipt',
+        'reward:points_pending:100',
+        'reward:optimization_token_pending:1',
+      ],
     };
   }
 

--- a/backend/src/receipts/application/receipt-ingestion.service.ts
+++ b/backend/src/receipts/application/receipt-ingestion.service.ts
@@ -12,6 +12,7 @@ import {
 import { toSlug } from '../../common/utils/slug.util';
 import { ProductMatchService } from '../../catalog/application/product-match.service';
 import { ProcessingJobsService } from '../../processing/application/processing-jobs.service';
+import { EntitlementsService } from '../../users/entitlements.service';
 import { type ReceiptRecordEntity } from '../domain/receipt-record.entity';
 import { ReceiptRecordRepository } from '../infrastructure/receipt-record.repository';
 import { QrCodeParserService } from './qr-code-parser.service';
@@ -31,6 +32,7 @@ export class ReceiptIngestionService {
     private readonly receiptContributionQualityService: ReceiptContributionQualityService,
     private readonly receiptRecordRepository: ReceiptRecordRepository,
     private readonly processingJobsService: ProcessingJobsService,
+    private readonly entitlementsService: EntitlementsService,
     @Inject(RECEIPT_PROCESSING_QUEUE)
     private readonly receiptProcessingQueue: Queue<ReceiptProcessingJob>,
   ) {}
@@ -118,6 +120,7 @@ export class ReceiptIngestionService {
     };
 
     await this.receiptRecordRepository.create(assessedRecord);
+    const reward = await this.grantReceiptRewardIfEligible(assessedRecord);
     const processingJob = await this.processingJobsService.createQueuedJob({
       queueName: 'receipt-processing',
       jobType: 'receipt_processing',
@@ -161,12 +164,53 @@ export class ReceiptIngestionService {
       confidenceScore: assessedRecord.confidenceScore,
       trustLevel: assessedRecord.trustLevel,
       moderationStatus: assessedRecord.moderationStatus,
-      rewardEligibilityStatus: assessedRecord.rewardEligibilityStatus,
-      reviewReason: assessedRecord.reviewReason,
+      rewardEligibilityStatus: reward.status,
+      rewardPoints: reward.points,
+      rewardOptimizationTokens: reward.optimizationTokens,
+      rewardMessage: reward.message,
+      reviewReason: reward.reviewReason ?? assessedRecord.reviewReason,
       jobId: processingJob.id,
       processingStatus: 'queued',
       dataNotice:
         'Prices and receipt data are based on receipts provided by users.',
+    };
+  }
+
+  private async grantReceiptRewardIfEligible(record: ReceiptRecordEntity): Promise<{
+    status: NonNullable<ReceiptRecord['rewardEligibilityStatus']>;
+    points: number;
+    optimizationTokens: number;
+    message: string;
+    reviewReason?: string;
+  }> {
+    if (
+      record.trustLevel !== 'trusted' ||
+      record.moderationStatus !== 'accepted' ||
+      record.rewardEligibilityStatus !== 'eligible_pending'
+    ) {
+      return {
+        status: record.rewardEligibilityStatus ?? 'disabled',
+        points: 0,
+        optimizationTokens: 0,
+        message:
+          'A nota foi registrada, mas ainda nao atingiu qualidade suficiente para recompensa.',
+      };
+    }
+
+    await this.entitlementsService.grantReceiptBonusTokens({
+      userId: record.userId,
+      receiptRecordId: record.id,
+      amount: 1,
+    });
+    await this.receiptRecordRepository.markRewardGranted(record.id);
+
+    return {
+      status: 'granted',
+      points: 100,
+      optimizationTokens: 1,
+      message:
+        'Nota validada: voce ganhou 100 pontos e 1 credito de otimizacao.',
+      reviewReason: 'receipt_reward_granted',
     };
   }
 

--- a/backend/src/receipts/infrastructure/receipt-record.repository.ts
+++ b/backend/src/receipts/infrastructure/receipt-record.repository.ts
@@ -71,6 +71,28 @@ export class ReceiptRecordRepository {
     });
   }
 
+  async markRewardGranted(receiptRecordId: string): Promise<void> {
+    const existing = await this.findById(receiptRecordId);
+
+    await this.prisma.receiptRecord.update({
+      where: {
+        id: receiptRecordId,
+      },
+      data: {
+        rewardEligibilityStatus: 'granted',
+        reviewReason: 'receipt_reward_granted',
+        rawReference: JSON.stringify({
+          rawSourceReference: existing?.rawSourceReference,
+          processingLogs: [
+            ...(existing?.processingLogs ?? []),
+            'reward:points_granted:100',
+            'reward:optimization_token_granted:1',
+          ],
+        }),
+      },
+    });
+  }
+
   async markExtractionFailed(
     receiptRecordId: string,
     reason: string,

--- a/backend/src/receipts/receipts.module.ts
+++ b/backend/src/receipts/receipts.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { CatalogModule } from '../catalog/catalog.module';
 import { ProcessingModule } from '../processing/processing.module';
 import { StoresModule } from '../stores/stores.module';
+import { UsersModule } from '../users/users.module';
 import { ReceiptsController } from './api/receipts.controller';
 import {
   OCR_RECEIPT_EXTRACTOR,
@@ -20,7 +21,7 @@ import { ReceiptSanitizerService } from './application/receipt-sanitizer.service
 import { ReceiptRecordRepository } from './infrastructure/receipt-record.repository';
 
 @Module({
-  imports: [CatalogModule, StoresModule, ProcessingModule],
+  imports: [CatalogModule, StoresModule, ProcessingModule, UsersModule],
   controllers: [ReceiptsController],
   providers: [
     ReceiptParserService,

--- a/backend/src/users/entitlements.service.ts
+++ b/backend/src/users/entitlements.service.ts
@@ -250,6 +250,31 @@ export class EntitlementsService {
     });
   }
 
+  async grantReceiptBonusTokens(input: {
+    userId: string;
+    receiptRecordId: string;
+    amount?: number;
+  }) {
+    const amount = input.amount ?? 1;
+    if (!Number.isInteger(amount) || amount <= 0) {
+      throw new BadRequestException('Receipt bonus amount must be positive');
+    }
+
+    return this.prisma.optimizationTokenLedgerEntry.upsert({
+      where: {
+        idempotencyKey: `receipt-bonus:${input.receiptRecordId}`,
+      },
+      update: {},
+      create: {
+        userId: input.userId,
+        action: 'receipt_bonus',
+        amount,
+        source: 'receipt_quality_reward',
+        idempotencyKey: `receipt-bonus:${input.receiptRecordId}`,
+      },
+    });
+  }
+
   private currentPeriod(now = new Date()): string {
     return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
   }

--- a/backend/test/integration/receipts/receipt-ingestion.integration.spec.ts
+++ b/backend/test/integration/receipts/receipt-ingestion.integration.spec.ts
@@ -31,8 +31,12 @@ describe('Receipt ingestion integration', () => {
         parseStatus: 'parsed',
         trustLevel: 'trusted',
         moderationStatus: 'accepted',
-        rewardEligibilityStatus: 'disabled',
-        reviewReason: 'receipt_rewards_disabled',
+        rewardEligibilityStatus: 'granted',
+        rewardPoints: 100,
+        rewardOptimizationTokens: 1,
+        rewardMessage:
+          'Nota validada: voce ganhou 100 pontos e 1 credito de otimizacao.',
+        reviewReason: 'receipt_reward_granted',
         dataNotice:
           'Prices and receipt data are based on receipts provided by users.',
       });

--- a/backend/test/support/us1-app.factory.ts
+++ b/backend/test/support/us1-app.factory.ts
@@ -233,6 +233,24 @@ class InMemoryReceiptRecordRepository {
     });
   }
 
+  async markRewardGranted(receiptRecordId: string) {
+    const existing = this.records.get(receiptRecordId);
+    if (!existing) {
+      return;
+    }
+
+    this.records.set(receiptRecordId, {
+      ...existing,
+      rewardEligibilityStatus: 'granted',
+      reviewReason: 'receipt_reward_granted',
+      processingLogs: [
+        ...(existing.processingLogs ?? []),
+        'reward:points_granted:100',
+        'reward:optimization_token_granted:1',
+      ],
+    });
+  }
+
   async findById(id: string) {
     const value = this.records.get(id);
     return value ? structuredClone(value) : null;

--- a/backend/test/unit/prisma-seed-coverage.spec.ts
+++ b/backend/test/unit/prisma-seed-coverage.spec.ts
@@ -32,7 +32,7 @@ describe('Prisma demo seed coverage', () => {
       "moderationStatus: 'quarantined'",
       "moderationStatus: 'duplicate'",
       "moderationStatus: 'rejected'",
-      "reviewReason: 'receipt_rewards_disabled'",
+      "reviewReason: 'receipt_reward_granted'",
       "reviewReason: 'duplicate_receipt'",
       "reviewReason: 'invalid_receipt_payload'",
       "sourceType: 'receipt'",

--- a/backend/test/unit/receipts/receipt-contribution-quality.service.spec.ts
+++ b/backend/test/unit/receipts/receipt-contribution-quality.service.spec.ts
@@ -35,7 +35,7 @@ function createReceipt(
 }
 
 describe('ReceiptContributionQualityService', () => {
-  it('accepts trusted non-duplicated receipts but keeps rewards disabled for MVP', async () => {
+  it('accepts trusted non-duplicated receipts and marks rewards ready', async () => {
     const service = new ReceiptContributionQualityService({
       findDuplicateCandidate: jest.fn().mockResolvedValue(null),
     } as never);
@@ -46,9 +46,11 @@ describe('ReceiptContributionQualityService', () => {
       duplicateKey: 'access-key:12345678901234567890123456789012345678901234',
       trustLevel: 'trusted',
       moderationStatus: 'accepted',
-      rewardEligibilityStatus: 'disabled',
-      reviewReason: 'receipt_rewards_disabled',
+      rewardEligibilityStatus: 'eligible_pending',
+      reviewReason: 'receipt_reward_ready',
     });
+    expect(result.logs).toContain('reward:points_pending:100');
+    expect(result.logs).toContain('reward:optimization_token_pending:1');
   });
 
   it('rejects duplicate receipts before reward eligibility', async () => {

--- a/backend/test/unit/users/entitlements.service.spec.ts
+++ b/backend/test/unit/users/entitlements.service.spec.ts
@@ -124,6 +124,22 @@ describe('EntitlementsService', () => {
     await expect(service.getAvailableTokenBalance('user-1')).resolves.toBe(1);
   });
 
+  it('grants receipt bonus tokens idempotently by receipt', async () => {
+    const mock = createPrismaMock();
+    const service = new EntitlementsService(mock.prisma as never);
+
+    await service.grantReceiptBonusTokens({
+      userId: 'user-1',
+      receiptRecordId: 'receipt-1',
+    });
+    await service.grantReceiptBonusTokens({
+      userId: 'user-1',
+      receiptRecordId: 'receipt-1',
+    });
+
+    expect(mock.ledger.size).toBe(1);
+    await expect(service.getAvailableTokenBalance('user-1')).resolves.toBe(1);
+  });
 
   it('rejects optimization when the configured free grant is zero', async () => {
     process.env.FREE_OPTIMIZATION_TOKENS_PER_MONTH = '0';

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -443,7 +443,7 @@ token rewards without letting bad or duplicated data corrupt prices.
 - [X] T159 Implement receipt contribution scoring, offer update quarantine, and manual review hooks in `backend/src/receipts/` and `backend/src/pricing/`
 - [X] T160 Add admin review surfaces for receipt-derived offers, suspicious submissions, and reward decisions in `web/src/dashboard/`
 - [X] T161 Add shopper receipt-submission feedback states for accepted, pending-review, duplicate, rejected, and rewarded outcomes in `web/src/public/` and `mobile/lib/features/`
-- [ ] T162 Connect receipt reward outcomes to the optimization token ledger only after contribution scoring passes in `backend/src/users/` and `backend/src/receipts/`
+- [X] T162 Connect receipt reward outcomes to the optimization token ledger only after contribution scoring passes in `backend/src/users/` and `backend/src/receipts/`
 
 ---
 
@@ -541,7 +541,7 @@ Premium access and extra optimization credits are support/admin operations for n
 - [~] T205 Persist optimization-specific variant substitutions on the original list while preserving the original `any variant` intent so future optimizations can swap variants again in `backend/src/lists/`, `backend/src/optimization/`, and `web/src/public/`
 - [X] T206 Update item decision math so savings compare selected offer against the second cheapest eligible offer, while city average remains a separate informational metric in `backend/src/optimization/`, `backend/src/common/contracts/optimization.contract.ts`, and `web/src/public/`
 - [X] T207 Rename shopper-facing trust copy to `Confianca da oferta`, including source labels for admin/manual/receipt evidence, receipt support count, freshness decay, and clearer no-receipt wording in `backend/src/optimization/`, `backend/src/pricing/`, and `web/src/public/`
-- [ ] T208 Add gamified receipt contribution rewards with points and token outcomes only after receipt quality scoring confirms useful, correctly processed receipt data in `backend/src/receipts/`, `backend/src/users/`, and `web/src/public/`
+- [~] T208 Add gamified receipt contribution rewards with points and token outcomes only after receipt quality scoring confirms useful, correctly processed receipt data in `backend/src/receipts/`, `backend/src/users/`, and `web/src/public/`
 - [X] T209 Add a dedicated admin receipt-processing queue/detail surface for receipt content, line-item quality, moderation status, and reward readiness in `backend/src/admin/` and `web/src/dashboard/`
 - [ ] T210 Add public city-request/contact flow while keeping city creation admin-only in `backend/src/regions/`, `backend/src/admin/`, and `web/src/public/`
 

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -419,6 +419,11 @@ type AdminReceiptProcessingResponse = {
     averageMatchConfidence: number;
     usefulDataRatio: number;
   };
+  reward: {
+    points: number;
+    optimizationTokens: number;
+    label: string;
+  };
 };
 
 type AdminQueueHealthResponse = {

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -380,6 +380,11 @@ describe('Admin dashboard pages', () => {
           averageMatchConfidence: 0.83,
           usefulDataRatio: 0.75,
         },
+        reward: {
+          points: 100,
+          optimizationTokens: 1,
+          label: '100 pontos + 1 credito pendente',
+        },
       },
     ]);
 
@@ -388,6 +393,7 @@ describe('Admin dashboard pages', () => {
     expect(await screen.findByText('Notas fiscais processadas')).toBeTruthy();
     expect(screen.getAllByText('Mercado Centro').length).toBeGreaterThan(0);
     expect(screen.getByText('3/4 itens fortes')).toBeTruthy();
+    expect(screen.getByText('100 pontos + 1 credito pendente')).toBeTruthy();
     expect(screen.getByText('eligible_pending')).toBeTruthy();
     expect(screen.getByText('Ver leitura')).toBeTruthy();
   });

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -2376,6 +2376,9 @@ export function AdminReceiptsPage() {
                 <div className="rounded-md border border-border/70 p-3">
                   <div className="text-xs text-muted-foreground">Reward</div>
                   <div className="mt-1 font-medium">
+                    {receipt.reward.label}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
                     {receipt.rewardEligibilityStatus}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- mark trusted accepted receipts as reward-ready after quality scoring
- grant idempotent receipt_bonus optimization token and return 100-point reward feedback
- surface reward point/token labels in the admin receipt queue and seed data

## Validation
- backend: npm test -- --runTestsByPath test/unit/receipts/receipt-contribution-quality.service.spec.ts test/unit/users/entitlements.service.spec.ts test/integration/receipts/receipt-ingestion.integration.spec.ts test/unit/prisma-seed-coverage.spec.ts
- backend: npm run lint
- backend: npm run build
- web: npm test -- dashboard-pages.spec.tsx
- web: npm run lint
- web: npm run build