### PR TITLE
Expand admin receipt detail review

### DIFF
--- a/backend/src/admin/application/admin-dashboard.service.ts
+++ b/backend/src/admin/application/admin-dashboard.service.ts
@@ -324,8 +324,7 @@ export class AdminDashboardService {
                             trustLevel:
                               selection.productOffer.receiptRecord.trustLevel,
                             reviewReason:
-                              selection.productOffer.receiptRecord
-                                .reviewReason,
+                              selection.productOffer.receiptRecord.reviewReason,
                           }
                         : null,
                     }
@@ -358,6 +357,7 @@ export class AdminDashboardService {
             ean: true,
             quantity: true,
             unitPrice: true,
+            lineTotal: true,
             originalUnitPrice: true,
             promotionalUnitPrice: true,
             matchConfidence: true,
@@ -434,7 +434,9 @@ export class AdminDashboardService {
     }
 
     const projectedReceipts = receipts.map((receipt) => {
-      const confidences = receipt.lineItems.map((item) => Number(item.matchConfidence));
+      const confidences = receipt.lineItems.map((item) =>
+        Number(item.matchConfidence),
+      );
       const lineItemCount = confidences.length;
       const highConfidenceLineItemCount = confidences.filter(
         (confidence) => confidence >= 0.75,
@@ -448,6 +450,11 @@ export class AdminDashboardService {
                 lineItemCount
               ).toFixed(2),
             );
+      const totalLineAmount = Number(
+        receipt.lineItems
+          .reduce((sum, item) => sum + Number(item.lineTotal), 0)
+          .toFixed(2),
+      );
 
       return {
         id: receipt.id,
@@ -478,11 +485,19 @@ export class AdminDashboardService {
           usefulDataRatio:
             lineItemCount === 0
               ? 0
-              : Number((highConfidenceLineItemCount / lineItemCount).toFixed(2)),
+              : Number(
+                  (highConfidenceLineItemCount / lineItemCount).toFixed(2),
+                ),
         },
-        reward: this.receiptRewardProjection(
-          receipt.rewardEligibilityStatus,
-        ),
+        reward: this.receiptRewardProjection(receipt.rewardEligibilityStatus),
+        extractedPayload: {
+          accessKey: receipt.accessKey,
+          sefazUrl: receipt.sefazUrl,
+          rawReference: receipt.rawReference,
+          purchaseDate: receipt.purchaseDate?.toISOString() ?? null,
+          lineItemCount,
+          totalLineAmount,
+        },
         lineItems: receipt.lineItems.map((item) => ({
           id: item.id,
           rawProductName: item.rawProductName,
@@ -490,6 +505,7 @@ export class AdminDashboardService {
           ean: item.ean,
           quantity: Number(item.quantity),
           unitPrice: Number(item.unitPrice),
+          lineTotal: Number(item.lineTotal),
           originalUnitPrice:
             item.originalUnitPrice === null
               ? null
@@ -548,7 +564,8 @@ export class AdminDashboardService {
                       : deltaAmount < 0
                         ? 'down'
                         : 'same',
-                previousObservedAt: comparison?.observedAt.toISOString() ?? null,
+                previousObservedAt:
+                  comparison?.observedAt.toISOString() ?? null,
               },
             };
           }),
@@ -748,18 +765,19 @@ export class AdminDashboardService {
       },
     });
 
-    const tokenBalances = await this.prisma.optimizationTokenLedgerEntry.groupBy({
-      by: ['userId'],
-      where: {
-        userId: {
-          in: users.map((user) => user.id),
+    const tokenBalances =
+      await this.prisma.optimizationTokenLedgerEntry.groupBy({
+        by: ['userId'],
+        where: {
+          userId: {
+            in: users.map((user) => user.id),
+          },
+          OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
         },
-        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
-      },
-      _sum: {
-        amount: true,
-      },
-    });
+        _sum: {
+          amount: true,
+        },
+      });
     const tokenBalanceByUser = new Map(
       tokenBalances.map((entry) => [
         entry.userId,

--- a/backend/src/common/contracts/admin.contract.ts
+++ b/backend/src/common/contracts/admin.contract.ts
@@ -133,6 +133,14 @@ export interface AdminReceiptProcessingContract {
     optimizationTokens: number;
     label: string;
   };
+  extractedPayload: {
+    accessKey: string | null;
+    sefazUrl: string | null;
+    rawReference: string | null;
+    purchaseDate: string | null;
+    lineItemCount: number;
+    totalLineAmount: number;
+  };
   lineItems: Array<{
     id: string;
     rawProductName: string;
@@ -140,11 +148,18 @@ export interface AdminReceiptProcessingContract {
     ean: string | null;
     quantity: number;
     unitPrice: number;
+    lineTotal: number;
     originalUnitPrice: number | null;
     promotionalUnitPrice: number | null;
     matchConfidence: number;
-    matcherStatus: 'matched_offer' | 'matched_name_only' | 'needs_product_review';
-    makerAction: 'offer_created' | 'link_existing_product' | 'create_or_match_product';
+    matcherStatus:
+      | 'matched_offer'
+      | 'matched_name_only'
+      | 'needs_product_review';
+    makerAction:
+      | 'offer_created'
+      | 'link_existing_product'
+      | 'create_or_match_product';
     offers: Array<{
       id: string;
       catalogProductName: string;

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -550,7 +550,7 @@ Premium access and extra optimization credits are support/admin operations for n
 - [X] T211 Add public web receipt-submission flow for QR/NFC-e URL and manual MVP item entry, returning `waiting_manual_release`, reward-pending feedback, and authenticated state handling in `web/src/public/`, `web/src/app/`, and `backend/src/receipts/`
 - [X] T212 Change receipt ingestion to manual processing by default, keeping an `RECEIPT_PROCESSING_MODE=automatic` escape hatch for future automatic queueing in `backend/src/receipts/` and `backend/src/jobs/`
 - [X] T213 Add admin release action so received receipts can be manually sent to the receipt-processing queue, with pending/released states in `backend/src/admin/` and `web/src/dashboard/`
-- [~] T214 Expand admin receipt detail with extracted payload, product matcher result, missing-product maker actions, and price up/down comparison against current offers in `backend/src/admin/` and `web/src/dashboard/`
+- [X] T214 Expand admin receipt detail with extracted payload, product matcher result, missing-product maker actions, and price up/down comparison against current offers in `backend/src/admin/` and `web/src/dashboard/`
 - [~] T215 Add mobile QR-code receipt submission flow that posts the scanned NFC-e URL to backend and shows submitted -> waiting release -> processing -> reward validated states in `mobile/lib/features/receipts/`
 - [X] T216 Adopt `web/src/assets/pricely-icon.png` as the official brand icon in web shell/header and plan reuse for favicon/mobile app assets.
 - [~] T217 Continue location web/mobile UX refactors with explicit location/radius preview, manual fallback, denied-permission states, and no-proximity claims until distance-aware optimization is fully active.

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -446,6 +446,14 @@ type AdminReceiptProcessingResponse = {
     optimizationTokens: number;
     label: string;
   };
+  extractedPayload: {
+    accessKey?: string | null;
+    sefazUrl?: string | null;
+    rawReference?: string | null;
+    purchaseDate?: string | null;
+    lineItemCount: number;
+    totalLineAmount: number;
+  };
   lineItems: Array<{
     id: string;
     rawProductName: string;
@@ -453,6 +461,7 @@ type AdminReceiptProcessingResponse = {
     ean?: string | null;
     quantity: number;
     unitPrice: number;
+    lineTotal: number;
     originalUnitPrice?: number | null;
     promotionalUnitPrice?: number | null;
     matchConfidence: number;

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -481,6 +481,14 @@ describe('Admin dashboard pages', () => {
           optimizationTokens: 1,
           label: '100 pontos + 1 credito pendente',
         },
+        extractedPayload: {
+          accessKey: '35260500000000000100550010000000011000000011',
+          sefazUrl: 'https://sefaz.example/accepted',
+          rawReference: null,
+          purchaseDate: '2026-05-09T10:00:00.000Z',
+          lineItemCount: 1,
+          totalLineAmount: 15.9,
+        },
         lineItems: [
           {
             id: 'line-1',
@@ -489,6 +497,7 @@ describe('Admin dashboard pages', () => {
             ean: '7891000000000',
             quantity: 1,
             unitPrice: 15.9,
+            lineTotal: 15.9,
             originalUnitPrice: 18.9,
             promotionalUnitPrice: 15.9,
             matchConfidence: 0.91,
@@ -534,7 +543,14 @@ describe('Admin dashboard pages', () => {
 
     fireEvent.click(screen.getByText('Ver leitura e matcher'));
     expect(await screen.findByText('CAFE PILAO 500G')).toBeTruthy();
+    expect(screen.getByText('Payload extraído')).toBeTruthy();
+    expect(screen.getByText('1 itens · R$ 15,90')).toBeTruthy();
+    expect(
+      screen.getByText(/35260500000000000100550010000000011000000011/),
+    ).toBeTruthy();
+    expect(screen.getByText('1 ofertas · 0 para revisar')).toBeTruthy();
     expect(screen.getByText('Oferta criada')).toBeTruthy();
+    expect(screen.getByText('Ver oferta criada')).toBeTruthy();
     expect(screen.getByText('Preço caiu')).toBeTruthy();
     expect(screen.getByText(/R\$ 16,90 anterior/)).toBeTruthy();
   });

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -305,6 +305,21 @@ function priceDirectionLabel(
   return labels[direction];
 }
 
+function receiptMakerActionButtonLabel(
+  action: AdminReceiptProcessingResponse['lineItems'][number]['makerAction'],
+) {
+  const labels: Record<
+    AdminReceiptProcessingResponse['lineItems'][number]['makerAction'],
+    string
+  > = {
+    create_or_match_product: 'Abrir criação de produto',
+    link_existing_product: 'Revisar vínculo',
+    offer_created: 'Ver oferta criada',
+  };
+
+  return labels[action];
+}
+
 export function AdminOverviewPage() {
   const { data, error } = useAdminData<AdminMetricsResponse | null>(
     fetchAdminMetrics,
@@ -2769,6 +2784,58 @@ export function AdminReceiptsPage() {
 
               {expandedReceiptId === receipt.id ? (
                 <div className="mt-4 grid gap-3">
+                  <div className="grid gap-3 rounded-md border border-border/70 bg-card/70 p-3 md:grid-cols-4">
+                    <div>
+                      <div className="text-xs text-muted-foreground">
+                        Payload extraído
+                      </div>
+                      <div className="mt-1 font-medium">
+                        {receipt.extractedPayload.lineItemCount} itens ·{' '}
+                        {formatCurrency(
+                          receipt.extractedPayload.totalLineAmount,
+                        )}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-xs text-muted-foreground">
+                        Chave NFC-e
+                      </div>
+                      <div className="mt-1 truncate font-medium">
+                        {receipt.extractedPayload.accessKey ?? 'Não informada'}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-xs text-muted-foreground">
+                        Origem
+                      </div>
+                      <div className="mt-1 truncate font-medium">
+                        {receipt.extractedPayload.sefazUrl
+                          ? 'QR/NFC-e'
+                          : (receipt.extractedPayload.rawReference ??
+                            'Entrada manual')}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-xs text-muted-foreground">
+                        Matcher
+                      </div>
+                      <div className="mt-1 font-medium">
+                        {
+                          receipt.lineItems.filter(
+                            (item) => item.matcherStatus === 'matched_offer',
+                          ).length
+                        }{' '}
+                        ofertas ·{' '}
+                        {
+                          receipt.lineItems.filter(
+                            (item) =>
+                              item.matcherStatus === 'needs_product_review',
+                          ).length
+                        }{' '}
+                        para revisar
+                      </div>
+                    </div>
+                  </div>
                   {receipt.lineItems.length === 0 ? (
                     <div className="rounded-md border border-border/70 bg-muted/20 p-3 text-sm text-muted-foreground">
                       Nenhum item extraído da nota fiscal ainda.
@@ -2815,6 +2882,9 @@ export function AdminReceiptsPage() {
                           <div className="mt-1 font-medium">
                             {formatCurrency(item.unitPrice)}
                           </div>
+                          <div className="text-xs text-muted-foreground">
+                            total {formatCurrency(item.lineTotal)}
+                          </div>
                           {item.originalUnitPrice &&
                           item.originalUnitPrice !== item.unitPrice ? (
                             <div className="text-xs text-muted-foreground">
@@ -2829,6 +2899,22 @@ export function AdminReceiptsPage() {
                           <div className="mt-1 font-medium">
                             {receiptMakerActionLabel(item.makerAction)}
                           </div>
+                          <Button
+                            asChild
+                            className="mt-2"
+                            size="sm"
+                            variant="outline"
+                          >
+                            <a
+                              href={
+                                item.makerAction === 'offer_created'
+                                  ? '/dashboard/precos'
+                                  : '/dashboard/catalogo'
+                              }
+                            >
+                              {receiptMakerActionButtonLabel(item.makerAction)}
+                            </a>
+                          </Button>
                         </div>
                         <div className="rounded-md border border-border/70 p-3">
                           <div className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- adds extracted payload summary to admin receipt review details
- exposes receipt line totals in the admin contract and dashboard
- makes matcher/maker state more actionable with review links and summary counts
- marks T214 complete in the phase plan

## Validation
- npm test -- dashboard-pages.spec.tsx
- npm test -- --runTestsByPath test/unit/admin/admin-dashboard.service.spec.ts
- npm run lint (backend)
- npm run build (backend)
- npm run lint (web)
- npm run build (web)
- git diff --check

Refs #300