### PR TITLE
Add mobile receipt queue submission

### DIFF
--- a/mobile/lib/app/app_services.dart
+++ b/mobile/lib/app/app_services.dart
@@ -27,7 +27,11 @@ class AppServices {
       authController: authController,
       backendGateway: backendGateway,
     );
-    receiptFlowController = ReceiptFlowController(workflowGateway);
+    receiptFlowController = ReceiptFlowController(
+      workflowGateway,
+      authController: authController,
+      backendGateway: backendGateway,
+    );
     optimizationController = OptimizationController(
       cacheService: localCacheService,
       shoppingListController: shoppingListController,

--- a/mobile/lib/features/home/presentation/mobile_home_screen.dart
+++ b/mobile/lib/features/home/presentation/mobile_home_screen.dart
@@ -972,20 +972,21 @@ class _ReceiptTab extends StatefulWidget {
 
 class _ReceiptTabState extends State<_ReceiptTab> {
   late final TextEditingController _storeController;
+  late final TextEditingController _qrCodeController;
   late final TextEditingController _receiptController;
 
   @override
   void initState() {
     super.initState();
     _storeController = TextEditingController(text: 'Mercado Azul');
-    _receiptController = TextEditingController(
-      text: 'Arroz 22.90\nFeijão 9.40\nBanana 4.90',
-    );
+    _qrCodeController = TextEditingController();
+    _receiptController = TextEditingController();
   }
 
   @override
   void dispose() {
     _storeController.dispose();
+    _qrCodeController.dispose();
     _receiptController.dispose();
     super.dispose();
   }
@@ -999,21 +1000,45 @@ class _ReceiptTabState extends State<_ReceiptTab> {
         Text('Enviar contribuição', style: theme.textTheme.headlineMedium),
         const SizedBox(height: 8),
         const Text(
-          'Envie recibos para ajudar a popular regiões com pouca cobertura. O processamento completo ainda é evolutivo.',
+          'Envie a URL do QR Code da NFC-e. A nota fica aguardando liberação manual do admin antes de reforçar preços e liberar rewards.',
         ),
         const SizedBox(height: 18),
         TextField(
           controller: _storeController,
-          decoration: const InputDecoration(labelText: 'Estabelecimento'),
+          decoration:
+              const InputDecoration(labelText: 'Estabelecimento opcional'),
+        ),
+        const SizedBox(height: 16),
+        TextField(
+          controller: _qrCodeController,
+          keyboardType: TextInputType.url,
+          decoration: const InputDecoration(
+            labelText: 'URL do QR Code NFC-e',
+            hintText: 'https://www.fazenda.../qrcode?p=...',
+          ),
+        ),
+        const SizedBox(height: 12),
+        OutlinedButton.icon(
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text(
+                  'Leitor de câmera será ativado no app nativo; por enquanto cole a URL lida do QR Code.',
+                ),
+              ),
+            );
+          },
+          icon: const Icon(Icons.qr_code_scanner),
+          label: const Text('Ler QR Code com a câmera'),
         ),
         const SizedBox(height: 16),
         TextField(
           controller: _receiptController,
-          minLines: 7,
-          maxLines: 12,
+          minLines: 4,
+          maxLines: 8,
           decoration: const InputDecoration(
-            labelText: 'Itens do recibo',
-            hintText: 'Um item por linha com preço ao final.',
+            labelText: 'Itens manuais opcionais',
+            hintText: 'Arroz 22.90\nFeijão 9.40',
           ),
         ),
         const SizedBox(height: 16),
@@ -1024,11 +1049,12 @@ class _ReceiptTabState extends State<_ReceiptTab> {
                   : () => widget.controller.submitReceipt(
                         storeName: _storeController.text.trim(),
                         rawReceipt: _receiptController.text.trim(),
+                        qrCodeUrl: _qrCodeController.text.trim(),
                       ),
           child: Text(
             widget.controller.state == ReceiptSubmissionState.submitting
                 ? 'Enviando...'
-                : 'Processar contribuição',
+                : 'Enviar nota para fila',
           ),
         ),
         if (widget.controller.errorMessage != null) ...<Widget>[
@@ -1614,10 +1640,20 @@ class _ReceiptSummaryCard extends StatelessWidget {
           Text(summary.storeName,
               style: Theme.of(context).textTheme.titleLarge),
           const SizedBox(height: 8),
+          Text('Protocolo: ${summary.id}'),
+          if (summary.qrCodeUrl != null && summary.qrCodeUrl!.isNotEmpty)
+            const Text('Origem: QR Code NFC-e'),
           Text('${summary.ingestedItems} itens ingeridos'),
-          Text('Status: ${summary.moderationStatus}'),
-          Text('Rewards: ${summary.rewardEligibilityStatus}'),
+          Text('Fila: ${_processingLabel(summary.processingStatus)}'),
+          Text('Moderação: ${summary.moderationStatus}'),
+          Text('Reward: ${_rewardLabel(summary.rewardEligibilityStatus)}'),
+          if (summary.rewardPoints > 0 ||
+              summary.rewardOptimizationTokens > 0)
+            Text(
+              '${summary.rewardPoints} pontos · ${summary.rewardOptimizationTokens} tokens',
+            ),
           Text('Motivo: ${summary.reviewReason}'),
+          Text(summary.rewardMessage),
           if (summary.lowConfidenceItems.isNotEmpty) ...<Widget>[
             const SizedBox(height: 8),
             Text('Baixa confiança: ${summary.lowConfidenceItems.join(', ')}'),
@@ -1625,6 +1661,40 @@ class _ReceiptSummaryCard extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String _processingLabel(String status) {
+    switch (status) {
+      case 'waiting_manual_release':
+        return 'aguardando liberação manual';
+      case 'queued':
+        return 'liberada para processamento';
+      case 'running':
+        return 'processando';
+      case 'completed':
+        return 'processada';
+      case 'failed':
+        return 'falhou';
+      case 'retrying':
+        return 'tentando novamente';
+      default:
+        return status;
+    }
+  }
+
+  String _rewardLabel(String status) {
+    switch (status) {
+      case 'granted':
+        return 'validado';
+      case 'eligible_pending':
+        return 'em processamento';
+      case 'ineligible':
+        return 'não elegível';
+      case 'disabled':
+        return 'desativado';
+      default:
+        return status;
+    }
   }
 }
 

--- a/mobile/lib/features/optimization/data/demo_grocery_workflow_gateway.dart
+++ b/mobile/lib/features/optimization/data/demo_grocery_workflow_gateway.dart
@@ -40,15 +40,21 @@ class DemoGroceryWorkflowGateway {
     }
 
     return ReceiptSubmissionSummary(
+      id: 'demo-receipt-${DateTime.now().millisecondsSinceEpoch}',
       storeName: storeName,
       ingestedItems: ingestedItems,
       lowConfidenceItems: lowConfidenceItems,
       moderationStatus:
           lowConfidenceItems.isEmpty ? 'accepted' : 'quarantined',
+      processingStatus: 'waiting_manual_release',
       reviewReason: lowConfidenceItems.isEmpty
           ? 'receipt_rewards_disabled'
           : 'low_confidence_extraction',
       rewardEligibilityStatus: 'disabled',
+      rewardPoints: 0,
+      rewardOptimizationTokens: 0,
+      rewardMessage:
+          'Nota recebida no modo demo. Rewards ficam pendentes no backend real.',
     );
   }
 

--- a/mobile/lib/features/receipts/application/receipt_flow_controller.dart
+++ b/mobile/lib/features/receipts/application/receipt_flow_controller.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/foundation.dart';
 
+import '../../auth/application/auth_controller.dart';
 import '../../optimization/data/demo_grocery_workflow_gateway.dart';
+import '../../shared/data/pricely_backend_gateway.dart';
 import '../domain/receipt_submission.dart';
 
 class ReceiptFlowController extends ChangeNotifier {
-  ReceiptFlowController(this._workflowGateway);
+  ReceiptFlowController(
+    this._workflowGateway, {
+    AuthController? authController,
+    PricelyBackendGateway? backendGateway,
+  })  : _authController = authController,
+        _backendGateway = backendGateway;
 
   final DemoGroceryWorkflowGateway _workflowGateway;
+  final AuthController? _authController;
+  final PricelyBackendGateway? _backendGateway;
 
   ReceiptSubmissionState _state = ReceiptSubmissionState.idle;
   ReceiptSubmissionSummary? _lastSubmission;
@@ -19,16 +28,29 @@ class ReceiptFlowController extends ChangeNotifier {
   Future<void> submitReceipt({
     required String storeName,
     required String rawReceipt,
+    String? qrCodeUrl,
   }) async {
     _state = ReceiptSubmissionState.submitting;
     _errorMessage = null;
     notifyListeners();
 
     try {
-      _lastSubmission = await _workflowGateway.submitReceipt(
-        storeName: storeName,
-        rawReceipt: rawReceipt,
-      );
+      final accessToken = _authController?.accessToken;
+      if (_backendGateway != null &&
+          accessToken != null &&
+          accessToken.isNotEmpty) {
+        _lastSubmission = await _backendGateway!.submitReceipt(
+          accessToken: accessToken,
+          storeName: storeName,
+          rawReceipt: rawReceipt,
+          qrCodeUrl: qrCodeUrl,
+        );
+      } else {
+        _lastSubmission = await _workflowGateway.submitReceipt(
+          storeName: storeName,
+          rawReceipt: rawReceipt,
+        );
+      }
       _state = ReceiptSubmissionState.success;
     } catch (_) {
       _state = ReceiptSubmissionState.failure;

--- a/mobile/lib/features/receipts/domain/receipt_submission.dart
+++ b/mobile/lib/features/receipts/domain/receipt_submission.dart
@@ -7,18 +7,62 @@ enum ReceiptSubmissionState {
 
 class ReceiptSubmissionSummary {
   const ReceiptSubmissionSummary({
+    required this.id,
     required this.storeName,
     required this.ingestedItems,
     required this.lowConfidenceItems,
     required this.moderationStatus,
+    required this.processingStatus,
     required this.reviewReason,
     required this.rewardEligibilityStatus,
+    required this.rewardPoints,
+    required this.rewardOptimizationTokens,
+    required this.rewardMessage,
+    this.qrCodeUrl,
   });
 
+  final String id;
   final String storeName;
   final int ingestedItems;
   final List<String> lowConfidenceItems;
   final String moderationStatus;
+  final String processingStatus;
   final String reviewReason;
   final String rewardEligibilityStatus;
+  final int rewardPoints;
+  final int rewardOptimizationTokens;
+  final String rewardMessage;
+  final String? qrCodeUrl;
+
+  factory ReceiptSubmissionSummary.fromJson(
+    Map<String, dynamic> json, {
+    String? fallbackQrCodeUrl,
+  }) {
+    return ReceiptSubmissionSummary(
+      id: json['id'] as String? ?? '',
+      storeName: json['storeName'] as String? ?? 'Nota fiscal enviada',
+      ingestedItems: (json['ingestedItems'] as num? ?? 0).toInt(),
+      lowConfidenceItems:
+          (json['lowConfidenceItems'] as List<dynamic>? ?? <dynamic>[])
+              .map((item) => item.toString())
+              .toList(),
+      moderationStatus: json['moderationStatus'] as String? ?? 'pending',
+      processingStatus:
+          json['processingStatus'] as String? ?? 'waiting_manual_release',
+      reviewReason: json['reviewReason'] as String? ?? 'waiting_manual_release',
+      rewardEligibilityStatus:
+          json['rewardEligibilityStatus'] as String? ?? 'eligible_pending',
+      rewardPoints: (json['rewardPoints'] as num? ?? 0).toInt(),
+      rewardOptimizationTokens:
+          (json['rewardOptimizationTokens'] as num? ?? 0).toInt(),
+      rewardMessage: json['rewardMessage'] as String? ??
+          'Reward em processamento até a nota ser validada.',
+      qrCodeUrl: json['qrCodeUrl'] as String? ?? fallbackQrCodeUrl,
+    );
+  }
+
+  bool get isWaitingManualRelease =>
+      processingStatus == 'waiting_manual_release';
+
+  bool get isRewardValidated => rewardEligibilityStatus == 'granted';
 }

--- a/mobile/lib/features/receipts/presentation/receipt_submission_screen.dart
+++ b/mobile/lib/features/receipts/presentation/receipt_submission_screen.dart
@@ -19,20 +19,21 @@ class ReceiptSubmissionScreen extends StatefulWidget {
 
 class _ReceiptSubmissionScreenState extends State<ReceiptSubmissionScreen> {
   late final TextEditingController _storeController;
+  late final TextEditingController _qrCodeController;
   late final TextEditingController _receiptController;
 
   @override
   void initState() {
     super.initState();
     _storeController = TextEditingController(text: 'Mercado Azul');
-    _receiptController = TextEditingController(
-      text: 'Arroz 22.90\nFeijao 9.40\nBanana 4.90',
-    );
+    _qrCodeController = TextEditingController();
+    _receiptController = TextEditingController();
   }
 
   @override
   void dispose() {
     _storeController.dispose();
+    _qrCodeController.dispose();
     _receiptController.dispose();
     super.dispose();
   }
@@ -41,7 +42,7 @@ class _ReceiptSubmissionScreenState extends State<ReceiptSubmissionScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Enviar recibo'),
+        title: const Text('Enviar nota fiscal'),
       ),
       body: AnimatedBuilder(
         animation: widget.controller,
@@ -51,20 +52,50 @@ class _ReceiptSubmissionScreenState extends State<ReceiptSubmissionScreen> {
           return ListView(
             padding: const EdgeInsets.all(16),
             children: <Widget>[
+              Text(
+                'Leia ou cole a URL do QR Code da NFC-e. A nota fica em fila aguardando liberação manual do admin antes do processamento automático.',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 16),
               TextField(
                 controller: _storeController,
                 decoration: const InputDecoration(
-                  labelText: 'Nome da loja',
+                  labelText: 'Nome da loja (opcional)',
                   border: OutlineInputBorder(),
                 ),
               ),
               const SizedBox(height: 16),
               TextField(
-                controller: _receiptController,
-                minLines: 6,
-                maxLines: 10,
+                controller: _qrCodeController,
                 decoration: const InputDecoration(
-                  labelText: 'Itens do recibo (um por linha com preco no fim)',
+                  labelText: 'URL do QR Code da NFC-e',
+                  hintText: 'https://www.fazenda.../qrcode?p=...',
+                  border: OutlineInputBorder(),
+                ),
+                keyboardType: TextInputType.url,
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton.icon(
+                onPressed: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text(
+                        'Leitor de câmera será ativado no app nativo; por enquanto cole a URL lida do QR Code.',
+                      ),
+                    ),
+                  );
+                },
+                icon: const Icon(Icons.qr_code_scanner),
+                label: const Text('Ler QR Code com a câmera'),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _receiptController,
+                minLines: 4,
+                maxLines: 8,
+                decoration: const InputDecoration(
+                  labelText: 'Itens manuais opcionais',
+                  hintText: 'Arroz 22.90\nFeijao 9.40',
                   border: OutlineInputBorder(),
                 ),
               ),
@@ -77,6 +108,7 @@ class _ReceiptSubmissionScreenState extends State<ReceiptSubmissionScreen> {
                         await widget.controller.submitReceipt(
                           storeName: _storeController.text.trim(),
                           rawReceipt: _receiptController.text,
+                          qrCodeUrl: _qrCodeController.text.trim(),
                         );
                         if (!context.mounted) {
                           return;
@@ -85,13 +117,15 @@ class _ReceiptSubmissionScreenState extends State<ReceiptSubmissionScreen> {
                             ReceiptSubmissionState.success) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             const SnackBar(
-                              content: Text('Recibo processado com sucesso.'),
+                              content: Text(
+                                'Nota enviada para a fila de liberação manual.',
+                              ),
                             ),
                           );
                         }
                       },
                 icon: const Icon(Icons.receipt_long),
-                label: const Text('Processar recibo'),
+                label: const Text('Enviar nota para fila'),
               ),
               const SizedBox(height: 16),
               if (submission != null)
@@ -140,11 +174,21 @@ class _SubmissionSummaryCard extends StatelessWidget {
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 8),
+            Text('Protocolo: ${summary.id}'),
+            if (summary.qrCodeUrl != null && summary.qrCodeUrl!.isNotEmpty)
+              const Text('Origem: QR Code NFC-e'),
             Text('${summary.ingestedItems} itens ingeridos'),
             const SizedBox(height: 8),
-            Text('Status: ${summary.moderationStatus}'),
-            Text('Rewards: ${summary.rewardEligibilityStatus}'),
+            Text('Fila: ${_processingLabel(summary.processingStatus)}'),
+            Text('Moderação: ${summary.moderationStatus}'),
+            Text('Reward: ${_rewardLabel(summary.rewardEligibilityStatus)}'),
+            if (summary.rewardPoints > 0 ||
+                summary.rewardOptimizationTokens > 0)
+              Text(
+                '${summary.rewardPoints} pontos · ${summary.rewardOptimizationTokens} tokens',
+              ),
             Text('Motivo: ${summary.reviewReason}'),
+            Text(summary.rewardMessage),
             if (summary.lowConfidenceItems.isNotEmpty) ...<Widget>[
               const SizedBox(height: 8),
               Text(
@@ -155,5 +199,39 @@ class _SubmissionSummaryCard extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  String _processingLabel(String status) {
+    switch (status) {
+      case 'waiting_manual_release':
+        return 'aguardando liberação manual';
+      case 'queued':
+        return 'liberada para processamento';
+      case 'running':
+        return 'processando';
+      case 'completed':
+        return 'processada';
+      case 'failed':
+        return 'falhou';
+      case 'retrying':
+        return 'tentando novamente';
+      default:
+        return status;
+    }
+  }
+
+  String _rewardLabel(String status) {
+    switch (status) {
+      case 'granted':
+        return 'validado';
+      case 'eligible_pending':
+        return 'em processamento';
+      case 'ineligible':
+        return 'não elegível';
+      case 'disabled':
+        return 'desativado';
+      default:
+        return status;
+    }
   }
 }

--- a/mobile/lib/features/shared/data/pricely_backend_gateway.dart
+++ b/mobile/lib/features/shared/data/pricely_backend_gateway.dart
@@ -1,6 +1,7 @@
 import '../../../core/networking/api_environment.dart';
 import '../../../core/networking/http_api_client.dart';
 import '../../optimization/domain/optimization_result.dart';
+import '../../receipts/domain/receipt_submission.dart';
 import '../../shopping_lists/domain/shopping_list_draft.dart';
 
 class PricelyBackendGateway {
@@ -58,6 +59,39 @@ class PricelyBackendGateway {
     return AuthUser.fromJson(response);
   }
 
+  List<Map<String, dynamic>> _parseManualReceiptItems(String? rawReceipt) {
+    if (rawReceipt == null || rawReceipt.trim().isEmpty) {
+      return <Map<String, dynamic>>[];
+    }
+
+    return rawReceipt
+        .split('\n')
+        .map((line) => line.trim())
+        .where((line) => line.isNotEmpty)
+        .map((line) {
+          final parts = line.split(RegExp(r'\s+'));
+          final unitPrice = parts.isEmpty
+              ? null
+              : double.tryParse(parts.last.replaceAll(',', '.'));
+          if (unitPrice == null || parts.length < 2) {
+            return null;
+          }
+
+          final rawProductName = parts.sublist(0, parts.length - 1).join(' ');
+          if (rawProductName.trim().isEmpty) {
+            return null;
+          }
+
+          return <String, dynamic>{
+            'rawProductName': rawProductName,
+            'quantity': 1,
+            'unitPrice': unitPrice,
+          };
+        })
+        .whereType<Map<String, dynamic>>()
+        .toList();
+  }
+
   Future<List<PublicRegionSummary>> fetchPublicRegions() async {
     final response = await _apiClient.get<List<dynamic>>('/regions');
     return response
@@ -103,6 +137,34 @@ class PricelyBackendGateway {
     final response =
         await _apiClient.get<Map<String, dynamic>>('/offers/$offerId');
     return PublicOfferDetail.fromJson(response);
+  }
+
+  Future<ReceiptSubmissionSummary> submitReceipt({
+    required String accessToken,
+    String? storeName,
+    String? qrCodeUrl,
+    String? rawReceipt,
+  }) async {
+    final items = _parseManualReceiptItems(rawReceipt);
+    final response = await _apiClient.post<Map<String, dynamic>>(
+      '/receipts',
+      accessToken: accessToken,
+      body: <String, dynamic>{
+        if (storeName != null && storeName.trim().isNotEmpty)
+          'storeName': storeName.trim(),
+        if (qrCodeUrl != null && qrCodeUrl.trim().isNotEmpty)
+          'qrCodeUrl': qrCodeUrl.trim(),
+        'sourceType': qrCodeUrl != null && qrCodeUrl.trim().isNotEmpty
+            ? 'qr_code_url'
+            : 'manual_entry',
+        if (items.isNotEmpty) 'items': items,
+      },
+    );
+
+    return ReceiptSubmissionSummary.fromJson(
+      response,
+      fallbackQrCodeUrl: qrCodeUrl,
+    );
   }
 
   Future<List<ShoppingListDraft>> fetchShoppingLists(String accessToken) async {

--- a/mobile/test/unit/features/receipts/receipt_backend_gateway_test.dart
+++ b/mobile/test/unit/features/receipts/receipt_backend_gateway_test.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:pricely_mobile/core/networking/http_api_client.dart';
+import 'package:pricely_mobile/features/shared/data/pricely_backend_gateway.dart';
+
+void main() {
+  test('submits qr code receipt to backend with manual-release feedback', () async {
+    Map<String, dynamic>? capturedBody;
+    String? authorizationHeader;
+    final gateway = PricelyBackendGateway(
+      HttpApiClient(
+        client: MockClient((request) async {
+          expect(request.url.path, '/receipts');
+          authorizationHeader = request.headers['authorization'];
+          capturedBody = jsonDecode(request.body) as Map<String, dynamic>;
+
+          return http.Response(
+            jsonEncode(<String, dynamic>{
+              'id': 'rr_123',
+              'storeName': 'Mercado Azul',
+              'parseStatus': 'queued',
+              'moderationStatus': 'pending',
+              'rewardEligibilityStatus': 'eligible_pending',
+              'rewardPoints': 100,
+              'rewardOptimizationTokens': 1,
+              'rewardMessage': 'Nota recebida: reward em processamento.',
+              'reviewReason': 'waiting_manual_release',
+              'processingStatus': 'waiting_manual_release',
+            }),
+            201,
+          );
+        }),
+      ),
+    );
+
+    final summary = await gateway.submitReceipt(
+      accessToken: 'token-123',
+      storeName: 'Mercado Azul',
+      qrCodeUrl: 'https://sefaz.example/qrcode?p=abc',
+      rawReceipt: 'Arroz 22.90',
+    );
+
+    expect(authorizationHeader, 'Bearer token-123');
+    expect(capturedBody?['sourceType'], 'qr_code_url');
+    expect(capturedBody?['qrCodeUrl'], 'https://sefaz.example/qrcode?p=abc');
+    expect(capturedBody?['items'], hasLength(1));
+    expect(summary.id, 'rr_123');
+    expect(summary.isWaitingManualRelease, isTrue);
+    expect(summary.rewardEligibilityStatus, 'eligible_pending');
+    expect(summary.rewardPoints, 100);
+    expect(summary.rewardOptimizationTokens, 1);
+  });
+}

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -503,7 +503,7 @@ rules into implementation tasks against the real product.
 - [~] T185 Refactor admin overview into an action-first operations surface that elevates stale offers, low-trust offers, failed jobs, quarantined receipts, catalog image gaps, and city coverage issues in `web/src/dashboard/`
 - [~] T186 Refactor public city and offer surfaces so activating cities have explicit placeholders, supported-establishment sections show active stores or activation states, offers are grouped by product/variant with cheapest eligible establishment first, and establishment filters/comparison panels replace duplicate offer cards in `web/src/public/` and `web/src/app/`
 - [~] T187 Refactor public web surfaces toward the audited direction for landing, city selection, offers explorer, offer detail, lists, list editor, optimization result, receipt states, location widgets, premium/free entitlement copy, and disabled billing gate in `web/src/public/`
-- [ ] T188 Refactor mobile surfaces toward the audited direction for onboarding/home, list, location widgets, optimization results by mode, receipt contribution, profile/value, error states, and dark-mode parity in `mobile/lib/features/`
+- [~] T188 Refactor mobile surfaces toward the audited direction for onboarding/home, list, location widgets, optimization results by mode, receipt contribution, profile/value, error states, and dark-mode parity in `mobile/lib/features/`
 - [~] T189 Refactor admin catalog and offer operations so variants are managed through a dedicated detail route/tab, long variant lists are searchable/collapsible, variant images appear in price/offer rows, and raw IDs move behind detail affordances in `web/src/dashboard/`
 - [~] T190 Refactor admin list operations and queue health cards so they show human-readable owner, list, mode, elapsed time, status, and icon actions before technical job/resource IDs in `web/src/dashboard/`
 - [X] T191 Add visual regression/screenshot validation for key aligned web flows with Playwright and keep existing MVP E2E coverage green in `web/e2e/`
@@ -551,7 +551,7 @@ Premium access and extra optimization credits are support/admin operations for n
 - [X] T212 Change receipt ingestion to manual processing by default, keeping an `RECEIPT_PROCESSING_MODE=automatic` escape hatch for future automatic queueing in `backend/src/receipts/` and `backend/src/jobs/`
 - [X] T213 Add admin release action so received receipts can be manually sent to the receipt-processing queue, with pending/released states in `backend/src/admin/` and `web/src/dashboard/`
 - [~] T214 Expand admin receipt detail with extracted payload, product matcher result, missing-product maker actions, and price up/down comparison against current offers in `backend/src/admin/` and `web/src/dashboard/`
-- [ ] T215 Add mobile QR-code receipt submission flow that posts the scanned NFC-e URL to backend and shows submitted -> waiting release -> processing -> reward validated states in `mobile/lib/features/receipts/`
+- [~] T215 Add mobile QR-code receipt submission flow that posts the scanned NFC-e URL to backend and shows submitted -> waiting release -> processing -> reward validated states in `mobile/lib/features/receipts/`
 - [X] T216 Adopt `web/src/assets/pricely-icon.png` as the official brand icon in web shell/header and plan reuse for favicon/mobile app assets.
 - [~] T217 Continue location web/mobile UX refactors with explicit location/radius preview, manual fallback, denied-permission states, and no-proximity claims until distance-aware optimization is fully active.
 


### PR DESCRIPTION
## Summary
- connects mobile receipt submission to the backend /receipts endpoint when the user has a session
- adds QR/NFC-e URL-first mobile receipt UX with manual-release, processing, and reward feedback states
- keeps the demo receipt gateway as a fallback for unauthenticated/local flows
- adds mobile gateway coverage for qr_code_url payloads and reward/manual-release projection
- marks T188/T215 partial because native camera scanning still needs a scanner dependency/integration

## Validation
- npm test
- git diff --check

## Not run locally
- flutter analyze / flutter test: flutter is not available in this local PATH; CI mobile job should validate

Refs #268