### PR TITLE
Add dashboard route coverage and error page

### DIFF
--- a/web/src/routes/app-router.spec.tsx
+++ b/web/src/routes/app-router.spec.tsx
@@ -2,14 +2,52 @@
 
 import { cleanup, render, screen } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { PricelyProvider } from '@/app/pricely-context';
 import { ThemeProvider } from '@/app/theme-context';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 import { dashboardRoute } from './dashboard';
 import { publicRoute } from './public';
+
+let pricelyState = {
+  accessToken: null as string | null,
+  currentUser: null as null | {
+    id: string;
+    email: string;
+    displayName: string;
+    role: 'customer' | 'admin';
+  },
+  isAuthenticated: false,
+};
+
+vi.mock('@/app/pricely-context', () => ({
+  usePricely: () => ({
+    ...pricelyState,
+    cities: [],
+    lists: [],
+    profile: {
+      totalEstimatedSavings: 0,
+      listsCreated: 0,
+      receiptsShared: 0,
+      invalidPromotionReports: 0,
+      entitlementPlan: 'free',
+      entitlementStatus: 'active',
+      availableOptimizationTokens: 0,
+      monthlyFreeOptimizationTokens: 2,
+      billingEnabled: false,
+      checkoutEnabled: false,
+    },
+  }),
+}));
+
+vi.mock('@/app/api', async () => {
+  const actual = await vi.importActual('@/app/api');
+  return {
+    ...actual,
+    fetchAdminReceiptProcessing: vi.fn().mockResolvedValue([]),
+  };
+});
 
 vi.mock('@/app/theme-context', async () => {
   const actual = await vi.importActual('@/app/theme-context');
@@ -44,13 +82,19 @@ function renderRoute(initialEntry: string) {
   return render(
     <TooltipProvider>
       <ThemeProvider>
-        <PricelyProvider>
-          <RouterProvider router={router} />
-        </PricelyProvider>
+        <RouterProvider router={router} />
       </ThemeProvider>
     </TooltipProvider>,
   );
 }
+
+beforeEach(() => {
+  pricelyState = {
+    accessToken: null,
+    currentUser: null,
+    isAuthenticated: false,
+  };
+});
 
 afterEach(() => {
   cleanup();
@@ -73,5 +117,40 @@ describe('application routes', () => {
         'O dashboard administrativo so pode ser acessado por contas admin no web.',
       ),
     ).toBeTruthy();
+  });
+
+  it('renders the admin receipts route registered in the dashboard navigation', async () => {
+    pricelyState = {
+      accessToken: 'token',
+      currentUser: {
+        id: 'admin-1',
+        email: 'admin@pricely.local',
+        displayName: 'Admin',
+        role: 'admin',
+      },
+      isAuthenticated: true,
+    };
+
+    renderRoute('/dashboard/notas');
+
+    expect(await screen.findByText('Notas fiscais processadas')).toBeTruthy();
+  });
+
+  it('renders a custom route error instead of the React Router default page', () => {
+    pricelyState = {
+      accessToken: 'token',
+      currentUser: {
+        id: 'admin-1',
+        email: 'admin@pricely.local',
+        displayName: 'Admin',
+        role: 'admin',
+      },
+      isAuthenticated: true,
+    };
+
+    renderRoute('/dashboard/rota-inexistente');
+
+    expect(screen.getByText('Pagina nao encontrada')).toBeTruthy();
+    expect(screen.queryByText('Unexpected Application Error!')).toBeNull();
   });
 });

--- a/web/src/routes/app-router.tsx
+++ b/web/src/routes/app-router.tsx
@@ -1,5 +1,7 @@
 import { createBrowserRouter, type RouteObject } from 'react-router-dom';
 
+import { RouteErrorPage } from './route-error';
+
 const publicChildren: RouteObject[] = [
   {
     index: true,
@@ -77,6 +79,10 @@ const publicChildren: RouteObject[] = [
       const { OptimizationPage } = await import('@/public/public-pages');
       return { Component: OptimizationPage };
     },
+  },
+  {
+    path: '*',
+    element: <RouteErrorPage />,
   },
 ];
 
@@ -167,11 +173,16 @@ const dashboardChildren: RouteObject[] = [
       return { Component: AdminCatalogPage };
     },
   },
