### PR TITLE
Test receipt processing modes

### DIFF
--- a/backend/test/integration/receipts/receipt-ingestion.integration.spec.ts
+++ b/backend/test/integration/receipts/receipt-ingestion.integration.spec.ts
@@ -3,7 +3,22 @@ import request from 'supertest';
 import { createUs1TestApp } from '../../support/us1-app.factory';
 
 describe('Receipt ingestion integration', () => {
-  it('accepts a receipt payload and returns a structured receipt record', async () => {
+  let previousProcessingMode: string | undefined;
+
+  beforeEach(() => {
+    previousProcessingMode = process.env.RECEIPT_PROCESSING_MODE;
+    delete process.env.RECEIPT_PROCESSING_MODE;
+  });
+
+  afterEach(() => {
+    if (previousProcessingMode === undefined) {
+      delete process.env.RECEIPT_PROCESSING_MODE;
+    } else {
+      process.env.RECEIPT_PROCESSING_MODE = previousProcessingMode;
+    }
+  });
+
+  it('keeps a trusted receipt waiting for manual release by default', async () => {
     const { app, queues, auth } = await createUs1TestApp();
 
     try {
@@ -45,6 +60,89 @@ describe('Receipt ingestion integration', () => {
       expect(response.body.jobId).toBeUndefined();
       expect(response.body.confidenceScore).toBeGreaterThan(0.8);
       expect(queues.receiptQueue.add).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('allows an admin to release a manually queued receipt for processing', async () => {
+    const { app, queues, auth } = await createUs1TestApp();
+
+    try {
+      const customer = await auth.registerCustomer(
+        'manual-release-receipt@pricely.local',
+      );
+      const admin = await auth.registerAdmin('receipt-admin@pricely.local');
+
+      const receipt = await request(app.getHttpServer())
+        .post('/receipts')
+        .set('Authorization', `Bearer ${customer.accessToken}`)
+        .send({
+          storeName: 'Mercado Manual',
+          sourceType: 'manual_entry',
+          items: [
+            {
+              rawProductName: 'Leite Integral 1L',
+              ean: '7891000100103',
+              quantity: 2,
+              unitPrice: 5.49,
+            },
+          ],
+        })
+        .expect(202);
+
+      expect(receipt.body.processingStatus).toBe('waiting_manual_release');
+      expect(receipt.body.jobId).toBeUndefined();
+      expect(queues.receiptQueue.add).not.toHaveBeenCalled();
+
+      const released = await request(app.getHttpServer())
+        .post(`/admin/receipt-processing/${receipt.body.id}/release`)
+        .set('Authorization', `Bearer ${admin.accessToken}`)
+        .expect(201);
+
+      expect(released.body).toMatchObject({
+        id: receipt.body.id,
+        processingStatus: 'queued',
+        jobId: expect.any(String),
+      });
+      expect(queues.receiptQueue.add).toHaveBeenCalledTimes(1);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('queues receipt processing immediately when automatic mode is enabled', async () => {
+    process.env.RECEIPT_PROCESSING_MODE = 'automatic';
+    const { app, queues, auth } = await createUs1TestApp();
+
+    try {
+      const session = await auth.registerCustomer(
+        'automatic-receipt@pricely.local',
+      );
+
+      const response = await request(app.getHttpServer())
+        .post('/receipts')
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .send({
+          storeName: 'Mercado Automatico',
+          sourceType: 'manual_entry',
+          items: [
+            {
+              rawProductName: 'Arroz Branco tp1 5kg',
+              ean: '7891234567895',
+              quantity: 1,
+              unitPrice: 28.9,
+            },
+          ],
+        })
+        .expect(202);
+
+      expect(response.body).toMatchObject({
+        parseStatus: 'parsed',
+        processingStatus: 'queued',
+        jobId: expect.any(String),
+      });
+      expect(queues.receiptQueue.add).toHaveBeenCalledTimes(1);
     } finally {
       await app.close();
     }

--- a/backend/test/support/us1-app.factory.ts
+++ b/backend/test/support/us1-app.factory.ts
@@ -1185,6 +1185,9 @@ export async function createUs1TestApp(): Promise<{
     registerCustomer: (
       email?: string,
     ) => Promise<{ accessToken: string; user: Record<string, unknown> }>;
+    registerAdmin: (
+      email?: string,
+    ) => Promise<{ accessToken: string; user: Record<string, unknown> }>;
   };
 }> {
   process.env.JWT_ACCESS_SECRET = 'test-jwt-secret';
@@ -1306,6 +1309,34 @@ export async function createUs1TestApp(): Promise<{
         return {
           accessToken: response.body.accessToken as string,
           user: response.body.user as Record<string, unknown>,
+        };
+      },
+      registerAdmin: async (email = `admin-${Date.now()}@pricely.local`) => {
+        const response = await request(app.getHttpServer())
+          .post('/auth/register')
+          .send({
+            email,
+            password: 'strong-password',
+            displayName: 'Admin de teste',
+          })
+          .expect(201);
+
+        await userAccountMock.userAccount.update({
+          where: { id: response.body.user.id as string },
+          data: { role: 'admin' },
+        });
+
+        const login = await request(app.getHttpServer())
+          .post('/auth/login')
+          .send({
+            email,
+            password: 'strong-password',
+          })
+          .expect(200);
+
+        return {
+          accessToken: login.body.accessToken as string,
+          user: login.body.user as Record<string, unknown>,
         };
       },
     },


### PR DESCRIPTION
## Summary
- add explicit API-level tests for default manual receipt processing
- add admin release coverage for manually queued receipts
- add automatic-mode coverage for RECEIPT_PROCESSING_MODE=automatic

## Validation
- backend: npm test -- --runTestsByPath test/integration/receipts/receipt-ingestion.integration.spec.ts
- backend: npm test
- backend: npm run lint
- backend: npm run build