### PR TITLE
Add public city inclusion requests

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -163,6 +163,13 @@ enum ReceiptRewardEligibilityStatus {
   granted
 }
 
+enum CityInclusionRequestStatus {
+  requested
+  reviewed
+  planned
+  rejected
+}
+
 model UserAccount {
   id               String            @id @default(uuid()) @db.Uuid
   email            String            @unique
@@ -199,6 +206,21 @@ model Region {
   optimizationRuns OptimizationRun[]
   preferredByUsers UserAccount[]     @relation("UserPreferredRegion")
   userLocationPreferences UserLocationPreference[]
+}
+
+model CityInclusionRequest {
+  id          String                     @id @default(uuid()) @db.Uuid
+  cityName    String
+  stateCode   String                     @db.VarChar(2)
+  contactName String?
+  contactEmail String?
+  message     String?
+  status      CityInclusionRequestStatus @default(requested)
+  createdAt   DateTime                   @default(now())
+  updatedAt   DateTime                   @updatedAt
+
+  @@index([stateCode, cityName])
+  @@index([status, createdAt])
 }
 
 model Establishment {

--- a/backend/src/common/contracts/regions.contract.ts
+++ b/backend/src/common/contracts/regions.contract.ts
@@ -8,6 +8,22 @@ export interface PublicRegionContract {
   offerCoverageStatus: 'live' | 'collecting_data';
 }
 
+export interface CityInclusionRequestContract {
+  id: string;
+  cityName: string;
+  stateCode: string;
+  status: 'requested' | 'reviewed' | 'planned' | 'rejected';
+  createdAt: string;
+}
+
+export interface CreateCityInclusionRequestContract {
+  cityName: string;
+  stateCode: string;
+  contactName?: string;
+  contactEmail?: string;
+  message?: string;
+}
+
 export interface PublicImpactContract {
   totalEstimatedSavings: number;
   optimizedListsCount: number;

--- a/backend/src/regions/api/public-regions.controller.ts
+++ b/backend/src/regions/api/public-regions.controller.ts
@@ -1,6 +1,34 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { IsEmail, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 
 import { PublicRegionsService } from '../application/public-regions.service';
+
+class CityInclusionRequestDto {
+  @IsString()
+  @MinLength(2)
+  @MaxLength(80)
+  cityName!: string;
+
+  @IsString()
+  @MinLength(2)
+  @MaxLength(2)
+  stateCode!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(80)
+  contactName?: string;
+
+  @IsOptional()
+  @IsEmail()
+  @MaxLength(160)
+  contactEmail?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  message?: string;
+}
 
 @Controller('regions')
 export class PublicRegionsController {
@@ -14,5 +42,10 @@ export class PublicRegionsController {
   @Get('impact')
   async impact() {
     return this.publicRegionsService.getPublicImpact();
+  }
+
+  @Post('requests')
+  async requestCity(@Body() body: CityInclusionRequestDto) {
+    return this.publicRegionsService.requestCityInclusion(body);
   }
 }

--- a/backend/src/regions/application/public-regions.service.ts
+++ b/backend/src/regions/application/public-regions.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+import { type CreateCityInclusionRequestContract } from '../../common/contracts';
 import { PrismaService } from '../../persistence/prisma.service';
 
 @Injectable()
@@ -90,5 +91,29 @@ export class PublicRegionsService {
     );
 
     return impact;
+  }
+
+  async requestCityInclusion(input: CreateCityInclusionRequestContract) {
+    const request = await this.prisma.cityInclusionRequest.create({
+      data: {
+        cityName: input.cityName.trim(),
+        stateCode: input.stateCode.trim().toUpperCase(),
+        contactName: input.contactName?.trim(),
+        contactEmail: input.contactEmail?.trim().toLowerCase(),
+        message: input.message?.trim(),
+      },
+    });
+
+    this.logger.log(
+      `City inclusion requested: ${request.cityName}-${request.stateCode}`,
+    );
+
+    return {
+      id: request.id,
+      cityName: request.cityName,
+      stateCode: request.stateCode,
+      status: request.status,
+      createdAt: request.createdAt.toISOString(),
+    };
   }
 }

--- a/backend/test/integration/regions/public-regions.integration.spec.ts
+++ b/backend/test/integration/regions/public-regions.integration.spec.ts
@@ -50,6 +50,15 @@ describe('Public regions and pricing integration', () => {
       establishment: {
         count: async () => 1,
       },
+      cityInclusionRequest: {
+        create: async ({ data }: { data: Record<string, unknown> }) => ({
+          id: 'request-1',
+          status: 'requested',
+          createdAt: new Date('2026-05-10T10:00:00Z'),
+          updatedAt: new Date('2026-05-10T10:00:00Z'),
+          ...data,
+        }),
+      },
       productOffer: {
         findMany: async ({ where }: { where: Record<string, unknown> }) => {
           if (where.catalogProductId) {
@@ -211,6 +220,27 @@ describe('Public regions and pricing integration', () => {
           id: 'variant-1',
         }),
         alternativeOffers: expect.any(Array),
+      }),
+    );
+  });
+
+  it('accepts public city inclusion requests without creating a region', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/regions/requests')
+      .send({
+        cityName: 'Santos',
+        stateCode: 'sp',
+        contactEmail: 'cliente@pricely.local',
+        message: 'Priorizar mercados da orla',
+      })
+      .expect(201);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        id: 'request-1',
+        cityName: 'Santos',
+        stateCode: 'SP',
+        status: 'requested',
       }),
     );
   });

