### PR TITLE
Harden homolog production runtime

### DIFF
--- a/.github/workflows/deploy-homolog-server.yml
+++ b/.github/workflows/deploy-homolog-server.yml
@@ -71,7 +71,7 @@ jobs:
       VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL || 'https://apipricely.grmeireles.dev' }}
       VITE_ALLOWED_HOSTS: ${{ vars.VITE_ALLOWED_HOSTS || 'pricely.grmeireles.dev' }}
       VITE_ALLOW_ALL_HOSTS: ${{ vars.VITE_ALLOW_ALL_HOSTS || 'true' }}
-      NODE_ENV: ${{ vars.NODE_ENV || 'development' }}
+      NODE_ENV: ${{ vars.NODE_ENV || 'production' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -224,14 +224,14 @@ jobs:
           docker compose --env-file .env up -d --force-recreate backend web
           docker compose --env-file .env ps
 
-          echo "Waiting for web preview..."
+          echo "Waiting for web production server..."
           for attempt in $(seq 1 30); do
             if docker compose --env-file .env exec -T web sh -lc \
-              "test -f dist/index.html && node -e \"fetch('http://127.0.0.1:5173').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))\"" </dev/null; then
+              "test -f /usr/share/nginx/html/index.html && wget -qO- http://127.0.0.1:5173 >/dev/null" </dev/null; then
               break
             fi
             if [ "$attempt" -eq 30 ]; then
-              echo "Web preview did not become ready"
+              echo "Web production server did not become ready"
               docker compose --env-file .env logs --tail=120 web
               exit 1
             fi
@@ -239,7 +239,7 @@ jobs:
           done
 
           docker compose --env-file .env exec -T web sh -lc \
-            "printenv | sort | grep -E '^(VITE_|NODE_ENV)'; sed -n '1,20p' dist/index.html" </dev/null
+            "printenv | sort | grep -E '^(VITE_|NODE_ENV)'; sed -n '1,20p' /usr/share/nginx/html/index.html" </dev/null
           docker image prune -f
           ENDSSH
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,8 @@ COPY prisma.config.ts ./
 RUN npm install
 
 COPY . .
+RUN npm run build
 
 EXPOSE 3000
 
-CMD ["npm", "run", "start:dev"]
+CMD ["npm", "run", "start"]

--- a/docker-compose.homolog.yml
+++ b/docker-compose.homolog.yml
@@ -66,7 +66,7 @@ services:
     environment:
       PORT: 3000
       APP_HOST: 0.0.0.0
-      NODE_ENV: ${NODE_ENV:-development}
+      NODE_ENV: ${NODE_ENV:-production}
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pricely}
       REDIS_HOST: redis
       REDIS_PORT: 6379
@@ -76,7 +76,7 @@ services:
       [
         "sh",
         "-lc",
-        "npm run db:generate && npm run db:push && npm run start:dev",
+        "npm run db:generate && npm run db:push && npm run start",
       ]
     ports:
       - "${BACKEND_PORT:-3000}:3000"
@@ -94,17 +94,11 @@ services:
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:3000}
       VITE_ALLOWED_HOSTS: ${VITE_ALLOWED_HOSTS:-pricely.grmeireles.dev}
       VITE_ALLOW_ALL_HOSTS: ${VITE_ALLOW_ALL_HOSTS:-true}
-    command:
-      [
-        "sh",
-        "-lc",
-        "npm run build && npm run preview -- --host 0.0.0.0 --port 5173",
-      ]
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "node -e \"fetch('http://127.0.0.1:5173').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))\"",
+          "wget -qO- http://127.0.0.1:5173 >/dev/null || exit 1",
         ]
       interval: 10s
       timeout: 5s

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,12 +1,21 @@
-FROM node:22-bookworm-slim
+FROM node:22-bookworm-slim AS build
 
 WORKDIR /app
+
+ARG VITE_API_BASE_URL=https://apipricely.grmeireles.dev
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 
 COPY package*.json ./
 RUN npm install
 
 COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
 
 EXPOSE 5173
 
-CMD ["sh", "-lc", "npm run build && npm run preview -- --host 0.0.0.0 --port 5173"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,17 @@
+server {
+  listen 5173;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location /assets/ {
+    try_files $uri =404;
+    access_log off;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+}


### PR DESCRIPTION
## Summary
- builds backend before image runtime and starts compiled dist instead of ts-node dev mode
- serves web dist through nginx with SPA fallback instead of runtime Vite preview/build
- updates homolog compose and deploy health checks for production runtime

## Validation
- docker build -t pricely-backend-runtime-test ./backend
- docker build -t pricely-web-runtime-test ./web
- docker run web image and request /dashboard/usuarios with no Vite dev assets