### PR TITLE
Harden functional catalog deletion flows

### DIFF
--- a/backend/src/admin/application/admin-dashboard.service.ts
+++ b/backend/src/admin/application/admin-dashboard.service.ts
@@ -1256,9 +1256,7 @@ export class AdminDashboardService {
   }
 
   async deleteProduct(id: string) {
-    const deleted = await this.catalogProductsService.updateProduct(id, {
-      isActive: false,
-    });
+    const deleted = await this.catalogProductsService.deleteProduct(id);
 
     this.logger.log(`Admin deactivated catalog product ${id}`);
 
@@ -1326,9 +1324,7 @@ export class AdminDashboardService {
   }
 
   async deleteProductVariant(id: string) {
-    const deleted = await this.catalogProductsService.updateVariant(id, {
-      isActive: false,
-    });
+    const deleted = await this.catalogProductsService.deleteVariant(id);
 
     this.logger.log(`Admin deactivated product variant ${id}`);
 

--- a/backend/src/catalog/application/catalog-products.service.ts
+++ b/backend/src/catalog/application/catalog-products.service.ts
@@ -76,6 +76,41 @@ export class CatalogProductsService {
     });
   }
 
+  async deleteProduct(id: string) {
+    const [deleted] = await this.prisma.$transaction([
+      this.prisma.catalogProduct.update({
+        where: { id },
+        data: {
+          isActive: false,
+        },
+        include: {
+          aliases: true,
+        },
+      }),
+      this.prisma.productVariant.updateMany({
+        where: {
+          catalogProductId: id,
+          isActive: true,
+        },
+        data: {
+          isActive: false,
+        },
+      }),
+      this.prisma.productOffer.updateMany({
+        where: {
+          catalogProductId: id,
+          isActive: true,
+        },
+        data: {
+          availabilityStatus: 'unavailable',
+          isActive: false,
+        },
+      }),
+    ]);
+
+    return deleted;
+  }
+
   async searchCatalogProducts(query: string) {
     const normalizedQuery = query.trim();
     const searchFilter = normalizedQuery
@@ -171,5 +206,28 @@ export class CatalogProductsService {
       where: { id },
       data: input,
     });
+  }
+
+  async deleteVariant(id: string) {
+    const [deleted] = await this.prisma.$transaction([
+      this.prisma.productVariant.update({
+        where: { id },
+        data: {
+          isActive: false,
+        },
+      }),
+      this.prisma.productOffer.updateMany({
+        where: {
+          productVariantId: id,
+          isActive: true,
+        },
+        data: {
+          availabilityStatus: 'unavailable',
+          isActive: false,
+        },
+      }),
+    ]);
+
+    return deleted;
   }
 }

--- a/backend/test/unit/catalog/catalog-products.service.spec.ts
+++ b/backend/test/unit/catalog/catalog-products.service.spec.ts
@@ -90,4 +90,101 @@ describe('CatalogProductsService', () => {
       orderBy: [{ brandName: 'asc' }, { displayName: 'asc' }],
     });
   });
