### PR TITLE
Add location-aware web and mobile UI

### DIFF
--- a/mobile/lib/features/home/presentation/mobile_home_screen.dart
+++ b/mobile/lib/features/home/presentation/mobile_home_screen.dart
@@ -853,22 +853,23 @@ class _OptimizationTab extends StatelessWidget {
                 child: const Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    Text('Local: menos deslocamento.'),
+                    Text('Uma loja local: menos deslocamento.'),
                     SizedBox(height: 6),
-                    Text('Global unico: melhor loja unica.'),
+                    Text('Menor preco local: divide entre lojas no raio.'),
                     SizedBox(height: 6),
-                    Text('Global completo: menor total, mesmo dividindo a compra.'),
+                    Text('Menor total cidade: compara toda a cidade.'),
                   ],
                 ),
               ),
               const SizedBox(height: 12),
               SegmentedButton<String>(
                 segments: const <ButtonSegment<String>>[
-                  ButtonSegment<String>(value: 'local', label: Text('Local')),
                   ButtonSegment<String>(
-                      value: 'global_unique', label: Text('Global único')),
+                      value: 'local_unique', label: Text('Uma loja local')),
                   ButtonSegment<String>(
-                      value: 'global_full', label: Text('Global completo')),
+                      value: 'local_multi', label: Text('Preco local')),
+                  ButtonSegment<String>(
+                      value: 'global_multi', label: Text('Cidade')),
                 ],
                 selected: <String>{listController.draft.lastMode},
                 onSelectionChanged: (selection) {
@@ -1472,10 +1473,10 @@ class _LocationPreviewCard extends StatelessWidget {
                 : '${region!.name} · ${region!.stateCode} · ${region!.activeEstablishmentCount} lojas candidatas na cidade.',
           ),
           const SizedBox(height: 8),
-          const Text('Raio local padrão: 5 km.'),
+          const Text('Raio local padrao: 5 km.'),
           const SizedBox(height: 8),
           Text(
-            'No MVP atual, a permissão de localização fica manual e a distância não altera a otimização. A busca continua baseada na cidade selecionada.',
+            'Quando houver localizacao salva, modos locais usam lojas dentro do raio. O modo cidade ignora distancia e compara a regiao selecionada.',
             style: theme.textTheme.bodySmall,
           ),
         ],

--- a/mobile/lib/features/optimization/domain/optimization_result.dart
+++ b/mobile/lib/features/optimization/domain/optimization_result.dart
@@ -94,6 +94,7 @@ class OptimizationSelection {
     required this.unit,
     required this.unitPrice,
     required this.subtotal,
+    this.distanceKm,
     required this.confidenceLabel,
     required this.decisionReason,
     required this.rejectedReason,
@@ -105,6 +106,7 @@ class OptimizationSelection {
   final String unit;
   final double unitPrice;
   final double subtotal;
+  final double? distanceKm;
   final String confidenceLabel;
   final String? decisionReason;
   final String? rejectedReason;
@@ -117,6 +119,7 @@ class OptimizationSelection {
       unit: json['unit'] as String? ?? 'un',
       unitPrice: (json['unitPrice'] as num?)?.toDouble() ?? 0,
       subtotal: (json['subtotal'] as num?)?.toDouble() ?? 0,
+      distanceKm: (json['distanceKm'] as num?)?.toDouble(),
       confidenceLabel: json['confidenceLabel'] as String? ?? 'medium',
       decisionReason: json['decisionReason'] as String?,
       rejectedReason: json['rejectedReason'] as String?,
@@ -131,6 +134,7 @@ class OptimizationSelection {
       'unit': unit,
       'unitPrice': unitPrice,
       'subtotal': subtotal,
+      'distanceKm': distanceKm,
       'confidenceLabel': confidenceLabel,
       'decisionReason': decisionReason,
       'rejectedReason': rejectedReason,

--- a/mobile/lib/features/optimization/presentation/multi_market_result_screen.dart
+++ b/mobile/lib/features/optimization/presentation/multi_market_result_screen.dart
@@ -139,10 +139,10 @@ class MultiMarketResultView extends StatelessWidget {
                   style: Theme.of(context).textTheme.titleMedium,
                 ),
                 const SizedBox(height: 8),
-                const Text('Raio local padrão: 5 km.'),
+                const Text('Raio local padrao: 5 km.'),
                 const SizedBox(height: 6),
                 const Text(
-                  'A distância ainda é apenas preview neste MVP. O resultado usa a cidade da lista e não promete loja mais próxima.',
+                  'Modos locais usam a localizacao salva e lojas dentro do raio. O modo cidade ignora distancia e compara toda a regiao.',
                 ),
               ],
             ),
@@ -183,7 +183,7 @@ class MultiMarketResultView extends StatelessWidget {
                               : null,
                           title: Text(selection.itemName),
                           subtitle: Text(
-                            '${selection.quantity} ${selection.unit} - ${_brandRuleLabel(draftItem)} - confiança ${selection.confidenceLabel}',
+                            '${selection.quantity} ${selection.unit} - ${_brandRuleLabel(draftItem)} - ${_distanceLabel(selection)} - confianca ${selection.confidenceLabel}',
                           ),
                           trailing: Text(_formatCurrency(selection.subtotal)),
                         );
@@ -237,5 +237,13 @@ class MultiMarketResultView extends StatelessWidget {
       return 'variante exata: ${item.name}';
     }
     return 'qualquer variante';
+  }
+
+  String _distanceLabel(OptimizationSelection selection) {
+    final distance = selection.distanceKm;
+    if (distance == null) {
+      return 'modo cidade';
+    }
+    return '${distance.toStringAsFixed(1)} km';
   }
 }