--- a/backend/test/support/us1-app.factory.ts
+++ b/backend/test/support/us1-app.factory.ts
@@ -595,6 +595,16 @@ class PrismaUserAccountMock {
     },
   };
 
+  readonly cityInclusionRequest = {
+    create: async ({ data }: { data: any }) => ({
+      id: crypto.randomUUID(),
+      status: 'requested',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...data,
+    }),
+  };
+
   readonly establishment = {
     count: async ({
       where,

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -543,7 +543,7 @@ Premium access and extra optimization credits are support/admin operations for n
 - [X] T207 Rename shopper-facing trust copy to `Confianca da oferta`, including source labels for admin/manual/receipt evidence, receipt support count, freshness decay, and clearer no-receipt wording in `backend/src/optimization/`, `backend/src/pricing/`, and `web/src/public/`
 - [~] T208 Add gamified receipt contribution rewards with points and token outcomes only after receipt quality scoring confirms useful, correctly processed receipt data in `backend/src/receipts/`, `backend/src/users/`, and `web/src/public/`
 - [X] T209 Add a dedicated admin receipt-processing queue/detail surface for receipt content, line-item quality, moderation status, and reward readiness in `backend/src/admin/` and `web/src/dashboard/`
-- [ ] T210 Add public city-request/contact flow while keeping city creation admin-only in `backend/src/regions/`, `backend/src/admin/`, and `web/src/public/`
+- [X] T210 Add public city-request/contact flow while keeping city creation admin-only in `backend/src/regions/`, `backend/src/admin/`, and `web/src/public/`
 
 ---
 

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -129,6 +129,14 @@ type PublicImpactResponse = {
   optimizedListsCount: number;
 };
 
+type CityInclusionRequestResponse = {
+  id: string;
+  cityName: string;
+  stateCode: string;
+  status: 'requested' | 'reviewed' | 'planned' | 'rejected';
+  createdAt: string;
+};
+
 type RegionOffersApiResponse = {
   region: {
     id: string;
@@ -716,6 +724,19 @@ export async function fetchPublicImpact() {
   return apiFetch<PublicImpactResponse>('/regions/impact');
 }
 
+export async function requestCityInclusion(input: {
+  cityName: string;
+  stateCode: string;
+  contactName?: string;
+  contactEmail?: string;
+  message?: string;
+}) {
+  return apiFetch<CityInclusionRequestResponse>('/regions/requests', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}
+
 export async function fetchRegionOffers(regionSlug: string) {
   return apiFetch<RegionOffersApiResponse>(`/regions/${regionSlug}/offers`);
 }
@@ -1286,6 +1307,7 @@ export function mapShoppingList(
 export type {
   AdminShoppingListAuditResponse,
   AdminUserResponse,
+  CityInclusionRequestResponse,
   CoveragePreviewResponse,
   AdminEstablishmentResponse,
   AdminMetricsResponse,

--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -8,6 +8,7 @@ import { CitiesPage, OfferDetailPage, OffersPage } from './public-pages';
 
 const fetchRegionOffers = vi.fn();
 const fetchOfferDetail = vi.fn();
+const requestCityInclusion = vi.fn();
 
 const setCityId = vi.fn();
 
@@ -51,6 +52,8 @@ vi.mock('@/app/api', async () => {
     ...actual,
     fetchRegionOffers: (...args: unknown[]) => fetchRegionOffers(...args),
     fetchOfferDetail: (...args: unknown[]) => fetchOfferDetail(...args),
+    requestCityInclusion: (...args: unknown[]) =>
+      requestCityInclusion(...args),
   };
 });
 
@@ -58,6 +61,7 @@ describe('public pages', () => {
   beforeEach(() => {
     fetchRegionOffers.mockReset();
     fetchOfferDetail.mockReset();
+    requestCityInclusion.mockReset();
     setCityId.mockReset();
   });
 
@@ -87,6 +91,43 @@ describe('public pages', () => {
     expect(
       screen.getByText(/2 estabelecimentos ativos com ofertas na cidade/),
     ).toBeTruthy();
+  });
+
+  it('submits a public city inclusion request', async () => {
+    requestCityInclusion.mockResolvedValue({
+      id: 'request-1',
+      cityName: 'Santos',
+      stateCode: 'SP',
+      status: 'requested',
+      createdAt: '2026-05-10T10:00:00.000Z',
+    });
+
+    render(
+      <MemoryRouter>
+        <CitiesPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Cidade'), {
+      target: { value: 'Santos' },
+    });
+    fireEvent.change(screen.getByLabelText('UF'), {
+      target: { value: 'sp' },
+    });
+    fireEvent.change(screen.getByLabelText('Contato'), {
+      target: { value: 'cliente@pricely.local' },
+    });
+    fireEvent.click(screen.getByText('Solicitar'));
+
+    await waitFor(() =>
+      expect(requestCityInclusion).toHaveBeenCalledWith({
+        cityName: 'Santos',
+        stateCode: 'SP',
+        contactEmail: 'cliente@pricely.local',
+        message: undefined,
+      }),
+    );
+    expect(screen.getByText('Pedido registrado')).toBeTruthy();
   });
 
   it('renders regional offers with empty-state friendly city context', async () => {

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -27,6 +27,7 @@ import {
   fetchCatalogProductVariants,
   fetchOfferDetail,
   fetchRegionOffers,
+  requestCityInclusion,
   searchCatalogProducts,
 } from '@/app/api';
 import { usePricely } from '@/app/pricely-context';
@@ -1149,6 +1150,38 @@ export function OfferDetailPage() {
 
 export function CitiesPage() {
   const { cities } = usePricely();
+  const [requestForm, setRequestForm] = useState({
+    cityName: '',
+    stateCode: '',
+    contactEmail: '',
+    message: '',
+  });
+  const [requestStatus, setRequestStatus] = useState<
+    'idle' | 'submitting' | 'submitted' | 'failed'
+  >('idle');
+
+  const handleCityRequestSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setRequestStatus('submitting');
+
+    try {
+      await requestCityInclusion({
+        cityName: requestForm.cityName,
+        stateCode: requestForm.stateCode,
+        contactEmail: requestForm.contactEmail || undefined,
+        message: requestForm.message || undefined,
+      });
+      setRequestStatus('submitted');
+      setRequestForm({
+        cityName: '',
+        stateCode: '',
+        contactEmail: '',
+        message: '',
+      });
+    } catch {
+      setRequestStatus('failed');
+    }
+  };
 
   return (
     <div className="flex flex-col gap-6">
@@ -1210,6 +1243,113 @@ export function CitiesPage() {
           </Card>
         ))}
       </div>
+
+      <Card className="border-border/70 bg-card/90 shadow-sm">
+        <CardHeader>
+          <CardTitle>Solicitar nova cidade</CardTitle>
+          <CardDescription>
+            A equipe analisa pedidos de cobertura. Somente admins conseguem
+            ativar cidades e estabelecimentos no sistema.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="grid gap-4 md:grid-cols-[1fr_120px] lg:grid-cols-[1fr_120px_1fr_auto]"
+            onSubmit={handleCityRequestSubmit}
+          >
+            <Field>
+              <FieldLabel htmlFor="city-request-name">Cidade</FieldLabel>
+              <Input
+                id="city-request-name"
+                maxLength={80}
+                minLength={2}
+                onChange={(event) =>
+                  setRequestForm((current) => ({
+                    ...current,
+                    cityName: event.target.value,
+                  }))
+                }
+                placeholder="Campinas"
+                required
+                value={requestForm.cityName}
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="city-request-state">UF</FieldLabel>
+              <Input
+                id="city-request-state"
+                maxLength={2}
+                minLength={2}
+                onChange={(event) =>
+                  setRequestForm((current) => ({
+                    ...current,
+                    stateCode: event.target.value.toUpperCase(),
+                  }))
+                }
+                placeholder="SP"
+                required
+                value={requestForm.stateCode}
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="city-request-email">Contato</FieldLabel>
+              <Input
+                id="city-request-email"
+                onChange={(event) =>
+                  setRequestForm((current) => ({
+                    ...current,
+                    contactEmail: event.target.value,
+                  }))
+                }
+                placeholder="email opcional"
+                type="email"
+                value={requestForm.contactEmail}
+              />
+            </Field>
+            <div className="flex items-end">
+              <Button disabled={requestStatus === 'submitting'} type="submit">
+                Solicitar
+              </Button>
+            </div>
+            <Field className="md:col-span-2 lg:col-span-4">
+              <FieldLabel htmlFor="city-request-message">
+                Estabelecimentos importantes
+              </FieldLabel>
+              <Textarea
+                id="city-request-message"
+                maxLength={500}
+                onChange={(event) =>
+                  setRequestForm((current) => ({
+                    ...current,
+                    message: event.target.value,
+                  }))
+                }
+                placeholder="Mercados ou bairros que deveriam entrar na cobertura"
+                value={requestForm.message}
+              />
+            </Field>
+          </form>
+          {requestStatus === 'submitted' ? (
+            <Alert className="mt-4">
+              <BadgeCheckIcon />
+              <AlertTitle>Pedido registrado</AlertTitle>
+              <AlertDescription>
+                Vamos avaliar a cidade e priorizar a ativação quando houver
+                cobertura mínima de estabelecimentos e ofertas.
+              </AlertDescription>
+            </Alert>
+          ) : null}
+          {requestStatus === 'failed' ? (
+            <Alert className="mt-4" variant="destructive">
+              <AlertCircleIcon />
+              <AlertTitle>Não foi possível enviar</AlertTitle>
+              <AlertDescription>
+                Revise os campos e tente novamente em instantes.
+              </AlertDescription>
+            </Alert>
+          ) : null}
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add persisted city inclusion requests while keeping region creation admin-only
- expose POST /regions/requests for public requests
- add a request form to the public cities page with success/error states

## Validation
- backend: npx prisma generate
- backend: npm test -- --runTestsByPath test/integration/regions/public-regions.integration.spec.ts
- backend: npm run lint
- backend: npm run build
- web: npm test -- public-pages.spec.tsx
- web: npm run lint
- web: npm run build