### PR TITLE
Harden NFCe receipt ingestion

### DIFF
--- a/backend/src/receipts/application/receipt-ingestion.service.ts
+++ b/backend/src/receipts/application/receipt-ingestion.service.ts
@@ -431,8 +431,9 @@ export class ReceiptIngestionService {
   }
 
   private parseSefazHtml(html: string): Partial<ReceiptIngestionRequest> {
+    const decodedHtml = this.decodeHtml(html);
     const text = this.decodeHtml(
-      html
+      decodedHtml
         .replace(/<script[\s\S]*?<\/script>/gi, ' ')
         .replace(/<style[\s\S]*?<\/style>/gi, ' ')
         .replace(/<[^>]+>/g, ' ')
@@ -446,7 +447,7 @@ export class ReceiptIngestionService {
     const purchaseDate = this.parseBrazilianDate(
       this.matchText(text, /Data Emissão\s+(\d{2}\/\d{2}\/\d{4}\s+\d{2}:\d{2}:\d{2})/i),
     );
-    const items = [...html.matchAll(/<tr>\s*<td><h7>([\s\S]*?)<\/h7>\s*\(Código:\s*([^)]+)\)<\/td>\s*<td>Qtde total de ítens:\s*([\d.,]+)<\/td>\s*<td>UN:\s*([^<]+)<\/td>\s*<td>Valor total R\$:\s*R\$\s*([\d.,]+)<\/td>\s*<\/tr>/gi)]
+    const items = [...decodedHtml.matchAll(/<tr>\s*<td><h7>([\s\S]*?)<\/h7>\s*\(Código:\s*([^)]+)\)<\/td>\s*<td>Qtde total de ítens:\s*([\d.,]+)<\/td>\s*<td>UN:\s*([^<]+)<\/td>\s*<td>Valor total R\$:\s*R\$\s*([\d.,]+)<\/td>\s*<\/tr>/gi)]
       .map((match) => {
         const rawProductName = this.decodeHtml(
           match[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim(),
@@ -525,9 +526,39 @@ export class ReceiptIngestionService {
     return value
       .replace(/&nbsp;/g, ' ')
       .replace(/&amp;/g, '&')
+      .replace(/&aacute;/g, '\u00e1')
+      .replace(/&agrave;/g, '\u00e0')
+      .replace(/&acirc;/g, '\u00e2')
+      .replace(/&atilde;/g, '\u00e3')
+      .replace(/&eacute;/g, '\u00e9')
+      .replace(/&ecirc;/g, '\u00ea')
+      .replace(/&iacute;/g, '\u00ed')
+      .replace(/&oacute;/g, '\u00f3')
+      .replace(/&ocirc;/g, '\u00f4')
+      .replace(/&otilde;/g, '\u00f5')
+      .replace(/&uacute;/g, '\u00fa')
+      .replace(/&ccedil;/g, '\u00e7')
+      .replace(/&Aacute;/g, '\u00c1')
+      .replace(/&Agrave;/g, '\u00c0')
+      .replace(/&Acirc;/g, '\u00c2')
+      .replace(/&Atilde;/g, '\u00c3')
+      .replace(/&Eacute;/g, '\u00c9')
+      .replace(/&Ecirc;/g, '\u00ca')
+      .replace(/&Iacute;/g, '\u00cd')
+      .replace(/&Oacute;/g, '\u00d3')
+      .replace(/&Ocirc;/g, '\u00d4')
+      .replace(/&Otilde;/g, '\u00d5')
+      .replace(/&Uacute;/g, '\u00da')
+      .replace(/&Ccedil;/g, '\u00c7')
       .replace(/&lt;/g, '<')
       .replace(/&gt;/g, '>')
       .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'");
+      .replace(/&#39;/g, "'")
+      .replace(/&#(\d+);/g, (_entity, codePoint: string) =>
+        String.fromCodePoint(Number(codePoint)),
+      )
+      .replace(/&#x([0-9a-f]+);/gi, (_entity, codePoint: string) =>
+        String.fromCodePoint(Number.parseInt(codePoint, 16)),
+      );
   }
 }

--- a/backend/test/integration/receipts/receipt-ingestion.integration.spec.ts
+++ b/backend/test/integration/receipts/receipt-ingestion.integration.spec.ts
@@ -65,6 +65,84 @@ describe('Receipt ingestion integration', () => {
     }
   });
 
+  it('accepts a SEFAZ NFC-e URL and extracts receipt data before manual release', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(
+        `
+          <html>
+            <body>
+              Nota Fiscal de Consumidor Eletr&ocirc;nica (NFC-e) SUPERMERCADO ENTITY LTDA
+              CNPJ: 04641376024400 -, Inscri&ccedil;&atilde;o Estadual: 0032546124242
+              Data Emiss&#227;o 15/05/2026 20:36:48
+              <table>
+                <tr><td><h7>REFR C COLA S/AC 200</h7> (C&oacute;digo: 1462210)</td><td>Qtde total de &iacute;tens: 3.000</td><td>UN: FR</td><td>Valor total R$: R$ 5,94</td></tr>
+              </table>
+            </body>
+          </html>
+        `,
+        {
+          status: 200,
+          headers: {
+            'content-type': 'text/html',
+          },
+        },
+      ),
+    );
+    const { app, queues, auth } = await createUs1TestApp();
+
+    try {
+      const session = await auth.registerCustomer(
+        'receipt-url-user@pricely.local',
+      );
+
+      const response = await request(app.getHttpServer())
+        .post('/receipts')
+        .set('Authorization', `Bearer ${session.accessToken}`)
+        .send({
+          sourceType: 'qr_code_url',
+          qrCodeUrl:
+            'https://portalsped.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml?p=31260504641376024400650100002111701459668768%7C2%7C1%7C1%7C00F59426796F3226861AC29D212C328ECB6AC66B',
+        })
+        .expect(202);
+
+      expect(response.body).toMatchObject({
+        storeName: 'SUPERMERCADO ENTITY LTDA',
+        storeCnpj: '04641376024400',
+        accessKey: '31260504641376024400650100002111701459668768',
+        parseStatus: 'parsed',
+        processingStatus: 'waiting_manual_release',
+      });
+      expect(response.body.jobId).toBeUndefined();
+      expect(queues.receiptQueue.add).not.toHaveBeenCalled();
+
+      const admin = await auth.registerAdmin('receipt-url-admin@pricely.local');
+      const audit = await request(app.getHttpServer())
+        .get(`/admin/receipt-processing/${response.body.id}`)
+        .set('Authorization', `Bearer ${admin.accessToken}`)
+        .expect(200);
+
+      expect(audit.body).toMatchObject({
+        id: response.body.id,
+        storeName: 'SUPERMERCADO ENTITY LTDA',
+        extractedPayload: expect.objectContaining({
+          accessKey: '31260504641376024400650100002111701459668768',
+          lineItemCount: 1,
+          totalLineAmount: 5.94,
+        }),
+        lineItems: [
+          expect.objectContaining({
+            rawProductName: 'REFR C COLA S/AC 200',
+            quantity: 3,
+            unitPrice: 1.98,
+          }),
+        ],
+      });
+    } finally {
+      fetchSpy.mockRestore();
+      await app.close();
+    }
+  });
+
   it('allows an admin to release a manually queued receipt for processing', async () => {
     const { app, queues, auth } = await createUs1TestApp();
 

--- a/backend/test/unit/receipts/receipt-ingestion-sefaz.spec.ts
+++ b/backend/test/unit/receipts/receipt-ingestion-sefaz.spec.ts
@@ -75,4 +75,105 @@ describe('ReceiptIngestionService SEFAZ HTML extraction', () => {
       }),
     );
   });
+
+  it('parses properly encoded SEFAZ HTML from a real NFC-e page', () => {
+    const service = createService() as unknown as {
+      parseSefazHtml(html: string): {
+        storeName?: string;
+        storeCnpj?: string;
+        purchaseDate?: string;
+        items?: Array<{
+          rawProductName: string;
+          ean?: string;
+          quantity: number;
+          unitPrice: number;
+          originalUnitPrice?: number;
+          packageSize?: string;
+        }>;
+      };
+    };
+    const html = `
+      <html>
+        <body>
+          Nota Fiscal de Consumidor Eletrônica (NFC-e) SUPERMERCADO SALES LTDA
+          CNPJ: 04641376024400 -, Inscrição Estadual: 0032546124242
+          AV. LEITE DE CASTRO, 261, FABRICAS, 3162500 - SAO JOAO DEL REI, MG
+          Data Emissão 15/05/2026 20:36:48
+          <table>
+            <tr><td><h7>BISC PIRAQUE 80G</h7> (Código: 2981734)</td><td>Qtde total de ítens: 1.000</td><td>UN: PT</td><td>Valor total R$: R$ 3,48</td></tr>
+            <tr><td><h7>CAFE SOL 3 COR 100G</h7> (Código: 1796254)</td><td>Qtde total de ítens: 1.000</td><td>UN: VD</td><td>Valor total R$: R$ 34,90</td></tr>
+          </table>
+        </body>
+      </html>
+    `;
+
+    expect(service.parseSefazHtml(html)).toEqual(
+      expect.objectContaining({
+        storeName: 'SUPERMERCADO SALES LTDA',
+        storeCnpj: '04641376024400',
+        purchaseDate: '2026-05-15T20:36:48-03:00',
+        items: [
+          expect.objectContaining({
+            rawProductName: 'BISC PIRAQUE 80G',
+            ean: '2981734',
+            quantity: 1,
+            unitPrice: 3.48,
+            originalUnitPrice: 3.48,
+            packageSize: '80 g',
+          }),
+          expect.objectContaining({
+            rawProductName: 'CAFE SOL 3 COR 100G',
+            ean: '1796254',
+            quantity: 1,
+            unitPrice: 34.9,
+            packageSize: '100 g',
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('parses SEFAZ HTML that uses named and numeric HTML entities', () => {
+    const service = createService() as unknown as {
+      parseSefazHtml(html: string): {
+        storeName?: string;
+        storeCnpj?: string;
+        purchaseDate?: string;
+        items?: Array<{
+          rawProductName: string;
+          ean?: string;
+          quantity: number;
+          unitPrice: number;
+        }>;
+      };
+    };
+    const html = `
+      <html>
+        <body>
+          Nota Fiscal de Consumidor Eletr&ocirc;nica (NFC-e) SUPERMERCADO ENTITY LTDA
+          CNPJ: 04641376024400 -, Inscri&ccedil;&atilde;o Estadual: 0032546124242
+          Data Emiss&#227;o 15/05/2026 20:36:48
+          <table>
+            <tr><td><h7>REFR C COLA S/AC 200</h7> (C&oacute;digo: 1462210)</td><td>Qtde total de &iacute;tens: 3.000</td><td>UN: FR</td><td>Valor total R$: R$ 5,94</td></tr>
+          </table>
+        </body>
+      </html>
+    `;
+
+    expect(service.parseSefazHtml(html)).toEqual(
+      expect.objectContaining({
+        storeName: 'SUPERMERCADO ENTITY LTDA',
+        storeCnpj: '04641376024400',
+        purchaseDate: '2026-05-15T20:36:48-03:00',
+        items: [
+          expect.objectContaining({
+            rawProductName: 'REFR C COLA S/AC 200',
+            ean: '1462210',
+            quantity: 3,
+            unitPrice: 1.98,
+          }),
+        ],
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- adds parser coverage for SEFAZ NFC-e HTML with proper accents and HTML entities
- decodes named and numeric HTML entities before extracting receipt fields
- adds integration coverage for submitting a SEFAZ NFC-e URL into the manual receipt queue

## Validation
- backend: npm test
- backend: npm run lint
- backend: npm run build