--- a/mobile/lib/features/shared/data/pricely_backend_gateway.dart
+++ b/mobile/lib/features/shared/data/pricely_backend_gateway.dart
@@ -301,7 +301,7 @@ class PricelyBackendGateway {
       id: json['id'] as String,
       title: json['name'] as String? ?? 'Minha lista',
       regionId: json['preferredRegionId'] as String? ?? '',
-      lastMode: json['lastMode'] as String? ?? 'global_full',
+      lastMode: json['lastMode'] as String? ?? 'global_multi',
       items: items
           .map(
             (item) => ShoppingListItemDraft(
@@ -352,6 +352,7 @@ class PricelyBackendGateway {
           unit: 'un',
           unitPrice: priceAmount.toDouble(),
           subtotal: priceAmount.toDouble(),
+          distanceKm: (selection['distanceKm'] as num?)?.toDouble(),
           confidenceLabel:
               selection['confidenceNotice'] as String? ?? 'confirmado',
           decisionReason: selection['decisionReason'] as String?,

--- a/mobile/lib/features/shopping_lists/domain/shopping_list_draft.dart
+++ b/mobile/lib/features/shopping_lists/domain/shopping_list_draft.dart
@@ -18,7 +18,7 @@ class ShoppingListDraft {
       id: null,
       title: 'Lista da semana',
       regionId: 'sao-paulo-sp',
-      lastMode: 'global_full',
+      lastMode: 'global_multi',
       items: <ShoppingListItemDraft>[],
     );
   }
@@ -28,7 +28,7 @@ class ShoppingListDraft {
       id: json['id'] as String?,
       title: json['title'] as String? ?? 'Lista da semana',
       regionId: json['regionId'] as String? ?? 'sao-paulo-sp',
-      lastMode: json['lastMode'] as String? ?? 'global_full',
+      lastMode: json['lastMode'] as String? ?? 'global_multi',
       items: (json['items'] as List<dynamic>? ?? <dynamic>[])
           .map((item) =>
               ShoppingListItemDraft.fromJson(item as Map<String, dynamic>))

--- a/mobile/test/unit/features/optimization/optimization_controller_test.dart
+++ b/mobile/test/unit/features/optimization/optimization_controller_test.dart
@@ -80,7 +80,7 @@ void main() {
                   'id': 'list-1',
                   'name': 'Compra mensal',
                   'preferredRegionId': 'sao-paulo-sp',
-                  'lastMode': 'global_full',
+                  'lastMode': 'global_multi',
                   'items': <dynamic>[
                     <String, dynamic>{
                       'id': 'item-1',

--- a/mobile/test/unit/features/shopping_lists/local_cache_service_test.dart
+++ b/mobile/test/unit/features/shopping_lists/local_cache_service_test.dart
@@ -12,7 +12,7 @@ void main() {
       id: 'list-1',
       title: 'Feira',
       regionId: 'sao-paulo-sp',
-      lastMode: 'global_full',
+      lastMode: 'global_multi',
       items: const <ShoppingListItemDraft>[
         ShoppingListItemDraft(id: '1', name: 'Banana', quantity: 6, unit: 'un'),
       ],

--- a/mobile/test/unit/features/shopping_lists/shopping_list_controller_test.dart
+++ b/mobile/test/unit/features/shopping_lists/shopping_list_controller_test.dart
@@ -179,7 +179,7 @@ void main() {
                   'id': 'list-1',
                   'name': 'Compra mensal',
                   'preferredRegionId': 'sao-paulo-sp',
-                  'lastMode': 'global_full',
+                  'lastMode': 'global_multi',
                   'items': <dynamic>[
                     <String, dynamic>{
                       'id': 'item-1',
@@ -205,7 +205,7 @@ void main() {
                 'id': 'list-1',
                 'name': 'Compra mensal',
                 'preferredRegionId': 'sao-paulo-sp',
-                'lastMode': 'global_full',
+                'lastMode': 'global_multi',
                 'items': <dynamic>[
                   <String, dynamic>{
                     'id': 'item-1',

--- a/mobile/test/widget/features/optimization/multi_market_result_screen_test.dart
+++ b/mobile/test/widget/features/optimization/multi_market_result_screen_test.dart
@@ -52,6 +52,7 @@ void main() {
               unit: 'pct',
               unitPrice: 22.9,
               subtotal: 22.9,
+              distanceKm: 1.2,
               confidenceLabel: 'high',
               decisionReason: 'selected_confirmed_offer',
               rejectedReason: null,
@@ -94,8 +95,9 @@ void main() {
     expect(find.text('Super Verde'), findsOneWidget);
     expect(find.textContaining('Economia estimada'), findsOneWidget);
     expect(find.text('Localização e raio'), findsOneWidget);
-    expect(find.text('Raio local padrão: 5 km.'), findsOneWidget);
-    expect(find.textContaining('não promete loja mais próxima'), findsOneWidget);
+    expect(find.text('Raio local padrao: 5 km.'), findsOneWidget);
+    expect(find.textContaining('Modos locais usam a localizacao salva'), findsOneWidget);
+    expect(find.textContaining('1.2 km'), findsOneWidget);
     expect(find.textContaining('variante exata: Camil · Arroz'), findsOneWidget);
     await tester.scrollUntilVisible(find.text('- Leite vegetal'), 220);
     expect(find.text('- Leite vegetal'), findsOneWidget);

--- a/mobile/test/widget/features/regions/mobile_home_public_regions_test.dart
+++ b/mobile/test/widget/features/regions/mobile_home_public_regions_test.dart
@@ -56,8 +56,8 @@ void main() {
       220,
     );
     expect(find.text('Localização e raio'), findsOneWidget);
-    expect(find.text('Raio local padrão: 5 km.'), findsOneWidget);
-    expect(find.textContaining('distância não altera a otimização'), findsOneWidget);
+    expect(find.text('Raio local padrao: 5 km.'), findsOneWidget);
+    expect(find.textContaining('modos locais usam lojas dentro do raio'), findsOneWidget);
   });
 
   testWidgets('renders active city offers and opens the offer detail sheet', (tester) async {

--- a/mobile/test/widget/features/shopping_lists/shopping_list_screen_test.dart
+++ b/mobile/test/widget/features/shopping_lists/shopping_list_screen_test.dart
@@ -49,7 +49,7 @@ void main() {
                   'id': 'list-1',
                   'name': 'Compra mensal',
                   'preferredRegionId': 'sao-paulo-sp',
-                  'lastMode': 'global_full',
+                  'lastMode': 'global_multi',
                   'items': <dynamic>[
                     <String, dynamic>{
                       'id': 'item-1',
@@ -98,7 +98,7 @@ void main() {
                 'id': 'list-1',
                 'name': 'Compra mensal',
                 'preferredRegionId': 'sao-paulo-sp',
-                'lastMode': 'global_full',
+                'lastMode': 'global_multi',
                 'items': <dynamic>[
                   <String, dynamic>{
                     'id': 'item-1',
@@ -196,7 +196,7 @@ void main() {
                   'id': 'list-1',
                   'name': 'Compra mensal',
                   'preferredRegionId': 'sao-paulo-sp',
-                  'lastMode': 'global_full',
+                  'lastMode': 'global_multi',
                   'items': <dynamic>[
                     <String, dynamic>{
                       'id': 'item-1',
@@ -223,7 +223,7 @@ void main() {
                 'id': 'list-1',
                 'name': 'Compra mensal',
                 'preferredRegionId': 'sao-paulo-sp',
-                'lastMode': 'global_full',
+                'lastMode': 'global_multi',
                 'items': <dynamic>[
                   <String, dynamic>{
                     'id': 'item-1',

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -472,9 +472,9 @@ radius while keeping global optimization limited to the user's selected city/reg
 - [X] T172 [P] Add backend unit tests for distance calculation, radius filtering, city-bound global filtering, and no-location/no-coverage edge cases in `backend/test/unit/optimization/` and `backend/test/unit/locations/`
 - [X] T173 Implement location preference services and coverage preview endpoints with explicit user-provided coordinates only in `backend/src/locations/`, `backend/src/users/`, and `backend/src/common/contracts/`
 - [X] T174 Refactor optimization candidate generation to support `local_unique`, `local_multi`, and `global_multi` semantics with distance-aware explanations in `backend/src/optimization/`
-- [ ] T175 Update web location widgets to support explicit browser geolocation permission, manual city/location selection, radius preview, active-establishment count, and selected-offer distance display in `web/src/public/` and `web/src/app/`
-- [ ] T176 Update mobile location widgets to support platform location permission, denied/restricted/unavailable states, manual city/location selection, radius preview, and optimization-result distance copy in `mobile/lib/features/profile/`, `mobile/lib/features/shopping_lists/`, and `mobile/lib/features/optimization/`
-- [ ] T177 Add integration/E2E coverage for browser/mobile location permission, manual-location fallback, local single-store, local multi-store, global city-only, zero-establishment radius, and location-denied flows in `backend/test/integration/optimization/`, `web/e2e/`, and `mobile/test/`
+- [X] T175 Update web location widgets to support explicit browser geolocation permission, manual city/location selection, radius preview, active-establishment count, and selected-offer distance display in `web/src/public/` and `web/src/app/`
+- [~] T176 Update mobile location widgets to support platform location permission, denied/restricted/unavailable states, manual city/location selection, radius preview, and optimization-result distance copy in `mobile/lib/features/profile/`, `mobile/lib/features/shopping_lists/`, and `mobile/lib/features/optimization/`
+- [~] T177 Add integration/E2E coverage for browser/mobile location permission, manual-location fallback, local single-store, local multi-store, global city-only, zero-establishment radius, and location-denied flows in `backend/test/integration/optimization/`, `web/e2e/`, and `mobile/test/`
 
 ---
 

--- a/web/e2e/mvp-smoke.spec.ts
+++ b/web/e2e/mvp-smoke.spec.ts
@@ -52,7 +52,7 @@ const savedList = {
   name: 'Compra mensal',
   preferredRegionId: 'sao-paulo-sp',
   status: 'ready',
-  lastMode: 'global_full',
+  lastMode: 'global_multi',
   latestEstimatedSavings: 18.5,
   latestOptimizationStatus: 'completed',
   latestOptimizedAt: '2026-05-05T10:00:00.000Z',
@@ -77,7 +77,7 @@ const savedList = {
 const optimizationResult = {
   id: 'run-1',
   shoppingListId: 'list-1',
-  mode: 'global_full',
+  mode: 'global_multi',
   status: 'completed',
   totalEstimatedCost: 15.8,
   estimatedSavings: 4.2,
@@ -198,7 +198,7 @@ async function mockApi(page: Page) {
         id: 'run-1',
         jobId: 'job-1',
         shoppingListId: 'list-1',
-        mode: 'global_full',
+        mode: 'global_multi',
         status: 'queued',
         queuedAt: '2026-05-05T10:00:00.000Z',
       }, 202);

--- a/web/e2e/responsive-qa.spec.ts
+++ b/web/e2e/responsive-qa.spec.ts
@@ -15,7 +15,7 @@ const list = {
   name: 'Compra responsiva',
   preferredRegionId: 'sao-paulo-sp',
   status: 'ready',
-  lastMode: 'global_full',
+  lastMode: 'global_multi',
   latestEstimatedSavings: 12.4,
   latestOptimizationStatus: 'completed',
   latestOptimizedAt: '2026-05-10T10:00:00.000Z',
@@ -157,7 +157,7 @@ async function mockResponsiveApi(page: Page) {
       return json({
         id: 'run-1',
         shoppingListId: 'list-1',
-        mode: 'global_full',
+        mode: 'global_multi',
         status: 'completed',
         totalEstimatedCost: 15.9,
         estimatedSavings: 1.2,
@@ -238,7 +238,7 @@ async function mockResponsiveApi(page: Page) {
           shoppingList: { id: 'list-1', name: 'Compra responsiva' },
           optimizationRun: {
             id: 'run-1',
-            mode: 'global_full',
+            mode: 'global_multi',
             status: 'completed',
             createdAt: '2026-05-10T10:00:00.000Z',
             completedAt: '2026-05-10T10:03:00.000Z',

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -85,6 +85,7 @@ type OptimizationResultApiResponse = {
     selectedPackageLabel?: string;
     establishmentName?: string;
     establishmentNeighborhood?: string;
+    distanceKm?: number;
     estimatedCost?: number;
     priceAmount?: number;
     comparisonPriceAmount?: number;
@@ -1014,12 +1015,16 @@ export async function runOptimization(
   token: string,
   listId: string,
   mode: OptimizationModeId,
+  input?: {
+    userLocationPreferenceId?: string;
+    coverageRadiusKm?: number;
+  },
 ) {
   await apiFetch<OptimizationRunAcceptedResponse>(
     `/shopping-lists/${listId}/optimize`,
     {
       method: 'POST',
-      body: JSON.stringify({ mode }),
+      body: JSON.stringify({ mode, ...input }),
     },
     token,
   );

--- a/web/src/app/mock-data.ts
+++ b/web/src/app/mock-data.ts
@@ -17,19 +17,19 @@ export const optimizationModes: Array<{
   description: string;
 }> = [
   {
-    id: 'local',
+    id: 'local_unique',
     label: 'Uma loja perto de mim',
     description:
       'Usa uma loja elegivel dentro do raio local quando houver localizacao.',
   },
   {
-    id: 'global_unique',
-    label: 'Uma loja na cidade',
+    id: 'local_multi',
+    label: 'Menor preco perto de mim',
     description:
-      'Escolhe uma unica loja na cidade para equilibrar cobertura e preco.',
+      'Escolhe item a item entre lojas dentro do raio local configurado.',
   },
   {
-    id: 'global_full',
+    id: 'global_multi',
     label: 'Menor total na cidade',
     description: 'Menor custo total, mesmo dividindo a compra em varias lojas.',
   },
@@ -38,6 +38,7 @@ export const optimizationModes: Array<{
 export const supportedCities: SupportedCity[] = [
   {
     id: 'sao-paulo-sp',
+    regionId: 'sao-paulo-sp',
     name: 'São Paulo',
     stateCode: 'SP',
     activeStoreCount: 3,
@@ -49,6 +50,7 @@ export const supportedCities: SupportedCity[] = [
   },
   {
     id: 'campinas-sp',
+    regionId: 'campinas-sp',
     name: 'Campinas',
     stateCode: 'SP',
     activeStoreCount: 2,
@@ -60,6 +62,7 @@ export const supportedCities: SupportedCity[] = [
   },
   {
     id: 'belo-horizonte-mg',
+    regionId: 'belo-horizonte-mg',
     name: 'Belo Horizonte',
     stateCode: 'MG',
     activeStoreCount: 1,
@@ -71,6 +74,7 @@ export const supportedCities: SupportedCity[] = [
   },
   {
     id: 'curitiba-pr',
+    regionId: 'curitiba-pr',
     name: 'Curitiba',
     stateCode: 'PR',
     activeStoreCount: 0,
@@ -207,7 +211,7 @@ export const initialShoppingLists: ShoppingList[] = [
     id: 'lista-semana',
     name: 'Compra da semana',
     cityId: 'sao-paulo-sp',
-    lastMode: 'global_full',
+    lastMode: 'global_multi',
     updatedAt: '2026-04-25T08:45:00-03:00',
     expectedSavings: 18.4,
     items: [
@@ -246,7 +250,7 @@ export const initialShoppingLists: ShoppingList[] = [
     id: 'lista-mensal',
     name: 'Reposição mensal',
     cityId: 'campinas-sp',
-    lastMode: 'global_unique',
+    lastMode: 'local_unique',
     updatedAt: '2026-04-24T19:30:00-03:00',
     expectedSavings: 27.9,
     items: [
@@ -278,7 +282,7 @@ export const initialShoppingLists: ShoppingList[] = [
 export const optimizationScenariosByList: Record<string, OptimizationScenario[]> = {
   'lista-semana': [
     {
-      mode: 'local',
+      mode: 'local_unique',
       label: 'Local',
       summary: 'Tudo no Atacadão Butantã, com cobertura boa e ida curta.',
       totalEstimatedCost: 63.8,
@@ -337,7 +341,7 @@ export const optimizationScenariosByList: Record<string, OptimizationScenario[]>
       ],
     },
     {
-      mode: 'global_unique',
+      mode: 'local_multi',
       label: 'Global único',
       summary: 'Carrefour Pinheiros entrega o melhor total em loja única.',
       totalEstimatedCost: 59.4,
@@ -401,7 +405,7 @@ export const optimizationScenariosByList: Record<string, OptimizationScenario[]>
       ],
     },
     {
-      mode: 'global_full',
+      mode: 'global_multi',
       label: 'Global completo',
       summary: 'Melhor custo total dividindo entre Assaí e Carrefour.',
       totalEstimatedCost: 54.7,
@@ -466,8 +470,8 @@ export const optimizationScenariosByList: Record<string, OptimizationScenario[]>
   ],
   'lista-mensal': [
     {
-      mode: 'local',
-      label: 'Local',
+      mode: 'local_unique',
+      label: 'Uma loja local',
       summary: 'Savegnago concentra a reposição com menos deslocamento.',
       totalEstimatedCost: 142.4,
       estimatedSavings: 11.6,

--- a/web/src/app/pricely-context.tsx
+++ b/web/src/app/pricely-context.tsx
@@ -9,7 +9,9 @@ import {
 
 import {
   completeShoppingListCheckout,
+  createLocationPreference,
   createShoppingList,
+  fetchLocationPreferences,
   fetchPublicRegions,
   fetchMe,
   fetchLatestOptimization,
@@ -24,6 +26,7 @@ import {
   updatePreferredRegion as updatePreferredRegionRequest,
   updateShoppingListItemPurchaseStatus,
   type OptimizationResultApiResponse,
+  type UserLocationPreferenceResponse,
 } from './api';
 import { profileSnapshot, supportedCities } from './mock-data';
 import type { OptimizationModeId, ShoppingList } from './types';
@@ -46,6 +49,7 @@ interface PricelyContextValue {
   profile: typeof profileSnapshot;
   preferredMode: OptimizationModeId;
   setPreferredMode: (mode: OptimizationModeId) => void;
+  locationPreferences: UserLocationPreferenceResponse[];
   currentUser: SessionUser | null;
   isAuthenticated: boolean;
   isBootstrapping: boolean;
@@ -91,7 +95,17 @@ interface PricelyContextValue {
   runOptimization: (
     listId: string,
     mode: OptimizationModeId,
+    input?: {
+      userLocationPreferenceId?: string;
+      coverageRadiusKm?: number;
+    },
   ) => Promise<OptimizationResultApiResponse>;
+  saveBrowserLocation: (input: {
+    label?: string;
+    latitude: number;
+    longitude: number;
+    coverageRadiusKm?: number;
+  }) => Promise<UserLocationPreferenceResponse>;
   loadLatestOptimization: (
     listId: string,
   ) => Promise<OptimizationResultApiResponse | null>;
@@ -122,7 +136,8 @@ export function PricelyProvider({ children }: PropsWithChildren) {
   const [cities, setCities] = useState(supportedCities);
   const [lists, setLists] = useState<ShoppingList[]>([]);
   const [selectedListId, setSelectedListId] = useState('');
-  const [preferredMode, setPreferredMode] = useState<OptimizationModeId>('global_full');
+  const [preferredMode, setPreferredMode] =
+    useState<OptimizationModeId>('global_multi');
   const [profile, setProfile] = useState(profileSnapshot);
   const [token, setToken] = useState<string | null>(null);
   const [currentUser, setCurrentUser] = useState<SessionUser | null>(null);
@@ -130,6 +145,9 @@ export function PricelyProvider({ children }: PropsWithChildren) {
   const [optimizationResults, setOptimizationResults] = useState<
     Record<string, OptimizationResultApiResponse | undefined>
   >({});
+  const [locationPreferences, setLocationPreferences] = useState<
+    UserLocationPreferenceResponse[]
+  >([]);
 
   useEffect(() => {
     let disposed = false;
@@ -145,6 +163,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
         setCities(
           regions.map((region) => ({
             id: region.slug,
+            regionId: region.id,
             name: region.name,
             stateCode: region.stateCode,
             activeStoreCount: region.activeEstablishmentCount,
@@ -218,6 +237,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
   useEffect(() => {
     if (!token) {
       setLists([]);
+      setLocationPreferences([]);
       setProfile(emptyProfile());
       setCurrentUser(null);
       setIsBootstrapping(false);
@@ -230,9 +250,10 @@ export function PricelyProvider({ children }: PropsWithChildren) {
       setIsBootstrapping(true);
 
       try {
-        const [user, shoppingLists] = await Promise.all([
+        const [user, shoppingLists, locations] = await Promise.all([
           fetchMe(token),
           fetchShoppingLists(token),
+          fetchLocationPreferences(token).catch(() => []),
         ]);
 
         if (disposed) {
@@ -241,6 +262,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
 
         const mappedLists = shoppingLists.map(mapShoppingList);
         setProfile(mapProfile(user));
+        setLocationPreferences(locations);
         setCurrentUser({
           id: user.id,
           email: user.email,
@@ -255,6 +277,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
           window.localStorage.removeItem(TOKEN_KEY);
           setToken(null);
           setLists([]);
+          setLocationPreferences([]);
           setProfile(emptyProfile());
           setCurrentUser(null);
           setCityIdState(null);
@@ -302,6 +325,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
       profile,
       preferredMode,
       setPreferredMode,
+      locationPreferences,
       currentUser,
       isAuthenticated: Boolean(token),
       isBootstrapping,
@@ -338,6 +362,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
         setLists([]);
         setSelectedListId('');
         setOptimizationResults({});
+        setLocationPreferences([]);
         setProfile(emptyProfile());
         setCityIdState(null);
       },
@@ -427,12 +452,23 @@ export function PricelyProvider({ children }: PropsWithChildren) {
 
         await reportShoppingListItemPriceMismatch(token, listId, itemId, input);
       },
-      runOptimization: async (listId, mode) => {
+      runOptimization: async (listId, mode, input) => {
         if (!token) {
           throw new Error('Você precisa entrar para otimizar uma lista.');
         }
 
-        const result = await runOptimizationRequest(token, listId, mode);
+        const list = lists.find((entry) => entry.id === listId);
+        const userLocationPreferenceId =
+          input?.userLocationPreferenceId ??
+          locationPreferences.find(
+            (preference) =>
+              preference.isDefault &&
+              (!list?.cityId || preference.regionSlug === list.cityId),
+          )?.id;
+        const result = await runOptimizationRequest(token, listId, mode, {
+          ...input,
+          userLocationPreferenceId,
+        });
         setOptimizationResults((current) => ({
           ...current,
           [listId]: result,
@@ -451,6 +487,37 @@ export function PricelyProvider({ children }: PropsWithChildren) {
         );
         setPreferredMode(mode);
         return result;
+      },
+      saveBrowserLocation: async (input) => {
+        if (!token) {
+          throw new Error('Voce precisa entrar para salvar a localizacao.');
+        }
+
+        const activeCity = cities.find((city) => city.id === cityId);
+        if (!activeCity) {
+          throw new Error('Escolha uma cidade antes de salvar a localizacao.');
+        }
+
+        const saved = await createLocationPreference(token, {
+          regionId: activeCity.regionId ?? activeCity.id,
+          label: input.label ?? 'Local atual',
+          latitude: input.latitude,
+          longitude: input.longitude,
+          coverageRadiusKm: input.coverageRadiusKm ?? 5,
+          isDefault: true,
+          locationSource: 'browser_geolocation',
+        });
+        setLocationPreferences((current) => [
+          saved,
+          ...current
+            .filter((entry) => entry.id !== saved.id)
+            .map((entry) =>
+              entry.regionId === saved.regionId
+                ? { ...entry, isDefault: false }
+                : entry,
+            ),
+        ]);
+        return saved;
       },
       loadLatestOptimization: async (listId) => {
         if (!token) {
@@ -487,6 +554,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
       currentUser,
       isBootstrapping,
       lists,
+      locationPreferences,
       optimizationResults,
       preferredMode,
       profile,

--- a/web/src/app/types.ts
+++ b/web/src/app/types.ts
@@ -1,10 +1,17 @@
-export type OptimizationModeId = 'local' | 'global_unique' | 'global_full';
+export type OptimizationModeId =
+  | 'local'
+  | 'global_unique'
+  | 'global_full'
+  | 'local_unique'
+  | 'local_multi'
+  | 'global_multi';
 
 export type FreshnessLevel = 'fresh' | 'aging' | 'stale';
 export type ConfidenceLevel = 'alta' | 'media' | 'baixa';
 
 export interface SupportedCity {
   id: string;
+  regionId?: string;
   name: string;
   stateCode: string;
   activeStoreCount: number;

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -200,7 +200,7 @@ describe('Admin dashboard pages', () => {
         },
         optimizationRun: {
           id: 'run-1',
-          mode: 'global_full',
+          mode: 'global_multi',
           status: 'completed',
           createdAt: '2026-05-10T04:00:00.000Z',
           completedAt: '2026-05-10T04:03:00.000Z',
@@ -214,7 +214,7 @@ describe('Admin dashboard pages', () => {
     expect(screen.getByText('Jobs recentes')).toBeTruthy();
     expect(screen.getByText('Lista: Compra da semana')).toBeTruthy();
     expect(screen.getByText(/Cliente Teste/)).toBeTruthy();
-    expect(screen.getByText(/Modo global full/)).toBeTruthy();
+    expect(screen.getByText(/Modo global multi/)).toBeTruthy();
     expect(screen.getByLabelText('Abrir detalhe do job job-1')).toBeTruthy();
     expect(screen.queryByText('Go to link')).toBeNull();
   });

--- a/web/src/public/checklist-page.spec.tsx
+++ b/web/src/public/checklist-page.spec.tsx
@@ -20,7 +20,7 @@ vi.mock('@/app/pricely-context', () => ({
         id: 'list-1',
         name: 'Compra do mes',
         cityId: 'sao-paulo-sp',
-        lastMode: 'global_full',
+        lastMode: 'global_multi',
         updatedAt: '2026-04-28T12:00:00.000Z',
         expectedSavings: 0,
         items: [

--- a/web/src/public/list-editor-page.spec.tsx
+++ b/web/src/public/list-editor-page.spec.tsx
@@ -24,7 +24,7 @@ const mockPricelyState = {
     },
   ],
   lists: [] as Array<Record<string, unknown>>,
-  preferredMode: 'global_full',
+  preferredMode: 'global_multi',
   saveList,
   isAuthenticated: true,
   isBootstrapping: false,
@@ -173,7 +173,7 @@ describe('ListEditorPage', () => {
         id: 'list-1',
         name: 'Compra mensal',
         cityId: 'sao-paulo-sp',
-        lastMode: 'global_full',
+        lastMode: 'global_multi',
         items: [
           {
             id: 'item-1',

--- a/web/src/public/optimization-page.spec.tsx
+++ b/web/src/public/optimization-page.spec.tsx
@@ -15,7 +15,7 @@ vi.mock('@/app/pricely-context', () => ({
   usePricely: () => ({
     isAuthenticated: true,
     isBootstrapping: false,
-    preferredMode: 'global_full',
+    preferredMode: 'global_multi',
     runOptimization,
     setPreferredMode,
     loadLatestOptimization,
@@ -25,7 +25,7 @@ vi.mock('@/app/pricely-context', () => ({
         id: 'list-1',
         name: 'Compra mensal',
         cityId: 'sao-paulo-sp',
-        lastMode: 'global_full',
+        lastMode: 'global_multi',
         items: [],
       },
     ],
@@ -55,19 +55,17 @@ describe('OptimizationPage', () => {
 
     expect(screen.getByText('Escolha o modo')).toBeTruthy();
     expect(screen.getByText('Uma loja perto de mim')).toBeTruthy();
-    expect(screen.getByText('Uma loja na cidade')).toBeTruthy();
+    expect(screen.getByText('Menor preco perto de mim')).toBeTruthy();
     expect(screen.getByText('Menor total na cidade')).toBeTruthy();
+    expect(document.body.textContent).toMatch(
+      /Compra mensal\s+-\s+S[aã]o Paulo\. Compare o melhor total/,
+    );
     expect(
-      screen.getByText('Compra mensal - São Paulo. Compare o melhor total, a cobertura e a economia estimada da sua compra.'),
+      screen.getByText('Prepara a compra em uma unica loja dentro do raio local configurado.'),
     ).toBeTruthy();
+    expect(screen.getByText(/exige localizacao salva/i)).toBeTruthy();
     expect(
-      screen.getByText(
-        'Prepara a compra em uma loja da cidade com raio local padrão de 5 km.',
-      ),
-    ).toBeTruthy();
-    expect(screen.getByText(/distância ainda aparece como preview/i)).toBeTruthy();
-    expect(
-      screen.getByText('Procura a melhor loja unica para equilibrar cobertura e preco.'),
+      screen.getByText('Escolhe item a item entre lojas dentro do raio local configurado.'),
     ).toBeTruthy();
     expect(
       screen.getByText('Busca o menor custo total item a item na cidade selecionada.'),
@@ -81,7 +79,7 @@ describe('OptimizationPage', () => {
       'list-1': {
         id: 'run-1',
         shoppingListId: 'list-1',
-        mode: 'global_full',
+        mode: 'global_multi',
         status: 'completed',
         totalEstimatedCost: 21.9,
         estimatedSavings: 1,
@@ -111,6 +109,7 @@ describe('OptimizationPage', () => {
               '3 notas fiscais aceitas apoiam este preco; ultima validacao ha 1 dias; confianca da oferta 78/100.',
             selectionStatus: 'selected',
             decisionReason: 'selected_confirmed_offer',
+            distanceKm: 1.4,
           },
         ],
       },
@@ -128,8 +127,9 @@ describe('OptimizationPage', () => {
     expect(screen.getByText('Oferta selecionada')).toBeTruthy();
     expect(screen.getByText('Oferta confirmada selecionada')).toBeTruthy();
     expect(screen.getByText('Selecionado: Cafe Pilao 500g · 500 g')).toBeTruthy();
-    expect(screen.getByText('Confiança alta')).toBeTruthy();
+    expect(document.body.textContent).toMatch(/Confian[cç]a alta/);
     expect(screen.getByText('78/100')).toBeTruthy();
+    expect(screen.getByText('1.4 km do local salvo')).toBeTruthy();
     expect(screen.getByText(/segundo menor elegivel/)).toBeTruthy();
     expect(screen.queryByText(/selected_confirmed_offer/i)).toBeNull();
     expect(screen.queryByText(/selected/i)).toBeNull();

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -117,17 +117,35 @@ const optimizationModeCopy: Record<
   local: {
     title: 'Uma loja perto de mim',
     summary:
-      'Prepara a compra em uma loja da cidade com raio local padrão de 5 km.',
+      'Modo legado: usa a semantica de uma loja local quando houver localizacao salva.',
+    tradeoff: 'Mantido apenas por compatibilidade com listas antigas.',
+  },
+  local_unique: {
+    title: 'Uma loja perto de mim',
+    summary:
+      'Prepara a compra em uma unica loja dentro do raio local configurado.',
     tradeoff:
-      'A distância ainda aparece como preview; a otimização usa a cidade selecionada até a regra geográfica ficar ativa.',
+      'Exige localizacao salva e pode priorizar cobertura antes do menor preco total.',
   },
   global_unique: {
     title: 'Uma loja na cidade',
     summary: 'Procura a melhor loja unica para equilibrar cobertura e preco.',
     tradeoff:
-      'Evita dividir a compra, mas pode ficar acima do menor custo total.',
+      'Modo legado mantido por compatibilidade com resultados antigos.',
+  },
+  local_multi: {
+    title: 'Menor preco perto de mim',
+    summary:
+      'Escolhe item a item entre lojas dentro do raio local configurado.',
+    tradeoff:
+      'Pode dividir a compra em mais de uma loja dentro do raio escolhido.',
   },
   global_full: {
+    title: 'Menor total na cidade',
+    summary: 'Modo legado equivalente ao menor total na cidade.',
+    tradeoff: 'Mantido por compatibilidade com listas antigas.',
+  },
+  global_multi: {
     title: 'Menor total na cidade',
     summary: 'Busca o menor custo total item a item na cidade selecionada.',
     tradeoff: 'Pode exigir mais de uma parada para capturar a melhor economia.',
@@ -3098,6 +3116,11 @@ export function OptimizationPage() {
                                   {selection.establishmentNeighborhood ??
                                     'bairro não informado'}
                                 </span>
+                                {selection.distanceKm !== undefined ? (
+                                  <span className="text-xs text-muted-foreground">
+                                    {selection.distanceKm.toFixed(1)} km do local salvo
+                                  </span>
+                                ) : null}
                               </div>
                             ) : (
                               'Sem loja definida'

--- a/web/src/public/public-shell.spec.tsx
+++ b/web/src/public/public-shell.spec.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PublicLayout } from './public-shell';
 
 const setCityId = vi.fn();
+const saveBrowserLocation = vi.fn();
 
 vi.mock('@/app/pricely-context', () => ({
   usePricely: () => ({
@@ -16,6 +17,8 @@ vi.mock('@/app/pricely-context', () => ({
     currentUser: null,
     isAuthenticated: false,
     signOut: vi.fn(),
+    locationPreferences: [],
+    saveBrowserLocation,
     cities: [
       {
         id: 'campinas-sp',
@@ -131,9 +134,11 @@ vi.mock('@/components/ui/select', () => {
 describe('PublicLayout', () => {
   beforeEach(() => {
     setCityId.mockReset();
+    saveBrowserLocation.mockReset();
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
     cleanup();
   });
@@ -146,12 +151,10 @@ describe('PublicLayout', () => {
     );
 
     expect(screen.getByText('Contexto da compra')).toBeTruthy();
-    expect(screen.getByText('Localização para otimização local')).toBeTruthy();
-    expect(screen.getByText(/raio local padrão 5 km/i)).toBeTruthy();
-    expect(screen.getByText(/distância ainda não altera a otimização/i)).toBeTruthy();
-    expect(
-      screen.queryByText('Sua compra continua de onde você parou'),
-    ).toBeNull();
+    expect(screen.getByText('Localizacao para otimizacao local')).toBeTruthy();
+    expect(screen.getByText(/raio local padrao 5 km/i)).toBeTruthy();
+    expect(screen.getByText(/modos locais usam essa localizacao salva/i)).toBeTruthy();
+    expect(screen.queryByText('Sua compra continua de onde voce parou')).toBeNull();
     expect(screen.getAllByText(/0 estabelecimentos ativos/).length).toBeGreaterThan(0);
 
     fireEvent.change(screen.getByRole('combobox', { name: 'Escolha sua cidade' }), {
@@ -168,9 +171,65 @@ describe('PublicLayout', () => {
       </MemoryRouter>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /usar localização/i }));
+    fireEvent.click(screen.getByRole('button', { name: /usar localizacao/i }));
 
-    expect(screen.getByText(/Permissão:/)).toBeTruthy();
-    expect(screen.getByText(/indisponível|manual|negada/)).toBeTruthy();
+    expect(document.body.textContent).toMatch(/Permiss[aã]o:/);
+    expect(document.body.textContent).toMatch(/indispon[ií]vel|manual|negada/);
+  });
+
+  it('saves explicit browser coordinates with the default local radius', async () => {
+    saveBrowserLocation.mockResolvedValueOnce({
+      id: 'location-1',
+      regionId: 'region-1',
+      regionSlug: 'campinas-sp',
+      label: 'Local atual',
+      latitude: -22.9,
+      longitude: -47.06,
+      coverageRadiusKm: 5,
+      activeEstablishmentCount: 2,
+      isDefault: true,
+      locationSource: 'browser_geolocation',
+      createdAt: '2026-05-13T12:00:00.000Z',
+      updatedAt: '2026-05-13T12:00:00.000Z',
+    });
+    vi.stubGlobal('navigator', {
+      geolocation: {
+        getCurrentPosition: (
+          success: (position: GeolocationPosition) => void,
+        ) => {
+          success({
+            coords: {
+              latitude: -22.9,
+              longitude: -47.06,
+              accuracy: 50,
+              altitude: null,
+              altitudeAccuracy: null,
+              heading: null,
+              speed: null,
+            },
+            timestamp: Date.now(),
+          } as GeolocationPosition);
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <PublicLayout />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /usar localizacao/i }));
+
+    await waitFor(() =>
+      expect(saveBrowserLocation).toHaveBeenCalledWith({
+        latitude: -22.9,
+        longitude: -47.06,
+        coverageRadiusKm: 5,
+      }),
+    );
+    await waitFor(() =>
+      expect(document.body.textContent).toMatch(/capturada para preview/),
+    );
   });
 });

--- a/web/src/public/public-shell.tsx
+++ b/web/src/public/public-shell.tsx
@@ -52,13 +52,28 @@ const linkClassName = ({ isActive }: { isActive: boolean }) =>
   isActive ? 'text-foreground' : 'text-muted-foreground transition-colors hover:text-foreground';
 
 export function PublicLayout() {
-  const { cityId, cities, currentUser, isAuthenticated, isBootstrapping, setCityId, signOut } =
-    usePricely();
+  const {
+    cityId,
+    cities,
+    currentUser,
+    isAuthenticated,
+    isBootstrapping,
+    locationPreferences,
+    saveBrowserLocation,
+    setCityId,
+    signOut,
+  } = usePricely();
   const { theme, toggleTheme } = useTheme();
   const [locationPermissionState, setLocationPermissionState] = useState<
     'manual' | 'requesting' | 'allowed' | 'denied' | 'unsupported'
   >('manual');
   const activeCity = cityId ? cities.find((city) => city.id === cityId) ?? null : null;
+  const activeLocation = activeCity
+    ? (locationPreferences ?? []).find(
+        (preference) =>
+          preference.isDefault && preference.regionSlug === activeCity.id,
+      )
+    : undefined;
   const shouldRequireCitySelection =
     isAuthenticated && !isBootstrapping && !cityId && cities.length > 0;
   const citySummary = activeCity
@@ -67,6 +82,12 @@ export function PublicLayout() {
   const radiusSummary = activeCity
     ? `${activeCity.activeStoreCount} lojas candidatas na cidade · raio local padrão 5 km`
     : 'Raio local padrão 5 km disponível após escolher a cidade';
+  const locationRadiusSummary = activeCity
+    ? activeLocation
+      ? `${activeLocation.activeEstablishmentCount} lojas dentro de ${activeLocation.coverageRadiusKm} km`
+      : `${activeCity.activeStoreCount} lojas na cidade - raio local padrao 5 km aguardando localizacao`
+    : radiusSummary;
+
   const requestBrowserLocation = () => {
     if (!navigator.geolocation) {
       setLocationPermissionState('unsupported');
@@ -75,7 +96,15 @@ export function PublicLayout() {
 
     setLocationPermissionState('requesting');
     navigator.geolocation.getCurrentPosition(
-      () => setLocationPermissionState('allowed'),
+      (position) => {
+        void saveBrowserLocation({
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+          coverageRadiusKm: 5,
+        })
+          .then(() => setLocationPermissionState('allowed'))
+          .catch(() => setLocationPermissionState('denied'));
+      },
       () => setLocationPermissionState('denied'),
       { enableHighAccuracy: false, maximumAge: 300000, timeout: 8000 },
     );
@@ -190,10 +219,10 @@ export function PublicLayout() {
           <div className="min-w-0">
             <div className="flex items-center gap-2 font-medium">
               <LocateFixedIcon className="size-4 text-primary" />
-              Localização para otimização local
+              Localizacao para otimizacao local
             </div>
             <div className="mt-1 text-muted-foreground">
-              {radiusSummary}. A distância ainda não altera a otimização; usamos a cidade selecionada até a regra geográfica ficar ativa.
+              {locationRadiusSummary}. Modos locais usam essa localizacao salva; modo cidade ignora distancia.
             </div>
           </div>
           <div className="flex flex-wrap gap-2 text-muted-foreground">
@@ -220,7 +249,7 @@ export function PublicLayout() {
             variant="outline"
           >
             <LocateFixedIcon data-icon="inline-start" />
-            Usar localização
+            Usar localizacao
           </Button>
         </div>
 


### PR DESCRIPTION
## Summary
- wires web location preferences into the public shell and optimization requests for local modes
- adds browser geolocation save flow with default 5 km radius and selected-offer distance copy
- updates mobile optimization mode labels, distance payload mapping, and location-radius copy while keeping native permission work marked partial
- updates tests and smoke fixtures to prefer local_unique/local_multi/global_multi

## Validation
- cd web; npm test
- cd web; npm run lint
- cd web; npm run build
- git diff --check
- cd mobile; flutter test (not run locally: Flutter is not installed in this environment)

Refs #274