### PR TITLE
Harden receipt store candidates

### DIFF
--- a/backend/src/common/contracts/receipt.contract.ts
+++ b/backend/src/common/contracts/receipt.contract.ts
@@ -12,6 +12,11 @@ export interface ReceiptLineItemInput {
 export interface ReceiptIngestionRequest {
   storeName?: string;
   storeCnpj?: string;
+  storeAddressLine?: string;
+  storeNeighborhood?: string;
+  storePostalCode?: string;
+  storeCityName?: string;
+  storeStateCode?: string;
   purchaseDate?: string;
   sourceType?:
     | 'manual_entry'
@@ -31,6 +36,11 @@ export interface ReceiptRecord {
   storeId?: string;
   storeName?: string;
   storeCnpj?: string;
+  storeAddressLine?: string;
+  storeNeighborhood?: string;
+  storePostalCode?: string;
+  storeCityName?: string;
+  storeStateCode?: string;
   accessKey?: string;
   sefazUrl?: string;
   purchaseDate?: string;

--- a/backend/src/receipts/api/dto/receipt-ingestion.dto.ts
+++ b/backend/src/receipts/api/dto/receipt-ingestion.dto.ts
@@ -74,6 +74,26 @@ export class ReceiptIngestionDto implements ReceiptIngestionRequest {
 
   @IsOptional()
   @IsString()
+  storeAddressLine?: string;
+
+  @IsOptional()
+  @IsString()
+  storeNeighborhood?: string;
+
+  @IsOptional()
+  @IsString()
+  storePostalCode?: string;
+
+  @IsOptional()
+  @IsString()
+  storeCityName?: string;
+
+  @IsOptional()
+  @IsString()
+  storeStateCode?: string;
+
+  @IsOptional()
+  @IsString()
   purchaseDate?: string;
 
   @IsOptional()

--- a/backend/src/receipts/application/receipt-ingestion.service.ts
+++ b/backend/src/receipts/application/receipt-ingestion.service.ts
@@ -59,6 +59,16 @@ export class ReceiptIngestionService {
       ...sanitizedRequest,
       storeName: sanitizedRequest.storeName ?? sefazExtraction.storeName,
       storeCnpj: sanitizedRequest.storeCnpj ?? sefazExtraction.storeCnpj,
+      storeAddressLine:
+        sanitizedRequest.storeAddressLine ?? sefazExtraction.storeAddressLine,
+      storeNeighborhood:
+        sanitizedRequest.storeNeighborhood ?? sefazExtraction.storeNeighborhood,
+      storePostalCode:
+        sanitizedRequest.storePostalCode ?? sefazExtraction.storePostalCode,
+      storeCityName:
+        sanitizedRequest.storeCityName ?? sefazExtraction.storeCityName,
+      storeStateCode:
+        sanitizedRequest.storeStateCode ?? sefazExtraction.storeStateCode,
       purchaseDate:
         sanitizedRequest.purchaseDate ?? sefazExtraction.purchaseDate,
       accessKey: sanitizedRequest.accessKey ?? qrCodeData.accessKey,
@@ -104,6 +114,11 @@ export class ReceiptIngestionService {
       storeId,
       storeName: parsedReceipt.storeName,
       storeCnpj: parsedReceipt.storeCnpj,
+      storeAddressLine: parsedReceipt.storeAddressLine,
+      storeNeighborhood: parsedReceipt.storeNeighborhood,
+      storePostalCode: parsedReceipt.storePostalCode,
+      storeCityName: parsedReceipt.storeCityName,
+      storeStateCode: parsedReceipt.storeStateCode,
       accessKey: parsedReceipt.accessKey,
       sefazUrl: parsedReceipt.sefazUrl,
       purchaseDate: parsedReceipt.purchaseDate,
@@ -136,7 +151,8 @@ export class ReceiptIngestionService {
       processingLogs: [...record.processingLogs, ...assessment.logs],
     };
 
-    await this.receiptRecordRepository.create(assessedRecord);
+    const persistedRecord =
+      await this.receiptRecordRepository.create(assessedRecord);
     const processingJob = this.isAutomaticReceiptProcessingEnabled()
       ? await this.enqueueReceiptProcessing(receiptRecordId)
       : null;
@@ -146,20 +162,25 @@ export class ReceiptIngestionService {
     );
 
     return {
-      id: assessedRecord.id,
-      storeId: assessedRecord.storeId,
-      storeName: assessedRecord.storeName,
-      storeCnpj: assessedRecord.storeCnpj,
-      accessKey: assessedRecord.accessKey,
-      sefazUrl: assessedRecord.sefazUrl,
-      purchaseDate: assessedRecord.purchaseDate,
-      parseStatus: assessedRecord.parseStatus,
-      confidenceScore: assessedRecord.confidenceScore,
-      trustLevel: assessedRecord.trustLevel,
-      moderationStatus: assessedRecord.moderationStatus,
-      rewardEligibilityStatus: assessedRecord.rewardEligibilityStatus,
-      ...this.projectReward(assessedRecord.rewardEligibilityStatus),
-      reviewReason: assessedRecord.reviewReason,
+      id: persistedRecord.id,
+      storeId: persistedRecord.storeId,
+      storeName: persistedRecord.storeName,
+      storeCnpj: persistedRecord.storeCnpj,
+      storeAddressLine: persistedRecord.storeAddressLine,
+      storeNeighborhood: persistedRecord.storeNeighborhood,
+      storePostalCode: persistedRecord.storePostalCode,
+      storeCityName: persistedRecord.storeCityName,
+      storeStateCode: persistedRecord.storeStateCode,
+      accessKey: persistedRecord.accessKey,
+      sefazUrl: persistedRecord.sefazUrl,
+      purchaseDate: persistedRecord.purchaseDate,
+      parseStatus: persistedRecord.parseStatus,
+      confidenceScore: persistedRecord.confidenceScore,
+      trustLevel: persistedRecord.trustLevel,
+      moderationStatus: persistedRecord.moderationStatus,
+      rewardEligibilityStatus: persistedRecord.rewardEligibilityStatus,
+      ...this.projectReward(persistedRecord.rewardEligibilityStatus),
+      reviewReason: persistedRecord.reviewReason,
       jobId: processingJob?.id,
       processingStatus: processingJob ? 'queued' : 'waiting_manual_release',
       dataNotice:
@@ -279,6 +300,11 @@ export class ReceiptIngestionService {
       storeId: record.storeId,
       storeName: record.storeName,
       storeCnpj: record.storeCnpj,
+      storeAddressLine: record.storeAddressLine,
+      storeNeighborhood: record.storeNeighborhood,
+      storePostalCode: record.storePostalCode,
+      storeCityName: record.storeCityName,
+      storeStateCode: record.storeStateCode,
       accessKey: record.accessKey,
       sefazUrl: record.sefazUrl,
       purchaseDate: record.purchaseDate,
@@ -444,6 +470,7 @@ export class ReceiptIngestionService {
       this.matchText(text, /Nota Fiscal de Consumidor Eletrônica \(NFC-e\)\s+(.+?)\s+CNPJ:/i) ??
       this.matchText(text, /Emitente\s+Nome \/ Razão Social\s+CNPJ\s+Inscrição Estadual\s+UF\s+(.+?)\s+\d{14}/i);
     const storeCnpj = this.matchText(text, /CNPJ:\s*(\d{14})/i);
+    const storeAddress = this.parseStoreAddress(text);
     const purchaseDate = this.parseBrazilianDate(
       this.matchText(text, /Data Emissão\s+(\d{2}\/\d{2}\/\d{4}\s+\d{2}:\d{2}:\d{2})/i),
     );
@@ -472,8 +499,46 @@ export class ReceiptIngestionService {
     return {
       storeName,
       storeCnpj,
+      storeAddressLine: storeAddress?.addressLine,
+      storeNeighborhood: storeAddress?.neighborhood,
+      storePostalCode: storeAddress?.postalCode,
+      storeCityName: storeAddress?.cityName,
+      storeStateCode: storeAddress?.stateCode,
       purchaseDate,
       items: items.length > 0 ? items : undefined,
+    };
+  }
+
+  private parseStoreAddress(text: string):
+    | {
+        addressLine: string;
+        neighborhood: string;
+        postalCode: string;
+        cityName: string;
+        stateCode: string;
+      }
+    | undefined {
+    const match = text.match(
+      /\b([A-ZÀ-Ú0-9 .'/-]+,\s*\d+[A-ZÀ-Ú0-9 .'/-]*,\s*[^,]+,\s*\d{5,8}\s*-\s*[^,]+,\s*[A-Z]{2})\b/i,
+    );
+    const address = match?.[1]
+      ?.replace(/\s+/g, ' ')
+      .replace(/^\d{9,}\s+/, '')
+      .trim();
+    const addressMatch = address?.match(
+      /^(.+?),\s*([^,]+),\s*([^,]+),\s*(\d{5,8})\s*-\s*(.+?),\s*([A-Z]{2})$/i,
+    );
+
+    if (!addressMatch) {
+      return undefined;
+    }
+
+    return {
+      addressLine: `${addressMatch[1].trim()}, ${addressMatch[2].trim()}`,
+      neighborhood: addressMatch[3].trim(),
+      postalCode: addressMatch[4].replace(/\D/g, ''),
+      cityName: addressMatch[5].trim(),
+      stateCode: addressMatch[6].toUpperCase(),
     };
   }
 

--- a/backend/src/receipts/application/receipt-parser.service.ts
+++ b/backend/src/receipts/application/receipt-parser.service.ts
@@ -23,6 +23,11 @@ export interface ParsedReceiptLineItem {
 export interface ParsedReceipt {
   storeName?: string;
   storeCnpj?: string;
+  storeAddressLine?: string;
+  storeNeighborhood?: string;
+  storePostalCode?: string;
+  storeCityName?: string;
+  storeStateCode?: string;
   accessKey?: string;
   sefazUrl?: string;
   purchaseDate?: string;
@@ -56,6 +61,11 @@ export class ReceiptParserService {
     return {
       storeName,
       storeCnpj: request.storeCnpj,
+      storeAddressLine: request.storeAddressLine,
+      storeNeighborhood: request.storeNeighborhood,
+      storePostalCode: request.storePostalCode,
+      storeCityName: request.storeCityName,
+      storeStateCode: request.storeStateCode,
       accessKey: request.accessKey,
       sefazUrl: request.qrCodeUrl,
       purchaseDate: request.purchaseDate,

--- a/backend/src/receipts/application/receipt-sanitizer.service.ts
+++ b/backend/src/receipts/application/receipt-sanitizer.service.ts
@@ -16,6 +16,11 @@ export class ReceiptSanitizerService {
       ...request,
       storeName: this.cleanText(request.storeName),
       storeCnpj: this.cleanCnpj(request.storeCnpj),
+      storeAddressLine: this.cleanText(request.storeAddressLine),
+      storeNeighborhood: this.cleanText(request.storeNeighborhood),
+      storePostalCode: this.cleanPostalCode(request.storePostalCode),
+      storeCityName: this.cleanText(request.storeCityName),
+      storeStateCode: this.cleanStateCode(request.storeStateCode),
       qrCodeUrl: this.cleanUrl(request.qrCodeUrl),
       accessKey: this.cleanAccessKey(request.accessKey),
       uploadedFile: request.uploadedFile
@@ -50,6 +55,20 @@ export class ReceiptSanitizerService {
     const digits = value?.replace(/\D/g, '');
 
     return digits?.length === 44 ? digits : undefined;
+  }
+
+  cleanPostalCode(value?: string): string | undefined {
+    const digits = value?.replace(/\D/g, '');
+
+    return digits && digits.length >= 5 && digits.length <= 8
+      ? digits
+      : undefined;
+  }
+
+  cleanStateCode(value?: string): string | undefined {
+    const stateCode = value?.replace(/[^a-z]/gi, '').toUpperCase();
+
+    return stateCode?.length === 2 ? stateCode : undefined;
   }
 
   cleanUrl(value?: string): string | undefined {

--- a/backend/src/receipts/domain/receipt-record.entity.ts
+++ b/backend/src/receipts/domain/receipt-record.entity.ts
@@ -6,6 +6,11 @@ export interface ReceiptRecordEntity {
   storeId?: string;
   storeName?: string;
   storeCnpj?: string;
+  storeAddressLine?: string;
+  storeNeighborhood?: string;
+  storePostalCode?: string;
+  storeCityName?: string;
+  storeStateCode?: string;
   accessKey?: string;
   sefazUrl?: string;
   purchaseDate?: string;

--- a/backend/src/receipts/infrastructure/receipt-record.repository.ts
+++ b/backend/src/receipts/infrastructure/receipt-record.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../persistence/prisma.service';
+import { toSlug } from '../../common/utils/slug.util';
 import { type ReceiptRecordEntity } from '../domain/receipt-record.entity';
 
 @Injectable()
@@ -7,7 +8,13 @@ export class ReceiptRecordRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(record: ReceiptRecordEntity): Promise<ReceiptRecordEntity> {
-    const establishment = await this.findKnownEstablishment(record);
+    const establishment = await this.findOrCreateEstablishmentCandidate(record);
+    const processingLogs = [
+      ...record.processingLogs,
+      ...(establishment && establishment.id !== record.storeId
+        ? [`store_candidate_linked:${establishment.id}`]
+        : []),
+    ];
 
     await this.prisma.receiptRecord.create({
       data: {
@@ -25,7 +32,7 @@ export class ReceiptRecordRepository {
           : null,
         rawReference: JSON.stringify({
           rawSourceReference: record.rawSourceReference,
-          processingLogs: record.processingLogs,
+          processingLogs,
         }),
         confidenceScore: record.confidenceScore,
         duplicateKey: record.duplicateKey,
@@ -54,7 +61,11 @@ export class ReceiptRecordRepository {
       },
     });
 
-    return record;
+    return {
+      ...record,
+      storeId: establishment?.id ?? record.storeId,
+      processingLogs,
+    };
   }
 
   async attachProcessingJob(
@@ -236,6 +247,59 @@ export class ReceiptRecordRepository {
     return this.prisma.establishment.findFirst({
       where: {
         unitName: record.storeName,
+      },
+    });
+  }
+
+  private async findOrCreateEstablishmentCandidate(record: ReceiptRecordEntity) {
+    const knownEstablishment = await this.findKnownEstablishment(record);
+
+    if (knownEstablishment) {
+      return knownEstablishment;
+    }
+
+    if (
+      !record.storeCnpj ||
+      !record.storeName ||
+      !record.storeCityName ||
+      !record.storeStateCode
+    ) {
+      return null;
+    }
+
+    const regionSlug = `${toSlug(record.storeCityName)}-${record.storeStateCode.toLowerCase()}`;
+    const region = await this.prisma.region.findFirst({
+      where: {
+        OR: [
+          { slug: regionSlug },
+          {
+            name: record.storeCityName,
+            stateCode: record.storeStateCode,
+          },
+        ],
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+
+    if (!region) {
+      return null;
+    }
+
+    return this.prisma.establishment.create({
+      data: {
+        brandName: record.storeName,
+        unitName: record.storeName,
+        cnpj: this.formatCnpj(record.storeCnpj),
+        cityName: region.name,
+        neighborhood: record.storeNeighborhood ?? 'A revisar',
+        addressLine: record.storeAddressLine,
+        postalCode: record.storePostalCode,
+        locationSource: 'receipt_candidate',
+        regionId: region.id,
+        isActive: false,
       },
     });
   }

--- a/backend/test/integration/receipts/receipt-ingestion.integration.spec.ts
+++ b/backend/test/integration/receipts/receipt-ingestion.integration.spec.ts
@@ -73,6 +73,7 @@ describe('Receipt ingestion integration', () => {
             <body>
               Nota Fiscal de Consumidor Eletr&ocirc;nica (NFC-e) SUPERMERCADO ENTITY LTDA
               CNPJ: 04641376024400 -, Inscri&ccedil;&atilde;o Estadual: 0032546124242
+              AV. LEITE DE CASTRO, 261, FABRICAS, 3162500 - SAO JOAO DEL REI, MG
               Data Emiss&#227;o 15/05/2026 20:36:48
               <table>
                 <tr><td><h7>REFR C COLA S/AC 200</h7> (C&oacute;digo: 1462210)</td><td>Qtde total de &iacute;tens: 3.000</td><td>UN: FR</td><td>Valor total R$: R$ 5,94</td></tr>
@@ -108,6 +109,11 @@ describe('Receipt ingestion integration', () => {
       expect(response.body).toMatchObject({
         storeName: 'SUPERMERCADO ENTITY LTDA',
         storeCnpj: '04641376024400',
+        storeAddressLine: 'AV. LEITE DE CASTRO, 261',
+        storeNeighborhood: 'FABRICAS',
+        storePostalCode: '3162500',
+        storeCityName: 'SAO JOAO DEL REI',
+        storeStateCode: 'MG',
         accessKey: '31260504641376024400650100002111701459668768',
         parseStatus: 'parsed',
         processingStatus: 'waiting_manual_release',

--- a/backend/test/unit/receipts/receipt-ingestion-sefaz.spec.ts
+++ b/backend/test/unit/receipts/receipt-ingestion-sefaz.spec.ts
@@ -24,6 +24,11 @@ describe('ReceiptIngestionService SEFAZ HTML extraction', () => {
       parseSefazHtml(html: string): {
         storeName?: string;
         storeCnpj?: string;
+        storeAddressLine?: string;
+        storeNeighborhood?: string;
+        storePostalCode?: string;
+        storeCityName?: string;
+        storeStateCode?: string;
         purchaseDate?: string;
         items?: Array<{
           rawProductName: string;
@@ -54,6 +59,11 @@ describe('ReceiptIngestionService SEFAZ HTML extraction', () => {
       expect.objectContaining({
         storeName: 'SUPERMERCADO TESTE LTDA',
         storeCnpj: '04641376024400',
+        storeAddressLine: 'AV. LEITE DE CASTRO, 261',
+        storeNeighborhood: 'FABRICAS',
+        storePostalCode: '3162500',
+        storeCityName: 'SAO JOAO DEL REI',
+        storeStateCode: 'MG',
         purchaseDate: '2026-05-15T20:36:48-03:00',
         items: [
           expect.objectContaining({
@@ -81,6 +91,11 @@ describe('ReceiptIngestionService SEFAZ HTML extraction', () => {
       parseSefazHtml(html: string): {
         storeName?: string;
         storeCnpj?: string;
+        storeAddressLine?: string;
+        storeNeighborhood?: string;
+        storePostalCode?: string;
+        storeCityName?: string;
+        storeStateCode?: string;
         purchaseDate?: string;
         items?: Array<{
           rawProductName: string;
@@ -111,6 +126,11 @@ describe('ReceiptIngestionService SEFAZ HTML extraction', () => {
       expect.objectContaining({
         storeName: 'SUPERMERCADO SALES LTDA',
         storeCnpj: '04641376024400',
+        storeAddressLine: 'AV. LEITE DE CASTRO, 261',
+        storeNeighborhood: 'FABRICAS',
+        storePostalCode: '3162500',
+        storeCityName: 'SAO JOAO DEL REI',
+        storeStateCode: 'MG',
         purchaseDate: '2026-05-15T20:36:48-03:00',
         items: [
           expect.objectContaining({

--- a/backend/test/unit/receipts/receipt-record.repository.spec.ts
+++ b/backend/test/unit/receipts/receipt-record.repository.spec.ts
@@ -1,0 +1,139 @@
+import { ReceiptRecordRepository } from '../../../src/receipts/infrastructure/receipt-record.repository';
+import { type ReceiptRecordEntity } from '../../../src/receipts/domain/receipt-record.entity';
+
+function buildReceiptRecord(
+  overrides: Partial<ReceiptRecordEntity> = {},
+): ReceiptRecordEntity {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    userId: '22222222-2222-4222-8222-222222222222',
+    storeName: 'SUPERMERCADO TESTE LTDA',
+    storeCnpj: '04641376024400',
+    storeAddressLine: 'AV. LEITE DE CASTRO, 261',
+    storeNeighborhood: 'FABRICAS',
+    storePostalCode: '3162500',
+    storeCityName: 'SAO JOAO DEL REI',
+    storeStateCode: 'MG',
+    sourceType: 'qr_code_url',
+    parseStatus: 'parsed',
+    confidenceScore: 0.95,
+    trustLevel: 'trusted',
+    moderationStatus: 'accepted',
+    rewardEligibilityStatus: 'eligible_pending',
+    processingLogs: ['receipt_received'],
+    lineItems: [
+      {
+        id: '33333333-3333-4333-8333-333333333333',
+        receiptRecordId: '11111111-1111-4111-8111-111111111111',
+        rawProductName: 'CAFE PILAO TRAD 500G',
+        normalizedName: 'cafe pilao trad 500g',
+        quantity: 1,
+        unitPrice: 25.8,
+        originalUnitPrice: 25.8,
+        currency: 'BRL',
+        matchConfidence: 0.9,
+      },
+    ],
+    createdAt: '2026-05-15T23:36:48.000Z',
+    updatedAt: '2026-05-15T23:36:48.000Z',
+    ...overrides,
+  };
+}
+
+describe('ReceiptRecordRepository', () => {
+  it('creates an inactive establishment candidate for a new NFC-e store in an existing region', async () => {
+    const createdEstablishment = {
+      id: '44444444-4444-4444-8444-444444444444',
+      brandName: 'SUPERMERCADO TESTE LTDA',
+      unitName: 'SUPERMERCADO TESTE LTDA',
+      cnpj: '04.641.376/0244-00',
+      cityName: 'Sao Joao Del Rei',
+      neighborhood: 'FABRICAS',
+      regionId: '55555555-5555-4555-8555-555555555555',
+      isActive: false,
+    };
+    const prisma = {
+      establishment: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue(createdEstablishment),
+      },
+      region: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: '55555555-5555-4555-8555-555555555555',
+          name: 'Sao Joao Del Rei',
+        }),
+      },
+      receiptRecord: {
+        create: jest.fn().mockResolvedValue({}),
+      },
+    };
+    const repository = new ReceiptRecordRepository(prisma as never);
+
+    const stored = await repository.create(buildReceiptRecord());
+
+    expect(prisma.region.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { slug: 'sao-joao-del-rei-mg' },
+          { name: 'SAO JOAO DEL REI', stateCode: 'MG' },
+        ],
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+    expect(prisma.establishment.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        brandName: 'SUPERMERCADO TESTE LTDA',
+        unitName: 'SUPERMERCADO TESTE LTDA',
+        cnpj: '04.641.376/0244-00',
+        cityName: 'Sao Joao Del Rei',
+        neighborhood: 'FABRICAS',
+        addressLine: 'AV. LEITE DE CASTRO, 261',
+        postalCode: '3162500',
+        locationSource: 'receipt_candidate',
+        regionId: '55555555-5555-4555-8555-555555555555',
+        isActive: false,
+      }),
+    });
+    expect(prisma.receiptRecord.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        establishmentId: '44444444-4444-4444-8444-444444444444',
+      }),
+    });
+    expect(stored).toMatchObject({
+      storeId: '44444444-4444-4444-8444-444444444444',
+      processingLogs: [
+        'receipt_received',
+        'store_candidate_linked:44444444-4444-4444-8444-444444444444',
+      ],
+    });
+  });
+
+  it('does not create a city or establishment when the NFC-e city is not administered yet', async () => {
+    const prisma = {
+      establishment: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn(),
+      },
+      region: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+      receiptRecord: {
+        create: jest.fn().mockResolvedValue({}),
+      },
+    };
+    const repository = new ReceiptRecordRepository(prisma as never);
+
+    const stored = await repository.create(buildReceiptRecord());
+
+    expect(prisma.establishment.create).not.toHaveBeenCalled();
+    expect(prisma.receiptRecord.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        establishmentId: null,
+      }),
+    });
+    expect(stored.storeId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- extract NFC-e store address/city metadata from SEFAZ HTML
- create inactive establishment candidates when a receipt store CNPJ belongs to an already administered region
- add TDD coverage for parser extraction, repository candidate creation, and receipt ingestion response fields

## Validation
- npm test -- --runTestsByPath test/unit/receipts/receipt-ingestion-sefaz.spec.ts test/unit/receipts/receipt-record.repository.spec.ts
- npm test -- --runTestsByPath test/integration/receipts/receipt-ingestion.integration.spec.ts
- npm run lint
- npm run build
- npm test