+  {
+    path: '*',
+    element: <RouteErrorPage />,
+  },
 ];
 
 export const appRouter = createBrowserRouter([
   {
     path: '/',
+    errorElement: <RouteErrorPage />,
     lazy: async () => {
       const { PublicLayout } = await import('@/public/public-shell');
       return { Component: PublicLayout };
@@ -180,10 +191,15 @@ export const appRouter = createBrowserRouter([
   },
   {
     path: '/dashboard',
+    errorElement: <RouteErrorPage />,
     lazy: async () => {
       const { AdminLayout } = await import('@/dashboard/admin-shell');
       return { Component: AdminLayout };
     },
     children: dashboardChildren,
+  },
+  {
+    path: '*',
+    element: <RouteErrorPage />,
   },
 ]);

--- a/web/src/routes/dashboard.tsx
+++ b/web/src/routes/dashboard.tsx
@@ -11,10 +11,12 @@ import {
   AdminRegionsPage,
   AdminUsersPage,
 } from '@/dashboard/dashboard-pages';
+import { RouteErrorPage } from './route-error';
 
 export const dashboardRoute = {
   path: '/dashboard',
   element: <AdminLayout />,
+  errorElement: <RouteErrorPage />,
   children: [
     {
       index: true,
@@ -63,6 +65,10 @@ export const dashboardRoute = {
     {
       path: 'catalogo',
       element: <AdminCatalogPage />,
+    },
+    {
+      path: '*',
+      element: <RouteErrorPage />,
     },
   ],
 };

--- a/web/src/routes/public.tsx
+++ b/web/src/routes/public.tsx
@@ -8,13 +8,16 @@ import {
   OfferDetailPage,
   OffersPage,
   OptimizationPage,
+  ReceiptSubmissionPage,
   SignInPage,
   SignUpPage,
 } from '@/public/public-pages';
+import { RouteErrorPage } from './route-error';
 
 export const publicRoute = {
   path: '/',
   element: <PublicLayout />,
+  errorElement: <RouteErrorPage />,
   children: [
     {
       index: true,
@@ -45,6 +48,10 @@ export const publicRoute = {
       element: <ListsPage />,
     },
     {
+      path: 'notas',
+      element: <ReceiptSubmissionPage />,
+    },
+    {
       path: 'listas/:listId',
       element: <ListEditorPage />,
     },
@@ -55,6 +62,10 @@ export const publicRoute = {
     {
       path: 'otimizacao/:listId',
       element: <OptimizationPage />,
+    },
+    {
+      path: '*',
+      element: <RouteErrorPage />,
     },
   ],
 };

--- a/web/src/routes/route-error.tsx
+++ b/web/src/routes/route-error.tsx
@@ -1,0 +1,44 @@
+import { Link, isRouteErrorResponse, useRouteError } from 'react-router-dom';
+
+import { AlertTriangleIcon } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+export function RouteErrorPage() {
+  const error = useRouteError();
+  const isRouteError = isRouteErrorResponse(error);
+  const status = isRouteError ? error.status : error ? 500 : 404;
+  const title =
+    status === 404
+      ? 'Pagina nao encontrada'
+      : 'Nao foi possivel abrir esta pagina';
+  const description =
+    status === 404
+      ? 'O endereco informado nao existe nesta versao do Pricely.'
+      : 'Tente voltar para uma area conhecida do app.';
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-4 py-10">
+      <section className="grid w-full max-w-xl gap-5 rounded-lg border border-border/70 bg-card p-6 shadow-sm">
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-lg bg-destructive/10 text-destructive">
+            <AlertTriangleIcon className="size-5" />
+          </div>
+          <div>
+            <div className="text-sm text-muted-foreground">Erro {status}</div>
+            <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+          </div>
+        </div>
+        <p className="text-sm text-muted-foreground">{description}</p>
+        <div className="flex flex-wrap gap-2">
+          <Button asChild>
+            <Link to="/">Ir para o inicio</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link to="/dashboard">Abrir dashboard</Link>
+          </Button>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- keep dashboard/public static route maps aligned with lazy app router for receipt routes
- add a custom router error page for 404 and unexpected route errors
- add route coverage for /dashboard/notas so the admin receipts page cannot regress to 404

## Validation
- web: npm test -- app-router.spec.tsx
- web: npm run lint
- web: npm run build