### PR TITLE
Polish public receipt handoff

### DIFF
--- a/web/src/public/checklist-page.spec.tsx
+++ b/web/src/public/checklist-page.spec.tsx
@@ -10,6 +10,9 @@ const updateListItemPurchaseStatus = vi.fn();
 const completeListCheckout = vi.fn();
 const loadLatestOptimization = vi.fn();
 const reportListItemPriceMismatch = vi.fn();
+const checklistMockState = vi.hoisted(() => ({
+  listOverride: null as Record<string, unknown> | null,
+}));
 
 vi.mock('@/app/pricely-context', () => ({
   usePricely: () => ({
@@ -36,6 +39,7 @@ vi.mock('@/app/pricely-context', () => ({
             preferredBrandNames: [],
           },
         ],
+        ...checklistMockState.listOverride,
       },
     ],
     updateListItemPurchaseStatus,
@@ -59,6 +63,7 @@ vi.mock('@/app/pricely-context', () => ({
 
 describe('ChecklistPage', () => {
   beforeEach(() => {
+    checklistMockState.listOverride = null;
     updateListItemPurchaseStatus.mockReset();
     updateListItemPurchaseStatus.mockResolvedValue({});
     completeListCheckout.mockReset();
@@ -130,5 +135,43 @@ describe('ChecklistPage', () => {
         },
       ),
     );
+  });
+
+  it('shows receipt handoff states after the list is completed', () => {
+    checklistMockState.listOverride = {
+      completedAt: '2026-05-14T12:00:00.000Z',
+      paidTotal: 98.7,
+      items: [
+        {
+          id: 'item-1',
+          name: 'Arroz tipo 1 1kg',
+          quantity: 1,
+          unitLabel: 'un',
+          purchaseStatus: 'purchased',
+          status: 'resolved',
+          imageUrl: 'https://example.com/arroz.png',
+          brandPreferenceMode: 'exact',
+          preferredBrandNames: [],
+        },
+      ],
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/listas/list-1/checklist']}>
+        <Routes>
+          <Route path="/listas/:listId/checklist" element={<ChecklistPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText('Compra fechada, valide com a nota fiscal'),
+    ).toBeTruthy();
+    expect(screen.getByText('Envio recebido')).toBeTruthy();
+    expect(screen.getByText('Reward em processamento')).toBeTruthy();
+    expect(
+      screen.getByText('Reward validado após nota confiável'),
+    ).toBeTruthy();
+    expect(screen.getAllByText('Enviar nota fiscal').length).toBeGreaterThan(0);
   });
 });

--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -245,6 +245,8 @@ describe('public pages', () => {
       id: 'receipt-1',
       processingStatus: 'waiting_manual_release',
       rewardEligibilityStatus: 'eligible_pending',
+      rewardPoints: 100,
+      rewardOptimizationTokens: 1,
       rewardMessage:
         'Nota recebida: reward em processamento ate a liberacao e validacao.',
     });
@@ -286,6 +288,10 @@ describe('public pages', () => {
     expect(
       screen.getAllByText(/aguardando liberação manual/).length,
     ).toBeGreaterThan(0);
+    expect(screen.getByText('Fila')).toBeTruthy();
+    expect(screen.getByText('Reward')).toBeTruthy();
+    expect(screen.getByText('Admin libera no dashboard')).toBeTruthy();
+    expect(screen.getByText(/Reward previsto após validação/)).toBeTruthy();
   });
 
   it('renders regional offers with empty-state friendly city context', async () => {

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -1657,6 +1657,20 @@ export function ReceiptSubmissionPage() {
   const [submission, setSubmission] = useState<{
     status: 'idle' | 'submitting' | 'submitted' | 'failed';
     message?: string;
+    processingStatus?:
+      | 'waiting_manual_release'
+      | 'queued'
+      | 'running'
+      | 'completed'
+      | 'failed'
+      | 'retrying';
+    rewardEligibilityStatus?:
+      | 'disabled'
+      | 'ineligible'
+      | 'eligible_pending'
+      | 'granted';
+    rewardPoints?: number;
+    rewardOptimizationTokens?: number;
   }>({ status: 'idle' });
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -1691,6 +1705,10 @@ export function ReceiptSubmissionPage() {
           response.processingStatus === 'waiting_manual_release'
             ? 'Nota recebida. Ela fica aguardando liberação manual antes do processamento.'
             : (response.rewardMessage ?? 'Nota enviada para processamento.'),
+        processingStatus: response.processingStatus,
+        rewardEligibilityStatus: response.rewardEligibilityStatus,
+        rewardPoints: response.rewardPoints,
+        rewardOptimizationTokens: response.rewardOptimizationTokens,
       });
       setForm({
         storeName: '',
@@ -1853,11 +1871,62 @@ export function ReceiptSubmissionPage() {
               </Button>
             </form>
             {submission.status === 'submitted' ? (
-              <Alert className="mt-4">
-                <BadgeCheckIcon />
-                <AlertTitle>Nota recebida</AlertTitle>
-                <AlertDescription>{submission.message}</AlertDescription>
-              </Alert>
+              <div className="mt-4 grid gap-3">
+                <Alert>
+                  <BadgeCheckIcon />
+                  <AlertTitle>Nota recebida</AlertTitle>
+                  <AlertDescription>{submission.message}</AlertDescription>
+                </Alert>
+                <div className="grid gap-3 md:grid-cols-3">
+                  <div className="rounded-lg border border-border/70 bg-muted/30 p-3">
+                    <div className="text-sm font-medium">Fila</div>
+                    <div className="mt-1 text-sm text-muted-foreground">
+                      {submission.processingStatus === 'waiting_manual_release'
+                        ? 'Aguardando liberação manual'
+                        : submission.processingStatus === 'queued'
+                          ? 'Liberada para processamento'
+                          : submission.processingStatus === 'running'
+                            ? 'Processando leitura'
+                            : submission.processingStatus === 'completed'
+                              ? 'Processada'
+                              : submission.processingStatus === 'failed'
+                                ? 'Falhou'
+                                : submission.processingStatus === 'retrying'
+                                  ? 'Tentando novamente'
+                                  : 'Recebida'}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border border-border/70 bg-muted/30 p-3">
+                    <div className="text-sm font-medium">Reward</div>
+                    <div className="mt-1 text-sm text-muted-foreground">
+                      {submission.rewardEligibilityStatus === 'granted'
+                        ? 'Validado e concedido'
+                        : submission.rewardEligibilityStatus ===
+                            'eligible_pending'
+                          ? 'Em processamento'
+                          : submission.rewardEligibilityStatus === 'ineligible'
+                            ? 'Sem elegibilidade'
+                            : 'Aguardando qualidade'}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border border-border/70 bg-muted/30 p-3">
+                    <div className="text-sm font-medium">Próximo passo</div>
+                    <div className="mt-1 text-sm text-muted-foreground">
+                      {submission.processingStatus === 'waiting_manual_release'
+                        ? 'Admin libera no dashboard'
+                        : 'Acompanhar validação no histórico'}
+                    </div>
+                  </div>
+                </div>
+                {submission.rewardEligibilityStatus === 'eligible_pending' ? (
+                  <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-950">
+                    Reward previsto após validação:{' '}
+                    {submission.rewardPoints ?? 100} pontos e{' '}
+                    {submission.rewardOptimizationTokens ?? 1} crédito de
+                    otimização.
+                  </div>
+                ) : null}
+              </div>
             ) : null}
             {submission.status === 'failed' ? (
               <Alert className="mt-4" variant="destructive">
@@ -1879,10 +1948,10 @@ export function ReceiptSubmissionPage() {
           </CardHeader>
           <CardContent className="grid gap-3 text-sm">
             {[
-              'Nota enviada fica aguardando liberação manual.',
-              'Admin confere leitura, matcher e qualidade dos itens.',
-              'Processamento gera ofertas e compara preços.',
-              'Nota confiável concede 100 pontos e 1 crédito.',
+              'Nota enviada entra na fila manual.',
+              'Admin libera o processamento no dashboard.',
+              'Matcher compara itens com catálogo e cria ofertas quando aplicável.',
+              'Reward sai de processamento para validado quando a nota é confiável.',
             ].map((step, index) => (
               <div
                 className="flex items-center gap-3 rounded-lg border border-emerald-200 bg-white/70 p-3"
@@ -2403,6 +2472,17 @@ export function ChecklistPage() {
                   Use a nota fiscal para validar os preços encontrados e ajudar
                   a melhorar a confiança das próximas ofertas.
                 </p>
+                <div className="grid gap-2 text-sm sm:grid-cols-3">
+                  <span className="rounded-md border border-border/70 bg-background px-3 py-2">
+                    Envio recebido
+                  </span>
+                  <span className="rounded-md border border-border/70 bg-background px-3 py-2">
+                    Reward em processamento
+                  </span>
+                  <span className="rounded-md border border-border/70 bg-background px-3 py-2">
+                    Reward validado após nota confiável
+                  </span>
+                </div>
                 <Button asChild size="sm" variant="outline">
                   <Link to="/notas">Enviar nota fiscal</Link>
                 </Button>


### PR DESCRIPTION
## Summary
- Make receipt submission show explicit manual queue, reward, and next-step states after upload.
- Clarify checklist completion handoff into receipt validation/reward processing.
- Add web regression tests for receipt manual release and completed-checklist handoff states.

## Validation
- npm test -- public-pages.spec.tsx checklist-page.spec.tsx (web)
- npm run lint (web)
- npm run build (web)
- git diff --check

## Note
- Tried validating the rich seed with DATABASE_URL=postgresql://root:root@127.0.0.1:5432/pricely?schema=public, but local Postgres rejected those credentials. Need the exact local DATABASE_URL to run db:seed end to end.

Refs #290