+
+  it('soft deletes a catalog product with its active variants and offers', async () => {
+    const prisma = {
+      catalogProduct: {
+        update: jest.fn().mockResolvedValue({
+          id: 'product-1',
+          isActive: false,
+        }),
+      },
+      productVariant: {
+        updateMany: jest.fn().mockResolvedValue({ count: 2 }),
+      },
+      productOffer: {
+        updateMany: jest.fn().mockResolvedValue({ count: 3 }),
+      },
+      $transaction: jest.fn((operations: Array<Promise<unknown>>) =>
+        Promise.all(operations),
+      ),
+    };
+
+    const service = new CatalogProductsService(prisma as never);
+
+    await expect(service.deleteProduct('product-1')).resolves.toEqual(
+      expect.objectContaining({
+        id: 'product-1',
+        isActive: false,
+      }),
+    );
+
+    expect(prisma.catalogProduct.update).toHaveBeenCalledWith({
+      where: { id: 'product-1' },
+      data: { isActive: false },
+      include: {
+        aliases: true,
+      },
+    });
+    expect(prisma.productVariant.updateMany).toHaveBeenCalledWith({
+      where: {
+        catalogProductId: 'product-1',
+        isActive: true,
+      },
+      data: {
+        isActive: false,
+      },
+    });
+    expect(prisma.productOffer.updateMany).toHaveBeenCalledWith({
+      where: {
+        catalogProductId: 'product-1',
+        isActive: true,
+      },
+      data: {
+        availabilityStatus: 'unavailable',
+        isActive: false,
+      },
+    });
+  });
+
+  it('soft deletes a product variant and removes its active offers from circulation', async () => {
+    const prisma = {
+      productVariant: {
+        update: jest.fn().mockResolvedValue({
+          id: 'variant-1',
+          isActive: false,
+        }),
+      },
+      productOffer: {
+        updateMany: jest.fn().mockResolvedValue({ count: 2 }),
+      },
+      $transaction: jest.fn((operations: Array<Promise<unknown>>) =>
+        Promise.all(operations),
+      ),
+    };
+
+    const service = new CatalogProductsService(prisma as never);
+
+    await expect(service.deleteVariant('variant-1')).resolves.toEqual(
+      expect.objectContaining({
+        id: 'variant-1',
+        isActive: false,
+      }),
+    );
+
+    expect(prisma.productVariant.update).toHaveBeenCalledWith({
+      where: { id: 'variant-1' },
+      data: { isActive: false },
+    });
+    expect(prisma.productOffer.updateMany).toHaveBeenCalledWith({
+      where: {
+        productVariantId: 'variant-1',
+        isActive: true,
+      },
+      data: {
+        availabilityStatus: 'unavailable',
+        isActive: false,
+      },
+    });
+  });
 });

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -37,6 +37,8 @@ const fetchAdminOffers = vi.fn();
 const fetchAdminProducts = vi.fn();
 const fetchAdminProductVariants = vi.fn();
 const createAdminOffer = vi.fn();
+const deleteAdminProduct = vi.fn();
+const deleteAdminProductVariant = vi.fn();
 const fetchAdminUsers = vi.fn();
 const setAdminUserPremium = vi.fn();
 const grantAdminUserTokens = vi.fn();
@@ -89,6 +91,9 @@ vi.mock('@/app/api', () => ({
   createAdminOffer: (...args: unknown[]) => createAdminOffer(...args),
   createAdminProduct: vi.fn(),
   createAdminProductVariant: vi.fn(),
+  deleteAdminProduct: (...args: unknown[]) => deleteAdminProduct(...args),
+  deleteAdminProductVariant: (...args: unknown[]) =>
+    deleteAdminProductVariant(...args),
   updateAdminOffer: vi.fn(),
   updateAdminProduct: vi.fn(),
   updateAdminProductVariant: vi.fn(),
@@ -195,6 +200,8 @@ describe('Admin dashboard pages', () => {
     fetchAdminOffers.mockReset();
     fetchAdminProducts.mockReset();
     fetchAdminProductVariants.mockReset();
+    deleteAdminProduct.mockReset();
+    deleteAdminProductVariant.mockReset();
     fetchAdminUsers.mockReset();
     setAdminUserPremium.mockReset();
     grantAdminUserTokens.mockReset();
@@ -477,6 +484,11 @@ describe('Admin dashboard pages', () => {
         unitName: 'Mercado Centro',
       },
     ]);
+    deleteAdminProduct.mockResolvedValue({ id: 'product-1', isActive: false });
+    deleteAdminProductVariant.mockResolvedValue({
+      id: 'variant-1',
+      isActive: false,
+    });
 
     render(<AdminCatalogPage />);
 
@@ -494,6 +506,19 @@ describe('Admin dashboard pages', () => {
     });
     await waitFor(() => {
       expect(screen.getAllByText(/Cafe Pilao 500g/).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getByText('Excluir variante'));
+    await waitFor(() => {
+      expect(deleteAdminProductVariant).toHaveBeenCalledWith(
+        'token',
+        'variant-1',
+      );
+    });
+
+    fireEvent.click(screen.getByText('Excluir produto'));
+    await waitFor(() => {
+      expect(deleteAdminProduct).toHaveBeenCalledWith('token', 'product-1');
     });
 
     render(<AdminPricesPage />);


### PR DESCRIPTION
## Summary
- adds TDD coverage for catalog product and variant deletion side effects
- deactivates related active variants and offers when deleting catalog entities
- covers admin catalog delete actions in the dashboard test suite

## Validation
- backend: npm test
- backend: npm run lint
- backend: npm run build
- web: npm test
- web: npm run lint
- web: npm run build