### PR TITLE
Finalize receipt reward projection

### DIFF
--- a/backend/src/receipts/application/receipt-ingestion.service.ts
+++ b/backend/src/receipts/application/receipt-ingestion.service.ts
@@ -139,13 +139,7 @@ export class ReceiptIngestionService {
       trustLevel: assessedRecord.trustLevel,
       moderationStatus: assessedRecord.moderationStatus,
       rewardEligibilityStatus: assessedRecord.rewardEligibilityStatus,
-      rewardPoints: assessedRecord.rewardEligibilityStatus === 'eligible_pending' ? 100 : 0,
-      rewardOptimizationTokens:
-        assessedRecord.rewardEligibilityStatus === 'eligible_pending' ? 1 : 0,
-      rewardMessage:
-        assessedRecord.rewardEligibilityStatus === 'eligible_pending'
-          ? 'Nota recebida: reward em processamento ate a liberacao e validacao.'
-          : 'Nota recebida para revisao.',
+      ...this.projectReward(assessedRecord.rewardEligibilityStatus),
       reviewReason: assessedRecord.reviewReason,
       jobId: processingJob?.id,
       processingStatus: processingJob ? 'queued' : 'waiting_manual_release',
@@ -220,13 +214,7 @@ export class ReceiptIngestionService {
       trustLevel: record.trustLevel,
       moderationStatus: record.moderationStatus,
       rewardEligibilityStatus: record.rewardEligibilityStatus,
-      rewardPoints: record.rewardEligibilityStatus === 'eligible_pending' ? 100 : 0,
-      rewardOptimizationTokens:
-        record.rewardEligibilityStatus === 'eligible_pending' ? 1 : 0,
-      rewardMessage:
-        record.rewardEligibilityStatus === 'granted'
-          ? 'Nota validada: voce ganhou 100 pontos e 1 credito de otimizacao.'
-          : 'Nota recebida: reward em processamento ate a liberacao e validacao.',
+      ...this.projectReward(record.rewardEligibilityStatus),
       reviewReason: record.reviewReason,
       jobId: record.processingJobId,
       processingStatus: record.processingStatus ?? 'waiting_manual_release',
@@ -237,6 +225,47 @@ export class ReceiptIngestionService {
 
   private isAutomaticReceiptProcessingEnabled(): boolean {
     return process.env.RECEIPT_PROCESSING_MODE === 'automatic';
+  }
+
+  private projectReward(
+    status: ReceiptRecordEntity['rewardEligibilityStatus'],
+  ): Pick<
+    ReceiptRecord,
+    'rewardPoints' | 'rewardOptimizationTokens' | 'rewardMessage'
+  > {
+    if (status === 'granted') {
+      return {
+        rewardPoints: 100,
+        rewardOptimizationTokens: 1,
+        rewardMessage:
+          'Nota validada: voce ganhou 100 pontos e 1 credito de otimizacao.',
+      };
+    }
+
+    if (status === 'eligible_pending') {
+      return {
+        rewardPoints: 100,
+        rewardOptimizationTokens: 1,
+        rewardMessage:
+          'Nota recebida: reward em processamento ate a liberacao e validacao.',
+      };
+    }
+
+    if (status === 'ineligible') {
+      return {
+        rewardPoints: 0,
+        rewardOptimizationTokens: 0,
+        rewardMessage:
+          'Nota recebida, mas sem reward por duplicidade ou falta de dados uteis.',
+      };
+    }
+
+    return {
+      rewardPoints: 0,
+      rewardOptimizationTokens: 0,
+      rewardMessage:
+        'Nota recebida para revisao de qualidade antes de liberar reward.',
+    };
   }
 
   private inferSourceType(

--- a/backend/test/integration/receipts/receipt-ingestion.integration.spec.ts
+++ b/backend/test/integration/receipts/receipt-ingestion.integration.spec.ts
@@ -104,6 +104,12 @@ describe('Receipt ingestion integration', () => {
         id: receipt.body.id,
         processingStatus: 'queued',
         jobId: expect.any(String),
+        rewardEligibilityStatus: 'granted',
+        rewardPoints: 100,
+        rewardOptimizationTokens: 1,
+        rewardMessage:
+          'Nota validada: voce ganhou 100 pontos e 1 credito de otimizacao.',
+        reviewReason: 'receipt_reward_granted',
       });
       expect(queues.receiptQueue.add).toHaveBeenCalledTimes(1);
     } finally {

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -541,7 +541,7 @@ Premium access and extra optimization credits are support/admin operations for n
 - [X] T205 Persist optimization-specific variant substitutions on the original list while preserving the original `any variant` intent so future optimizations can swap variants again in `backend/src/lists/`, `backend/src/optimization/`, and `web/src/public/`
 - [X] T206 Update item decision math so savings compare selected offer against the second cheapest eligible offer, while city average remains a separate informational metric in `backend/src/optimization/`, `backend/src/common/contracts/optimization.contract.ts`, and `web/src/public/`
 - [X] T207 Rename shopper-facing trust copy to `Confianca da oferta`, including source labels for admin/manual/receipt evidence, receipt support count, freshness decay, and clearer no-receipt wording in `backend/src/optimization/`, `backend/src/pricing/`, and `web/src/public/`
-- [~] T208 Add gamified receipt contribution rewards with points and token outcomes only after receipt quality scoring confirms useful, correctly processed receipt data in `backend/src/receipts/`, `backend/src/users/`, and `web/src/public/`
+- [X] T208 Add gamified receipt contribution rewards with points and token outcomes only after receipt quality scoring confirms useful, correctly processed receipt data in `backend/src/receipts/`, `backend/src/users/`, and `web/src/public/`
 - [X] T209 Add a dedicated admin receipt-processing queue/detail surface for receipt content, line-item quality, moderation status, and reward readiness in `backend/src/admin/` and `web/src/dashboard/`
 - [X] T210 Add public city-request/contact flow while keeping city creation admin-only in `backend/src/regions/`, `backend/src/admin/`, and `web/src/public/`
 

--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -294,6 +294,41 @@ describe('public pages', () => {
     expect(screen.getByText(/Reward previsto após validação/)).toBeTruthy();
   });
 
+  it('shows granted receipt reward points and optimization credit', async () => {
+    submitReceipt.mockResolvedValue({
+      id: 'receipt-validated',
+      processingStatus: 'completed',
+      rewardEligibilityStatus: 'granted',
+      rewardPoints: 100,
+      rewardOptimizationTokens: 1,
+      rewardMessage:
+        'Nota validada: voce ganhou 100 pontos e 1 credito de otimizacao.',
+    });
+
+    render(
+      <MemoryRouter>
+        <ReceiptSubmissionPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Estabelecimento'), {
+      target: { value: 'Mercado Validado' },
+    });
+    fireEvent.change(screen.getByLabelText('Produto'), {
+      target: { value: 'Cafe torrado' },
+    });
+    fireEvent.change(screen.getByLabelText('Preço'), {
+      target: { value: '15.9' },
+    });
+    fireEvent.click(screen.getByText('Enviar nota'));
+
+    await waitFor(() => expect(submitReceipt).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('Validado e concedido')).toBeTruthy();
+    expect(screen.getByText(/Reward validado/)).toBeTruthy();
+    expect(screen.getAllByText(/100 pontos/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/1 crédito de otimização/)).toBeTruthy();
+  });
+
   it('renders regional offers with empty-state friendly city context', async () => {
     fetchRegionOffers.mockResolvedValue({
       region: {

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -1918,9 +1918,12 @@ export function ReceiptSubmissionPage() {
                     </div>
                   </div>
                 </div>
-                {submission.rewardEligibilityStatus === 'eligible_pending' ? (
+                {submission.rewardEligibilityStatus === 'eligible_pending' ||
+                submission.rewardEligibilityStatus === 'granted' ? (
                   <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-950">
-                    Reward previsto após validação:{' '}
+                    {submission.rewardEligibilityStatus === 'granted'
+                      ? 'Reward validado: '
+                      : 'Reward previsto após validação: '}
                     {submission.rewardPoints ?? 100} pontos e{' '}
                     {submission.rewardOptimizationTokens ?? 1} crédito de
                     otimização.


### PR DESCRIPTION
## Summary
- centralizes receipt reward projection for pending, granted, ineligible, and review states
- returns points and optimization credit when manually processed receipts move to granted
- shows validated receipt rewards in the public receipt submission flow

## Validation
- npm test -- --runTestsByPath test/integration/receipts/receipt-ingestion.integration.spec.ts test/unit/users/entitlements.service.spec.ts
- npm test -- public-pages.spec.tsx
- npm run lint (backend)
- npm run build (backend)
- npm run lint (web)
- npm run build (web)
- git diff --check

Refs #302