### PR TITLE
Add location-aware optimization E2E coverage

### DIFF
--- a/backend/test/integration/optimization/multi-market-optimization.integration.spec.ts
+++ b/backend/test/integration/optimization/multi-market-optimization.integration.spec.ts
@@ -78,7 +78,9 @@ describe('Multi-market optimization integration', () => {
       expect(latestResponse.body.coverageStatus).toBe('complete');
       expect(latestResponse.body.totalEstimatedCost).toBe(40.88);
       expect(latestResponse.body.selections).toHaveLength(2);
-      expect(latestResponse.body.explanationSummary).toEqual(expect.any(String));
+      expect(latestResponse.body.explanationSummary).toEqual(
+        expect.any(String),
+      );
       expect(latestResponse.body.explanationPayload).toEqual(
         expect.objectContaining({
           version: 1,
@@ -102,14 +104,17 @@ describe('Multi-market optimization integration', () => {
     const { app, auth } = await createUs1TestApp();
 
     try {
-      const session = await auth.registerCustomer('catalog-backed@pricely.local');
+      const session = await auth.registerCustomer(
+        'catalog-backed@pricely.local',
+      );
 
       const offersResponse = await request(app.getHttpServer())
         .get('/regions/sao-paulo-sp/offers')
         .expect(200);
 
       const arrozOffer = offersResponse.body.offers.find(
-        (offer: { productName: string }) => offer.productName === 'Arroz tipo 1 5kg',
+        (offer: { productName: string }) =>
+          offer.productName === 'Arroz tipo 1 5kg',
       );
 
       expect(arrozOffer).toBeDefined();
@@ -164,6 +169,153 @@ describe('Multi-market optimization integration', () => {
           establishmentName: 'Unidade Pinheiros',
         }),
       );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('uses saved coordinates for local multi-store optimization and exposes selection distance', async () => {
+    const { app, auth } = await createUs1TestApp();
+
+    try {
+      const session = await auth.registerCustomer(
+        'local-coverage@pricely.local',
+      );
+
+      const locationResponse = await request(app.getHttpServer())
+        .post('/locations')
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .send({
+          regionId: 'region-test-1',
+          label: 'Casa',
+          latitude: -23.566263,
+          longitude: -46.683677,
+          coverageRadiusKm: 1,
+          isDefault: true,
+          locationSource: 'browser_geolocation',
+        })
+        .expect(201);
+
+      expect(locationResponse.body.activeEstablishmentCount).toBe(1);
+
+      const listResponse = await request(app.getHttpServer())
+        .post('/shopping-lists')
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .send({
+          name: 'Local groceries',
+          lastMode: 'local_multi',
+          regionSlug: 'sao-paulo-sp',
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/shopping-lists/${listResponse.body.id}/items`)
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .send({
+          items: [
+            {
+              requestedName: 'Arroz',
+              quantity: 1,
+              catalogProductId: 'product-test-arroz',
+              brandPreferenceMode: 'any',
+            },
+          ],
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/shopping-lists/${listResponse.body.id}/optimize`)
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .send({
+          mode: 'local_multi',
+          userLocationPreferenceId: locationResponse.body.id,
+          coverageRadiusKm: 1,
+        })
+        .expect(201);
+
+      const latestResponse = await request(app.getHttpServer())
+        .get(`/shopping-lists/${listResponse.body.id}/optimizations/latest`)
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .expect(200);
+
+      expect(latestResponse.body.mode).toBe('local_multi');
+      expect(
+        latestResponse.body.explanationPayload.constraints
+          .userLocationPreferenceId,
+      ).toBe(locationResponse.body.id);
+      expect(
+        latestResponse.body.explanationPayload.constraints
+          .candidateEstablishmentCount,
+      ).toBe(1);
+      expect(latestResponse.body.selections[0]).toEqual(
+        expect.objectContaining({
+          establishmentName: 'Unidade Pinheiros',
+          distanceKm: expect.any(Number),
+        }),
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects local optimization when the saved radius has no covered establishments', async () => {
+    const { app, auth } = await createUs1TestApp();
+
+    try {
+      const session = await auth.registerCustomer(
+        'local-zero-coverage@pricely.local',
+      );
+
+      const locationResponse = await request(app.getHttpServer())
+        .post('/locations')
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .send({
+          regionId: 'region-test-1',
+          label: 'Fora do raio',
+          latitude: -23.9,
+          longitude: -46.9,
+          coverageRadiusKm: 1,
+          isDefault: true,
+          locationSource: 'browser_geolocation',
+        })
+        .expect(201);
+
+      expect(locationResponse.body.activeEstablishmentCount).toBe(0);
+
+      const listResponse = await request(app.getHttpServer())
+        .post('/shopping-lists')
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .send({
+          name: 'No local coverage',
+          lastMode: 'local_unique',
+          regionSlug: 'sao-paulo-sp',
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/shopping-lists/${listResponse.body.id}/items`)
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .send({
+          items: [
+            {
+              requestedName: 'Arroz',
+              quantity: 1,
+              catalogProductId: 'product-test-arroz',
+              brandPreferenceMode: 'any',
+            },
+          ],
+        })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/shopping-lists/${listResponse.body.id}/optimize`)
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .send({
+          mode: 'local_unique',
+          userLocationPreferenceId: locationResponse.body.id,
+          coverageRadiusKm: 1,
+        })
+        .expect(400);
     } finally {
       await app.close();
     }

--- a/backend/test/support/us1-app.factory.ts
+++ b/backend/test/support/us1-app.factory.ts
@@ -15,6 +15,7 @@ import { QueueModule } from '../../src/common/queue/queue.module';
 import { CatalogModule } from '../../src/catalog/catalog.module';
 import { ProductMatchRepository } from '../../src/catalog/infrastructure/product-match.repository';
 import { JobsModule } from '../../src/jobs/jobs.module';
+import { LocationsModule } from '../../src/locations/locations.module';
 import { OptimizationRunProcessor } from '../../src/jobs/optimization-run.processor';
 import { ListsModule } from '../../src/lists/lists.module';
 import { OptimizationModule } from '../../src/optimization/optimization.module';
@@ -281,8 +282,14 @@ class InMemoryStoreOfferRepository {
   }
 
   async upsert(offer: any) {
-    this.offers.set(offer.id, structuredClone(offer));
-    return structuredClone(offer);
+    const enriched = {
+      ...offer,
+      storeRegionId: offer.storeRegionId ?? 'region-test-1',
+      storeLatitude: offer.storeLatitude ?? -23.566263,
+      storeLongitude: offer.storeLongitude ?? -46.683677,
+    };
+    this.offers.set(offer.id, structuredClone(enriched));
+    return structuredClone(enriched);
   }
 
   async findByCanonicalNames(canonicalNames: string[]) {
@@ -293,6 +300,10 @@ class InMemoryStoreOfferRepository {
 
   async findByListItems(
     items: Array<{ catalogProductId?: string; normalizedName?: string }>,
+    scope?: {
+      regionId?: string;
+      establishmentIds?: string[];
+    },
   ) {
     const catalogProductIds = new Set(
       items.map((item) => item.catalogProductId).filter(Boolean),
@@ -304,9 +315,13 @@ class InMemoryStoreOfferRepository {
     return Array.from(this.offers.values())
       .filter(
         (offer) =>
-          (offer.catalogProductId &&
+          (!scope?.regionId ||
+            this.regionMatches(offer.storeRegionId, scope.regionId)) &&
+          (!scope?.establishmentIds ||
+            scope.establishmentIds.includes(offer.storeId)) &&
+          ((offer.catalogProductId &&
             catalogProductIds.has(offer.catalogProductId)) ||
-          canonicalNames.has(offer.canonicalName),
+            canonicalNames.has(offer.canonicalName)),
       )
       .map((offer) => structuredClone(offer));
   }
@@ -315,6 +330,20 @@ class InMemoryStoreOfferRepository {
     const offer = this.offers.get(id);
     return offer ? structuredClone(offer) : null;
   }
+
+  private regionMatches(
+    offerRegionId: string | undefined,
+    scopeRegionId: string,
+  ) {
+    if (offerRegionId === scopeRegionId) {
+      return true;
+    }
+
+    return (
+      (offerRegionId === 'region-test-1' && scopeRegionId === 'sao-paulo-sp') ||
+      (offerRegionId === 'sao-paulo-sp' && scopeRegionId === 'region-test-1')
+    );
+  }
 }
 
 class PrismaUserAccountMock {
@@ -322,6 +351,7 @@ class PrismaUserAccountMock {
   private readonly processingJobs = new Map<string, any>();
   private readonly optimizationRuns = new Map<string, any>();
   private readonly optimizationSelections: any[] = [];
+  private readonly userLocationPreferences = new Map<string, any>();
   private readonly userEntitlements: any[] = [];
   private readonly optimizationTokenLedgerEntries = new Map<string, any>();
   private readonly regions = [
@@ -342,6 +372,9 @@ class PrismaUserAccountMock {
       cnpj: '00.000.000/0001-00',
       cityName: 'Sao Paulo',
       neighborhood: 'Pinheiros',
+      postalCode: '05422-001',
+      latitude: -23.566263,
+      longitude: -46.683677,
       regionId: 'region-test-1',
       isActive: true,
     },
@@ -618,7 +651,7 @@ class PrismaUserAccountMock {
       ).length,
     findMany: async () =>
       this.establishments.map((entry) => ({
-        ...structuredClone(entry),
+        ...entry,
         region: structuredClone(
           this.regions.find((region) => region.id === entry.regionId),
         ),
@@ -641,6 +674,91 @@ class PrismaUserAccountMock {
       }
       Object.assign(establishment, data);
       return structuredClone(establishment);
+    },
+  };
+
+  readonly userLocationPreference = {
+    findMany: async ({ where }: { where?: { userId?: string } }) =>
+      Array.from(this.userLocationPreferences.values())
+        .filter((entry) => !where?.userId || entry.userId === where.userId)
+        .map((entry) => ({
+          ...structuredClone(entry),
+          region: structuredClone(
+            this.regions.find((region) => region.id === entry.regionId),
+          ),
+        })),
+    findFirst: async ({
+      where,
+    }: {
+      where?: {
+        id?: string;
+        userId?: string;
+        regionId?: string;
+        isDefault?: boolean;
+      };
+    }) => {
+      const preference = Array.from(this.userLocationPreferences.values()).find(
+        (entry) =>
+          (!where?.id || entry.id === where.id) &&
+          (!where?.userId || entry.userId === where.userId) &&
+          (!where?.regionId || entry.regionId === where.regionId) &&
+          (where?.isDefault === undefined ||
+            entry.isDefault === where.isDefault),
+      );
+      return preference
+        ? {
+            ...structuredClone(preference),
+            region: structuredClone(
+              this.regions.find((region) => region.id === preference.regionId),
+            ),
+          }
+        : null;
+    },
+    findUnique: async ({ where }: { where: { id: string } }) => {
+      const preference = this.userLocationPreferences.get(where.id);
+      return preference ? structuredClone(preference) : null;
+    },
+    updateMany: async ({
+      where,
+      data,
+    }: {
+      where?: { userId?: string };
+      data: Record<string, unknown>;
+    }) => {
+      for (const [id, preference] of this.userLocationPreferences.entries()) {
+        if (!where?.userId || preference.userId === where.userId) {
+          this.userLocationPreferences.set(id, { ...preference, ...data });
+        }
+      }
+      return { count: this.userLocationPreferences.size };
+    },
+    create: async ({
+      data,
+      include,
+    }: {
+      data: any;
+      include?: { region?: boolean };
+    }) => {
+      const now = new Date();
+      const preference = {
+        id: crypto.randomUUID(),
+        createdAt: now,
+        updatedAt: now,
+        postalCode: null,
+        ...data,
+        latitude: data.latitude ?? null,
+        longitude: data.longitude ?? null,
+        coverageRadiusKm: data.coverageRadiusKm ?? 5,
+      };
+      this.userLocationPreferences.set(preference.id, preference);
+      return {
+        ...structuredClone(preference),
+        region: include?.region
+          ? structuredClone(
+              this.regions.find((region) => region.id === preference.regionId),
+            )
+          : undefined,
+      };
     },
   };
 
@@ -875,6 +993,10 @@ class PrismaUserAccountMock {
         estimatedSavings: null,
         summary: null,
         ...data,
+        coverageRadiusKm:
+          data.coverageRadiusKm !== null && data.coverageRadiusKm !== undefined
+            ? Number(data.coverageRadiusKm)
+            : null,
       };
 
       this.optimizationRuns.set(record.id, record);
@@ -885,6 +1007,10 @@ class PrismaUserAccountMock {
       const updated = {
         ...existing,
         ...data,
+        coverageRadiusKm:
+          data.coverageRadiusKm !== null && data.coverageRadiusKm !== undefined
+            ? Number(data.coverageRadiusKm)
+            : existing?.coverageRadiusKm,
       };
 
       this.shoppingListRepository.setOptimizationSummary(
@@ -1170,7 +1296,10 @@ class PrismaUserAccountMock {
     count: async () => 0,
   };
 
-  async $transaction<T>(operations: Promise<T>[]) {
+  async $transaction<T>(operations: Promise<T>[] | ((tx: this) => Promise<T>)) {
+    if (typeof operations === 'function') {
+      return operations(this);
+    }
     return Promise.all(operations);
   }
 }
@@ -1215,6 +1344,9 @@ export async function createUs1TestApp(): Promise<{
       storeId: 'est-test-1',
       storeName: 'Unidade Pinheiros',
       neighborhood: 'Pinheiros',
+      storeRegionId: 'region-test-1',
+      storeLatitude: -23.566263,
+      storeLongitude: -46.683677,
     },
     {
       id: 'offer-test-1',
@@ -1231,6 +1363,9 @@ export async function createUs1TestApp(): Promise<{
       storeId: 'est-test-1',
       storeName: 'Unidade Pinheiros',
       neighborhood: 'Pinheiros',
+      storeRegionId: 'region-test-1',
+      storeLatitude: -23.566263,
+      storeLongitude: -46.683677,
     },
   ]);
   const userAccountMock = new PrismaUserAccountMock(
@@ -1248,6 +1383,7 @@ export async function createUs1TestApp(): Promise<{
       PricingModule,
       RegionsModule,
       StoresModule,
+      LocationsModule,
       ReceiptsModule,
       OptimizationModule,
       JobsModule,

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -474,7 +474,7 @@ radius while keeping global optimization limited to the user's selected city/reg
 - [X] T174 Refactor optimization candidate generation to support `local_unique`, `local_multi`, and `global_multi` semantics with distance-aware explanations in `backend/src/optimization/`
 - [X] T175 Update web location widgets to support explicit browser geolocation permission, manual city/location selection, radius preview, active-establishment count, and selected-offer distance display in `web/src/public/` and `web/src/app/`
 - [X] T176 Update mobile location widgets to support platform location permission, denied/restricted/unavailable states, manual city/location selection, radius preview, and optimization-result distance copy in `mobile/lib/features/profile/`, `mobile/lib/features/shopping_lists/`, and `mobile/lib/features/optimization/`
-- [~] T177 Add integration/E2E coverage for browser/mobile location permission, manual-location fallback, local single-store, local multi-store, global city-only, zero-establishment radius, and location-denied flows in `backend/test/integration/optimization/`, `web/e2e/`, and `mobile/test/`
+- [X] T177 Add integration/E2E coverage for browser/mobile location permission, manual-location fallback, local single-store, local multi-store, global city-only, zero-establishment radius, and location-denied flows in `backend/test/integration/optimization/`, `web/e2e/`, and `mobile/test/`
 
 ---
 

--- a/web/e2e/mvp-smoke.spec.ts
+++ b/web/e2e/mvp-smoke.spec.ts
@@ -82,7 +82,8 @@ const optimizationResult = {
   totalEstimatedCost: 15.8,
   estimatedSavings: 4.2,
   coverageStatus: 'complete',
-  explanationSummary: 'Menor cesta encontrada com dados de recibos de usuarios.',
+  explanationSummary:
+    'Menor cesta encontrada com dados de recibos de usuarios.',
   createdAt: '2026-05-05T10:00:00.000Z',
   completedAt: '2026-05-05T10:00:02.000Z',
   selections: [
@@ -109,6 +110,7 @@ const optimizationResult = {
       selectionStatus: 'selected',
       confidenceNotice: 'Preco observado em recibo recente.',
       decisionReason: 'selected_confirmed_offer',
+      distanceKm: 0.8,
     },
   ],
 };
@@ -146,6 +148,47 @@ async function mockApi(page: Page) {
       return json(customerUser);
     }
 
+    if (path === '/locations' && method === 'GET') {
+      return json([]);
+    }
+
+    if (path === '/locations' && method === 'POST') {
+      const body = JSON.parse(request.postData() ?? '{}') as {
+        latitude?: number;
+        longitude?: number;
+        coverageRadiusKm?: number;
+      };
+      return json(
+        {
+          id: 'location-1',
+          regionId: region.id,
+          regionSlug: region.slug,
+          regionName: region.name,
+          label: 'Local atual',
+          latitude: body.latitude,
+          longitude: body.longitude,
+          postalCode: null,
+          coverageRadiusKm: body.coverageRadiusKm ?? 5,
+          activeEstablishmentCount: 2,
+          isDefault: true,
+          locationSource: 'browser_geolocation',
+          createdAt: '2026-05-05T10:00:00.000Z',
+          updatedAt: '2026-05-05T10:00:00.000Z',
+        },
+        201,
+      );
+    }
+
+    if (path === '/locations/coverage-preview' && method === 'POST') {
+      return json({
+        regionId: region.id,
+        coverageRadiusKm: 5,
+        activeEstablishmentCount: 2,
+        fallbackUsed: false,
+        establishments: [],
+      });
+    }
+
     if (path === '/regions') {
       return json([region]);
     }
@@ -159,13 +202,20 @@ async function mockApi(page: Page) {
     }
 
     if (path === '/shopping-lists' && method === 'POST') {
-      return json({ ...savedList, id: 'list-2', name: 'Compra semanal', items: [] }, 201);
+      return json(
+        { ...savedList, id: 'list-2', name: 'Compra semanal', items: [] },
+        201,
+      );
     }
 
     if (path === '/shopping-lists/list-2' && method === 'PATCH') {
       const body = JSON.parse(request.postData() ?? '{}') as {
         name: string;
-        items: Array<{ requestedName: string; quantity?: number; unitLabel?: string }>;
+        items: Array<{
+          requestedName: string;
+          quantity?: number;
+          unitLabel?: string;
+        }>;
       };
       return json({
         ...savedList,
@@ -194,14 +244,17 @@ async function mockApi(page: Page) {
     }
 
     if (path === '/shopping-lists/list-1/optimize') {
-      return json({
-        id: 'run-1',
-        jobId: 'job-1',
-        shoppingListId: 'list-1',
-        mode: 'global_multi',
-        status: 'queued',
-        queuedAt: '2026-05-05T10:00:00.000Z',
-      }, 202);
+      return json(
+        {
+          id: 'run-1',
+          jobId: 'job-1',
+          shoppingListId: 'list-1',
+          mode: 'global_multi',
+          status: 'queued',
+          queuedAt: '2026-05-05T10:00:00.000Z',
+        },
+        202,
+      );
     }
 
     if (path === '/shopping-lists/list-1/optimizations/latest') {
@@ -252,7 +305,11 @@ async function mockApi(page: Page) {
           attemptCount: 0,
           createdAt: '2026-05-05T10:00:00.000Z',
           updatedAt: '2026-05-05T10:00:00.000Z',
-          owner: { id: 'user-1', displayName: 'Cliente Pricely', email: 'cliente@pricely.test' },
+          owner: {
+            id: 'user-1',
+            displayName: 'Cliente Pricely',
+            email: 'cliente@pricely.test',
+          },
           receiptRecord: {
             id: 'receipt-1',
             status: 'processed',
@@ -279,7 +336,11 @@ async function mockApi(page: Page) {
         attemptCount: 0,
         createdAt: '2026-05-05T10:00:00.000Z',
         updatedAt: '2026-05-05T10:00:00.000Z',
-        owner: { id: 'user-1', displayName: 'Cliente Pricely', email: 'cliente@pricely.test' },
+        owner: {
+          id: 'user-1',
+          displayName: 'Cliente Pricely',
+          email: 'cliente@pricely.test',
+        },
         receiptRecord: {
           id: 'receipt-1',
           status: 'processed',
@@ -325,20 +386,26 @@ test.beforeEach(async ({ page }) => {
   await mockApi(page);
 });
 
-test('MVP shopper flow covers sign-in, city, list, optimization, checklist, and premium gate', async ({ page }) => {
+test('MVP shopper flow covers sign-in, city, list, optimization, checklist, and premium gate', async ({
+  page,
+}) => {
   await page.goto('/entrar');
   await expect(page.getByText('Entrar no Pricely').first()).toBeVisible();
   await page.getByLabel('E-mail').fill(customerUser.email);
   await page.getByLabel('Senha').fill('password');
   await page.getByRole('button', { name: 'Entrar' }).click();
 
-  await expect(page.getByRole('heading', { name: 'Minhas listas' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Minhas listas' }),
+  ).toBeVisible();
   await expect(page.getByText('2 de 2 listas no mês')).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Comprar Premium' })).toBeDisabled();
+  await expect(
+    page.getByRole('button', { name: 'Comprar Premium' }),
+  ).toBeDisabled();
 
   await page.goto('/cidades');
   await expect(page.getByText('Cidades suportadas').first()).toBeVisible();
-  await expect(page.getByText('Sao Paulo · SP')).toBeVisible();
+  await expect(page.getByText('Sao Paulo · SP', { exact: true })).toBeVisible();
 
   await page.goto('/listas/nova');
   await page.getByLabel('Nome da lista').fill('Compra semanal');
@@ -348,23 +415,53 @@ test('MVP shopper flow covers sign-in, city, list, optimization, checklist, and 
   await page.getByRole('button', { name: 'Adicionar' }).click();
   await expect(page.getByText('Arroz tipo 1 1kg').first()).toBeVisible();
   await page.getByRole('button', { name: 'Salvar', exact: true }).click();
-  await expect(page.getByRole('heading', { name: 'Minhas listas' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Minhas listas' }),
+  ).toBeVisible();
 
   await page.goto('/otimizacao/list-1');
-  await expect(page.getByRole('heading', { name: 'Resultado da otimização' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Resultado da otimização' }),
+  ).toBeVisible();
   await page.getByText('Usar este modo').first().click();
   await expect(page.getByText('Decisões por item')).toBeVisible();
   await expect(page.getByText('Oferta confirmada selecionada')).toBeVisible();
-  await expect(page.getByText('Trust alto')).toBeVisible();
+  await expect(page.getByText('Confiança alta')).toBeVisible();
   await expect(page.getByText('82/100', { exact: true })).toBeVisible();
 
   await page.goto('/listas/list-1/checklist');
-  await expect(page.getByRole('heading', { name: 'Checklist de compra' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Checklist de compra' }),
+  ).toBeVisible();
   await page.getByRole('checkbox').click();
-  await expect(page.getByText('Comprado')).toBeVisible();
+  await expect(page.getByText('Comprado', { exact: true })).toBeVisible();
 });
 
-test('MVP admin flow covers route protection and queue detail', async ({ page }) => {
+test('location-aware web flow saves browser coordinates and shows local result distance', async ({
+  page,
+}) => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({
+    latitude: -23.566263,
+    longitude: -46.683677,
+  });
+  await page.addInitScript(() => {
+    window.localStorage.setItem('pricely-auth-token', 'customer-token');
+  });
+
+  await page.goto('/');
+  await page.getByRole('button', { name: /Usar localizacao/i }).click();
+  await expect(page.getByText(/2 lojas dentro de 5 km/)).toBeVisible();
+
+  await page.goto('/otimizacao/list-1');
+  await page.getByText('Menor preco perto de mim').click();
+  await page.getByText('Usar este modo').nth(1).click();
+  await expect(page.getByText('0.8 km do local salvo')).toBeVisible();
+});
+
+test('MVP admin flow covers route protection and queue detail', async ({
+  page,
+}) => {
   await page.goto('/dashboard');
   await expect(page.getByText('Acesso restrito')).toBeVisible();
 
@@ -374,11 +471,16 @@ test('MVP admin flow covers route protection and queue detail', async ({ page })
 
   await page.goto('/dashboard/fila');
   await expect(page.getByText('Saude da fila')).toBeVisible();
-  await expect(page.getByText('recibo receipt-1')).toBeVisible();
+  await expect(page.getByText('Nota fiscal: Mercado Centro')).toBeVisible();
+  await expect(
+    page.getByText('ID tecnico: receipt · receipt-1 · job job-1'),
+  ).toBeVisible();
   await page.goto('/dashboard/fila/job-1');
 
   await expect(page.getByText('Mercado Centro')).toBeVisible();
   await expect(page.getByText('Recibo contribuído')).toBeVisible();
   await expect(page.getByText('suspicious_price_detected')).toBeVisible();
-  await expect(page.getByRole('cell', { name: 'Arroz tipo 1 1kg', exact: true })).toBeVisible();
+  await expect(
+    page.getByRole('cell', { name: 'Arroz tipo 1 1kg', exact: true }),
+  ).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add backend integration coverage for saved-location local optimization and zero-radius coverage rejection
- extend the US1 test app mock with location preferences and distance-aware offers
- add Playwright smoke coverage for browser geolocation, local mode selection, and distance copy
- mark T177 complete in Phase 23 tasks

## Validation
- backend: npm run build
- backend: npm test -- --runInBand test/integration/optimization/multi-market-optimization.integration.spec.ts
- backend: npm run lint
- web: npm run build
- web: npm test
- web: npm run lint
- web: npm run e2e -- mvp-smoke.spec.ts
- git diff --check

Refs #278