### PR TITLE
Polish public entitlement copy

### DIFF
--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -24,6 +24,9 @@ const requestCityInclusion = vi.fn();
 const submitReceipt = vi.fn();
 
 const setCityId = vi.fn();
+const pricelyMockState = vi.hoisted(() => ({
+  profileOverride: null as Record<string, unknown> | null,
+}));
 
 vi.mock('@/app/pricely-context', () => ({
   usePricely: () => ({
@@ -42,8 +45,12 @@ vi.mock('@/app/pricely-context', () => ({
       listsCreated: 1,
       totalEstimatedSavings: 18.5,
       entitlementPlan: 'free',
+      entitlementStatus: 'active',
       availableOptimizationTokens: 1,
       monthlyFreeOptimizationTokens: 2,
+      billingEnabled: false,
+      checkoutEnabled: false,
+      ...pricelyMockState.profileOverride,
     },
     lists: [
       {
@@ -127,6 +134,7 @@ describe('public pages', () => {
     requestCityInclusion.mockReset();
     submitReceipt.mockReset();
     setCityId.mockReset();
+    pricelyMockState.profileOverride = null;
   });
 
   afterEach(() => {
@@ -207,6 +215,29 @@ describe('public pages', () => {
     expect(screen.getAllByText('Checklist').length).toBeGreaterThan(0);
     expect(screen.getByText('Nota fiscal')).toBeTruthy();
     expect(screen.getAllByText('Abrir checklist').length).toBeGreaterThan(0);
+  });
+
+  it('renders premium entitlement copy without free-plan messaging', () => {
+    pricelyMockState.profileOverride = {
+      entitlementPlan: 'premium',
+      availableOptimizationTokens: 999,
+      billingEnabled: false,
+      checkoutEnabled: false,
+    };
+
+    render(
+      <MemoryRouter>
+        <ListsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByText('Premium ativo').length).toBeGreaterThan(0);
+    expect(screen.getByText('Benefícios Premium')).toBeTruthy();
+    expect(screen.getByText('Otimizações ilimitadas')).toBeTruthy();
+    expect(
+      screen.queryByText(/O plano gratuito inclui 2 listas otimizadas/),
+    ).toBeNull();
+    expect(screen.queryByText('Comprar Premium')).toBeNull();
   });
 
   it('submits a receipt and shows manual-release status', async () => {

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -1963,6 +1963,8 @@ export function ListsPage() {
           { label: 'Nota fiscal', status: 'pending' as const },
         ],
       };
+  const isPremium = profile.entitlementPlan === 'premium';
+  const billingEnabled = profile.billingEnabled && profile.checkoutEnabled;
 
   return (
     <RequireAuthentication
@@ -2036,28 +2038,32 @@ export function ListsPage() {
           <CardHeader className="gap-3">
             <div className="flex flex-wrap items-center gap-2">
               <Badge className="bg-emerald-100 text-emerald-950 hover:bg-emerald-100">
-                {profile.entitlementPlan === 'premium'
-                  ? 'Premium ativo'
-                  : 'Plano gratuito'}
+                {isPremium ? 'Premium ativo' : 'Plano gratuito'}
               </Badge>
               <Badge variant="secondary">
-                {profile.entitlementPlan === 'premium'
+                {isPremium
                   ? 'Otimizações ilimitadas'
                   : `${profile.availableOptimizationTokens} de ${profile.monthlyFreeOptimizationTokens} listas no mês`}
               </Badge>
             </div>
-            <CardTitle>Uso de otimizações</CardTitle>
+            <CardTitle>
+              {isPremium ? 'Benefícios Premium' : 'Uso do plano gratuito'}
+            </CardTitle>
             <CardDescription>
-              {profile.entitlementPlan === 'premium'
-                ? 'Sua conta Premium está ativa. Você pode otimizar listas sem limite enquanto o billing permanece em validação operacional.'
-                : 'O plano gratuito inclui 2 listas otimizadas por mês. A compra Premium ainda está desativada enquanto o billing é validado.'}
+              {isPremium
+                ? 'Sua conta Premium está ativa. Você pode otimizar listas sem limite e manter o histórico sincronizado na conta.'
+                : billingEnabled
+                  ? 'O plano gratuito inclui 2 listas otimizadas por mês. Você pode fazer upgrade quando quiser liberar uso ilimitado.'
+                  : 'O plano gratuito inclui 2 listas otimizadas por mês. O upgrade Premium permanece temporariamente indisponível enquanto o billing é validado.'}
             </CardDescription>
           </CardHeader>
           <CardContent>
             <Button disabled variant="outline">
-              {profile.entitlementPlan === 'premium'
-                ? 'Gerenciar Premium'
-                : 'Comprar Premium'}
+              {isPremium
+                ? 'Premium ativo'
+                : billingEnabled
+                  ? 'Comprar Premium'
+                  : 'Premium indisponível'}
             </Button>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- Split Premium and free-plan copy in the public lists/profile surface.
- Remove free-plan/billing validation language from Premium accounts.
- Show disabled Premium upgrade state only for free users while billing remains unavailable.
- Add regression coverage for Premium copy.

## Validation
- npm test -- public-pages.spec.tsx (web)
- npm run lint (web)
- npm run build (web)
- git diff --check

Refs #288