### PR TITLE
Add location preview UX states

### DIFF
--- a/mobile/lib/features/home/presentation/mobile_home_screen.dart
+++ b/mobile/lib/features/home/presentation/mobile_home_screen.dart
@@ -406,6 +406,8 @@ class _HomeTab extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 20),
+          _LocationPreviewCard(region: region),
+          const SizedBox(height: 20),
           Row(
             children: <Widget>[
               Expanded(
@@ -1401,6 +1403,56 @@ class _SignalChip extends StatelessWidget {
         label,
         style:
             Theme.of(context).textTheme.labelLarge?.copyWith(color: foreground),
+      ),
+    );
+  }
+}
+
+class _LocationPreviewCard extends StatelessWidget {
+  const _LocationPreviewCard({required this.region});
+
+  final PublicRegionSummary? region;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Icon(Icons.my_location_outlined, color: theme.colorScheme.primary),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Localização e raio',
+                  style: theme.textTheme.titleMedium,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            region == null
+                ? 'Escolha uma cidade para carregar o preview local.'
+                : '${region!.name} · ${region!.stateCode} · ${region!.activeEstablishmentCount} lojas candidatas na cidade.',
+          ),
+          const SizedBox(height: 8),
+          const Text('Raio local padrão: 5 km.'),
+          const SizedBox(height: 8),
+          Text(
+            'No MVP atual, a permissão de localização fica manual e a distância não altera a otimização. A busca continua baseada na cidade selecionada.',
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/features/optimization/presentation/multi_market_result_screen.dart
+++ b/mobile/lib/features/optimization/presentation/multi_market_result_screen.dart
@@ -128,6 +128,27 @@ class MultiMarketResultView extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 12),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Localização e raio',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                const Text('Raio local padrão: 5 km.'),
+                const SizedBox(height: 6),
+                const Text(
+                  'A distância ainda é apenas preview neste MVP. O resultado usa a cidade da lista e não promete loja mais próxima.',
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
         for (final plan in result.storePlans) ...<Widget>[
           Card(
             child: Padding(

--- a/mobile/test/widget/features/optimization/multi_market_result_screen_test.dart
+++ b/mobile/test/widget/features/optimization/multi_market_result_screen_test.dart
@@ -93,7 +93,11 @@ void main() {
     expect(find.text('Mercado Azul'), findsOneWidget);
     expect(find.text('Super Verde'), findsOneWidget);
     expect(find.textContaining('Economia estimada'), findsOneWidget);
+    expect(find.text('Localização e raio'), findsOneWidget);
+    expect(find.text('Raio local padrão: 5 km.'), findsOneWidget);
+    expect(find.textContaining('não promete loja mais próxima'), findsOneWidget);
     expect(find.textContaining('variante exata: Camil · Arroz'), findsOneWidget);
+    await tester.scrollUntilVisible(find.text('- Leite vegetal'), 220);
     expect(find.text('- Leite vegetal'), findsOneWidget);
   });
 }

--- a/mobile/test/widget/features/regions/mobile_home_public_regions_test.dart
+++ b/mobile/test/widget/features/regions/mobile_home_public_regions_test.dart
@@ -51,6 +51,13 @@ void main() {
       find.textContaining('contribuir com recibos'),
       findsOneWidget,
     );
+    await tester.scrollUntilVisible(
+      find.text('Localização e raio'),
+      220,
+    );
+    expect(find.text('Localização e raio'), findsOneWidget);
+    expect(find.text('Raio local padrão: 5 km.'), findsOneWidget);
+    expect(find.textContaining('distância não altera a otimização'), findsOneWidget);
   });
 
   testWidgets('renders active city offers and opens the offer detail sheet', (tester) async {
@@ -61,6 +68,11 @@ void main() {
 
     expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
     expect(find.textContaining('2 lojas'), findsOneWidget);
+    await tester.scrollUntilVisible(
+      find.textContaining('2 lojas candidatas na cidade'),
+      220,
+    );
+    expect(find.textContaining('2 lojas candidatas na cidade'), findsOneWidget);
     expect(app.discoveryController.offers, hasLength(1));
     expect(app.discoveryController.offers.single.productName, 'Cafe torrado');
     final detail =

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -499,7 +499,7 @@ rules into implementation tasks against the real product.
 - [~] T181 Render persisted optimization explanations as shopper evidence modules with trust factor, source type, receipt/observation count, freshness decay, confidence notice, selected variant, true comparison math, and report/upload actions in `web/src/public/` and `mobile/lib/features/optimization/`
 - [~] T182 Render admin decision evidence modules with selected offers, rejected alternatives, trust decay, receipt provenance, moderation status, and source labels in `web/src/dashboard/`
 - [~] T183 Refactor receipt contribution surfaces so accepted, pending-review, duplicate, rejected, and low-confidence outcomes are visual and actionable without promising token rewards before T162 in `web/src/public/`, `web/src/dashboard/`, and `mobile/lib/features/receipts/`
-- [ ] T184 Add Phase 23-ready location widgets as explicit city/location/radius preview states, keeping proximity claims disabled until T170-T177 add persisted coordinates and distance-aware optimization in `web/src/public/` and `mobile/lib/features/`
+- [~] T184 Add Phase 23-ready location widgets as explicit city/location/radius preview states, keeping proximity claims disabled until T170-T177 add persisted coordinates and distance-aware optimization in `web/src/public/` and `mobile/lib/features/`
 - [~] T185 Refactor admin overview into an action-first operations surface that elevates stale offers, low-trust offers, failed jobs, quarantined receipts, catalog image gaps, and city coverage issues in `web/src/dashboard/`
 - [~] T186 Refactor public city and offer surfaces so activating cities have explicit placeholders, supported-establishment sections show active stores or activation states, offers are grouped by product/variant with cheapest eligible establishment first, and establishment filters/comparison panels replace duplicate offer cards in `web/src/public/` and `web/src/app/`
 - [~] T187 Refactor public web surfaces toward the audited direction for landing, city selection, offers explorer, offer detail, lists, list editor, optimization result, receipt states, location widgets, premium/free entitlement copy, and disabled billing gate in `web/src/public/`
@@ -553,7 +553,7 @@ Premium access and extra optimization credits are support/admin operations for n
 - [~] T214 Expand admin receipt detail with extracted payload, product matcher result, missing-product maker actions, and price up/down comparison against current offers in `backend/src/admin/` and `web/src/dashboard/`
 - [ ] T215 Add mobile QR-code receipt submission flow that posts the scanned NFC-e URL to backend and shows submitted -> waiting release -> processing -> reward validated states in `mobile/lib/features/receipts/`
 - [X] T216 Adopt `web/src/assets/pricely-icon.png` as the official brand icon in web shell/header and plan reuse for favicon/mobile app assets.
-- [ ] T217 Continue location web/mobile UX refactors with explicit location/radius preview, manual fallback, denied-permission states, and no-proximity claims until distance-aware optimization is fully active.
+- [~] T217 Continue location web/mobile UX refactors with explicit location/radius preview, manual fallback, denied-permission states, and no-proximity claims until distance-aware optimization is fully active.
 
 ---
 

--- a/web/src/public/list-editor-page.spec.tsx
+++ b/web/src/public/list-editor-page.spec.tsx
@@ -91,6 +91,9 @@ describe('ListEditorPage', () => {
     );
 
     expect(screen.getByText('1. Defina o contexto da compra')).toBeTruthy();
+    expect(screen.getByText('Preview de localização')).toBeTruthy();
+    expect(screen.getByText('Raio local padrão: 5 km')).toBeTruthy();
+    expect(screen.getByText(/distância ainda não altera a otimização/i)).toBeTruthy();
     expect(screen.getByText('2. Adicione itens reais da sua compra')).toBeTruthy();
     expect(screen.getByText('3. Salve agora ou otimize depois')).toBeTruthy();
 

--- a/web/src/public/optimization-page.spec.tsx
+++ b/web/src/public/optimization-page.spec.tsx
@@ -61,8 +61,11 @@ describe('OptimizationPage', () => {
       screen.getByText('Compra mensal - São Paulo. Compare o melhor total, a cobertura e a economia estimada da sua compra.'),
     ).toBeTruthy();
     expect(
-      screen.getByText('Usa uma loja elegivel dentro do raio local configurado.'),
+      screen.getByText(
+        'Prepara a compra em uma loja da cidade com raio local padrão de 5 km.',
+      ),
     ).toBeTruthy();
+    expect(screen.getByText(/distância ainda aparece como preview/i)).toBeTruthy();
     expect(
       screen.getByText('Procura a melhor loja unica para equilibrar cobertura e preco.'),
     ).toBeTruthy();

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -5,6 +5,7 @@ import {
   ArrowRightIcon,
   BadgeCheckIcon,
   ChevronRightIcon,
+  LocateFixedIcon,
   LogInIcon,
   MapPinIcon,
   ShieldAlertIcon,
@@ -115,8 +116,10 @@ const optimizationModeCopy: Record<
 > = {
   local: {
     title: 'Uma loja perto de mim',
-    summary: 'Usa uma loja elegivel dentro do raio local configurado.',
-    tradeoff: 'Menos deslocamento quando houver cobertura de localizacao.',
+    summary:
+      'Prepara a compra em uma loja da cidade com raio local padrão de 5 km.',
+    tradeoff:
+      'A distância ainda aparece como preview; a otimização usa a cidade selecionada até a regra geográfica ficar ativa.',
   },
   global_unique: {
     title: 'Uma loja na cidade',
@@ -2218,6 +2221,9 @@ export function ListEditorPage() {
   const selectedExactVariantLabel = selectedVariant
     ? `${selectedVariant.brandName ? `${selectedVariant.brandName} · ` : ''}${selectedVariant.displayName}`
     : undefined;
+  const selectedCity = selectedCityId
+    ? cities.find((entry) => entry.id === selectedCityId)
+    : null;
 
   const persistList = async (optimizeAfterSave: boolean) => {
     setError(null);
@@ -2441,6 +2447,30 @@ export function ListEditorPage() {
                 ))}
               </select>
             </Field>
+            <div className="rounded-lg border border-border/70 bg-background/80 p-3 md:col-span-2">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <LocateFixedIcon className="size-4 text-primary" />
+                Preview de localização
+              </div>
+              <div className="mt-2 grid gap-2 text-sm text-muted-foreground sm:grid-cols-3">
+                <span>
+                  Cidade:{' '}
+                  {selectedCity
+                    ? `${selectedCity.name} · ${selectedCity.stateCode}`
+                    : 'selecione uma cidade'}
+                </span>
+                <span>Raio local padrão: 5 km</span>
+                <span>
+                  {selectedCity
+                    ? `${selectedCity.activeStoreCount} lojas candidatas na cidade`
+                    : 'sem cobertura carregada'}
+                </span>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Nesta fase, o raio é exibido para orientar a escolha. A distância
+                ainda não altera a otimização nem gera promessa de proximidade.
+              </p>
+            </div>
           </CardContent>
         </Card>
 

--- a/web/src/public/public-shell.spec.tsx
+++ b/web/src/public/public-shell.spec.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { Children, isValidElement, type ReactElement, type ReactNode } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -135,6 +135,7 @@ describe('PublicLayout', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    cleanup();
   });
 
   it('shows active city coverage and allows changing the selected city', async () => {
@@ -145,6 +146,9 @@ describe('PublicLayout', () => {
     );
 
     expect(screen.getByText('Contexto da compra')).toBeTruthy();
+    expect(screen.getByText('Localização para otimização local')).toBeTruthy();
+    expect(screen.getByText(/raio local padrão 5 km/i)).toBeTruthy();
+    expect(screen.getByText(/distância ainda não altera a otimização/i)).toBeTruthy();
     expect(
       screen.queryByText('Sua compra continua de onde você parou'),
     ).toBeNull();
@@ -155,5 +159,18 @@ describe('PublicLayout', () => {
     });
 
     await waitFor(() => expect(setCityId).toHaveBeenCalledWith('sao-paulo-sp'));
+  });
+
+  it('keeps browser location as an explicit preview state', () => {
+    render(
+      <MemoryRouter>
+        <PublicLayout />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /usar localização/i }));
+
+    expect(screen.getByText(/Permissão:/)).toBeTruthy();
+    expect(screen.getByText(/indisponível|manual|negada/)).toBeTruthy();
   });
 });

--- a/web/src/public/public-shell.tsx
+++ b/web/src/public/public-shell.tsx
@@ -1,5 +1,13 @@
 import { Link, NavLink, Outlet } from 'react-router-dom';
-import { MapPinIcon, MoonStarIcon, ShieldCheckIcon, SparklesIcon, SunMediumIcon } from 'lucide-react';
+import {
+  LocateFixedIcon,
+  MapPinIcon,
+  MoonStarIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+  SunMediumIcon,
+} from 'lucide-react';
+import { useState } from 'react';
 
 import { usePricely } from '@/app/pricely-context';
 import { useTheme } from '@/app/theme-context';
@@ -47,12 +55,31 @@ export function PublicLayout() {
   const { cityId, cities, currentUser, isAuthenticated, isBootstrapping, setCityId, signOut } =
     usePricely();
   const { theme, toggleTheme } = useTheme();
+  const [locationPermissionState, setLocationPermissionState] = useState<
+    'manual' | 'requesting' | 'allowed' | 'denied' | 'unsupported'
+  >('manual');
   const activeCity = cityId ? cities.find((city) => city.id === cityId) ?? null : null;
   const shouldRequireCitySelection =
     isAuthenticated && !isBootstrapping && !cityId && cities.length > 0;
   const citySummary = activeCity
     ? `${activeCity.name} - ${activeCity.activeStoreCount} estabelecimentos ativos`
     : 'Escolha uma cidade para carregar ofertas e listas com contexto local';
+  const radiusSummary = activeCity
+    ? `${activeCity.activeStoreCount} lojas candidatas na cidade · raio local padrão 5 km`
+    : 'Raio local padrão 5 km disponível após escolher a cidade';
+  const requestBrowserLocation = () => {
+    if (!navigator.geolocation) {
+      setLocationPermissionState('unsupported');
+      return;
+    }
+
+    setLocationPermissionState('requesting');
+    navigator.geolocation.getCurrentPosition(
+      () => setLocationPermissionState('allowed'),
+      () => setLocationPermissionState('denied'),
+      { enableHighAccuracy: false, maximumAge: 300000, timeout: 8000 },
+    );
+  };
 
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(15,118,110,0.14),transparent_28%),radial-gradient(circle_at_85%_15%,rgba(37,99,235,0.10),transparent_22%),linear-gradient(180deg,#f8fafb_0%,#f3f8f6_48%,#eef7f8_100%)]">
@@ -157,6 +184,44 @@ export function PublicLayout() {
                   : 'Selecione uma cidade'}
             </span>
           </div>
+        </div>
+
+        <div className="grid gap-3 rounded-lg border border-border/70 bg-background/85 px-4 py-3 text-sm shadow-sm lg:grid-cols-[1.2fr_1fr_auto] lg:items-center">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 font-medium">
+              <LocateFixedIcon className="size-4 text-primary" />
+              Localização para otimização local
+            </div>
+            <div className="mt-1 text-muted-foreground">
+              {radiusSummary}. A distância ainda não altera a otimização; usamos a cidade selecionada até a regra geográfica ficar ativa.
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2 text-muted-foreground">
+            <span className="rounded-md border border-border/70 bg-card px-2.5 py-1">
+              Cidade: {activeCity ? `${activeCity.name} · ${activeCity.stateCode}` : 'manual pendente'}
+            </span>
+            <span className="rounded-md border border-border/70 bg-card px-2.5 py-1">
+              Permissão: {locationPermissionState === 'allowed'
+                ? 'capturada para preview'
+                : locationPermissionState === 'denied'
+                  ? 'negada'
+                  : locationPermissionState === 'unsupported'
+                    ? 'indisponível'
+                    : locationPermissionState === 'requesting'
+                      ? 'solicitando'
+                      : 'manual'}
+            </span>
+          </div>
+          <Button
+            disabled={locationPermissionState === 'requesting'}
+            onClick={requestBrowserLocation}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <LocateFixedIcon data-icon="inline-start" />
+            Usar localização
+          </Button>
         </div>
 
         <Outlet />


### PR DESCRIPTION
## Summary
- adds explicit web location preview states in the public shell and list editor with default 5 km radius, manual fallback, browser permission state, and no proximity promises
- updates shopper optimization mode copy to avoid claiming distance-aware behavior before backend proximity rules are active
- adds mobile home/result location preview cards and widget expectations
- marks T184/T217 partial in the phase task plan

## Validation
- npm test -- public-shell.spec.tsx list-editor-page.spec.tsx optimization-page.spec.tsx
- npm test
- npm run lint
- npm run build
- git diff --check

## Not run
- flutter test test/widget/features/regions/mobile_home_public_regions_test.dart test/widget/features/optimization/multi_market_result_screen_test.dart: flutter is not available in this local PATH
- dart format/analyze: dart is not available in this local PATH

Refs #266