### PR TITLE
Add refresh cookie sessions

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -191,7 +191,22 @@ model UserAccount {
   entitlements            UserEntitlement[]
   optimizationTokenLedger OptimizationTokenLedgerEntry[]
   locationPreferences     UserLocationPreference[]
+  sessions                UserSession[]
   preferredRegion         Region?                        @relation("UserPreferredRegion", fields: [preferredRegionId], references: [id], onDelete: SetNull)
+}
+
+model UserSession {
+  id               String      @id @default(uuid()) @db.Uuid
+  userId           String      @db.Uuid
+  refreshTokenHash String      @unique
+  expiresAt        DateTime
+  revokedAt        DateTime?
+  createdAt        DateTime    @default(now())
+  updatedAt        DateTime    @updatedAt
+  user             UserAccount @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, revokedAt])
+  @@index([expiresAt])
 }
 
 model Region {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -6,8 +6,11 @@ import {
   HttpStatus,
   Patch,
   Post,
+  Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
+import { type Request, type Response } from 'express';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
@@ -21,14 +24,43 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('register')
-  async register(@Body() body: RegisterDto) {
-    return this.authService.register(body);
+  async register(
+    @Body() body: RegisterDto,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    return this.respondWithSession(await this.authService.register(body), response);
   }
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
-  async login(@Body() body: LoginDto) {
-    return this.authService.login(body);
+  async login(
+    @Body() body: LoginDto,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    return this.respondWithSession(await this.authService.login(body), response);
+  }
+
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  async refresh(
+    @Req() request: Request,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    return this.respondWithSession(
+      await this.authService.refresh(this.readRefreshCookie(request)),
+      response,
+    );
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.OK)
+  async logout(
+    @Req() request: Request,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    const result = await this.authService.logout(this.readRefreshCookie(request));
+    this.clearRefreshCookie(response);
+    return result;
   }
 
   @Get('me')
@@ -44,5 +76,48 @@ export class AuthController {
     @Body() body: UpdatePreferredRegionDto,
   ) {
     return this.authService.updatePreferredRegion(user.sub, body.regionSlug);
+  }
+
+  private respondWithSession(
+    session: Awaited<ReturnType<AuthService['login']>>,
+    response: Response,
+  ) {
+    this.setRefreshCookie(response, session.refreshToken);
+    const { refreshToken: _refreshToken, ...publicSession } = session;
+    return publicSession;
+  }
+
+  private readRefreshCookie(request: Request): string | undefined {
+    const cookieHeader = request.headers.cookie;
+    if (!cookieHeader) {
+      return undefined;
+    }
+
+    return cookieHeader
+      .split(';')
+      .map((cookie) => cookie.trim())
+      .find((cookie) => cookie.startsWith('pricely_refresh='))
+      ?.split('=')
+      .slice(1)
+      .join('=');
+  }
+
+  private setRefreshCookie(response: Response, refreshToken: string) {
+    response.cookie('pricely_refresh', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/auth',
+      maxAge: 30 * 24 * 60 * 60 * 1000,
+    });
+  }
+
+  private clearRefreshCookie(response: Response) {
+    response.clearCookie('pricely_refresh', {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/auth',
+    });
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -19,7 +19,7 @@ function resolveJwtSecret(): string {
       useFactory: async () => ({
         secret: resolveJwtSecret(),
         signOptions: {
-          expiresIn: '7d',
+          expiresIn: Number(process.env.JWT_ACCESS_EXPIRES_IN_SECONDS ?? 900),
         },
       }),
     }),

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -5,10 +5,15 @@ import {
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { compare, hash } from 'bcryptjs';
+import { createHash, randomBytes } from 'crypto';
 import { type JwtUserPayload } from './auth.types';
 import { UsersService } from '../users/users.service';
 import { type LoginDto } from './dto/login.dto';
 import { type RegisterDto } from './dto/register.dto';
+import { PrismaService } from '../persistence/prisma.service';
+
+const ACCESS_TOKEN_EXPIRES_IN_SECONDS = 15 * 60;
+const REFRESH_TOKEN_EXPIRES_IN_DAYS = 30;
 
 @Injectable()
 export class AuthService {
@@ -17,6 +22,7 @@ export class AuthService {
   constructor(
     private readonly usersService: UsersService,
     private readonly jwtService: JwtService,
+    private readonly prisma: PrismaService,
   ) {}
 
   async register(input: RegisterDto) {
@@ -52,6 +58,61 @@ export class AuthService {
     return this.buildSession(updatedUser);
   }
 
+  async refresh(refreshToken?: string) {
+    if (!refreshToken) {
+      throw new UnauthorizedException('Refresh session is required');
+    }
+
+    const tokenHash = this.hashRefreshToken(refreshToken);
+    const session = await this.prisma.userSession.findUnique({
+      where: {
+        refreshTokenHash: tokenHash,
+      },
+      include: {
+        user: true,
+      },
+    });
+
+    if (
+      !session ||
+      session.revokedAt ||
+      session.expiresAt.getTime() <= Date.now() ||
+      session.user.status !== 'active'
+    ) {
+      throw new UnauthorizedException('Refresh session is no longer valid');
+    }
+
+    await this.prisma.userSession.update({
+      where: {
+        id: session.id,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
+
+    this.logger.log(`Rotated refresh session ${session.id} for user ${session.userId}`);
+    return this.buildSession(session.user);
+  }
+
+  async logout(refreshToken?: string) {
+    if (!refreshToken) {
+      return { status: 'ok' };
+    }
+
+    await this.prisma.userSession.updateMany({
+      where: {
+        refreshTokenHash: this.hashRefreshToken(refreshToken),
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
+
+    return { status: 'ok' };
+  }
+
   async getCurrentUser(userId: string) {
     return this.usersService.getProfileById(userId);
   }
@@ -78,9 +139,36 @@ export class AuthService {
       role: user.role,
     };
 
+    const refreshToken = this.createRefreshToken();
+    await this.prisma.userSession.create({
+      data: {
+        userId: user.id,
+        refreshTokenHash: this.hashRefreshToken(refreshToken),
+        expiresAt: this.refreshTokenExpiresAt(),
+      },
+    });
+
     return {
-      accessToken: await this.jwtService.signAsync(payload),
+      accessToken: await this.jwtService.signAsync(payload, {
+        expiresIn: ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+      }),
+      accessTokenExpiresInSeconds: ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+      refreshToken,
       user: await this.usersService.getProfileById(user.id),
     };
+  }
+
+  private createRefreshToken(): string {
+    return randomBytes(48).toString('base64url');
+  }
+
+  private hashRefreshToken(refreshToken: string): string {
+    return createHash('sha256').update(refreshToken).digest('hex');
+  }
+
+  private refreshTokenExpiresAt(): Date {
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + REFRESH_TOKEN_EXPIRES_IN_DAYS);
+    return expiresAt;
   }
 }

--- a/backend/src/common/contracts/auth.contract.ts
+++ b/backend/src/common/contracts/auth.contract.ts
@@ -32,5 +32,6 @@ export interface AuthenticatedUserProfile {
 
 export interface AuthSessionContract {
   accessToken: string;
+  accessTokenExpiresInSeconds: number;
   user: AuthenticatedUserProfile;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -55,7 +55,7 @@ async function bootstrap(): Promise<void> {
     origin: getCorsOrigins(),
     methods: ['GET', 'POST', 'PATCH', 'PUT', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
-    credentials: false,
+    credentials: true,
   });
 
   app.useLogger(app.get(Logger));

--- a/backend/test/integration/admin/admin-dashboard.integration.spec.ts
+++ b/backend/test/integration/admin/admin-dashboard.integration.spec.ts
@@ -27,6 +27,7 @@ type StoredUser = {
 
 class AdminPrismaMock {
   private readonly users = new Map<string, StoredUser>();
+  private readonly sessions = new Map<string, any>();
   private readonly regions = [
     {
       id: 'region-1',
@@ -102,6 +103,43 @@ class AdminPrismaMock {
         amount: 2,
       },
     }),
+  };
+
+  readonly userSession = {
+    create: async ({ data }: { data: any }) => {
+      const session = {
+        id: crypto.randomUUID(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        revokedAt: null,
+        ...data,
+      };
+      this.sessions.set(session.id, session);
+      return structuredClone(session);
+    },
+    findUnique: async ({ where }: { where: any }) => {
+      const session =
+        [...this.sessions.values()].find(
+          (entry) => entry.refreshTokenHash === where.refreshTokenHash,
+        ) ?? null;
+      if (!session) {
+        return null;
+      }
+      return {
+        ...structuredClone(session),
+        user: this.users.get(session.userId) ?? null,
+      };
+    },
+    update: async ({ where, data }: { where: any; data: any }) => {
+      const session = this.sessions.get(where.id);
+      if (!session) {
+        throw new Error(`Session ${where.id} not found`);
+      }
+      const updated = { ...session, ...data, updatedAt: new Date() };
+      this.sessions.set(updated.id, updated);
+      return structuredClone(updated);
+    },
+    updateMany: async () => ({ count: 0 }),
   };
 
   readonly shoppingList = {

--- a/backend/test/integration/admin/admin-processing.integration.spec.ts
+++ b/backend/test/integration/admin/admin-processing.integration.spec.ts
@@ -14,6 +14,7 @@ import { AppValidationPipe } from '../../../src/common/validation/validation.pip
 import { PrismaService } from '../../../src/persistence/prisma.service';
 
 class AdminProcessingPrismaMock {
+  private readonly sessions = new Map<string, any>();
   private readonly adminUser = {
     id: 'admin-1',
     email: 'admin@pricely.local',
@@ -80,6 +81,42 @@ class AdminProcessingPrismaMock {
         amount: 2,
       },
     }),
+  };
+
+  readonly userSession = {
+    create: async ({ data }: { data: any }) => {
+      const session = {
+        id: crypto.randomUUID(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        revokedAt: null,
+        ...data,
+      };
+      this.sessions.set(session.id, session);
+      return structuredClone(session);
+    },
+    findUnique: async ({ where }: { where: any }) => {
+      const session =
+        [...this.sessions.values()].find(
+          (entry) => entry.refreshTokenHash === where.refreshTokenHash,
+        ) ?? null;
+      return session
+        ? {
+            ...structuredClone(session),
+            user: this.adminUser,
+          }
+        : null;
+    },
+    update: async ({ where, data }: { where: any; data: any }) => {
+      const session = this.sessions.get(where.id);
+      if (!session) {
+        throw new Error(`Session ${where.id} not found`);
+      }
+      const updated = { ...session, ...data, updatedAt: new Date() };
+      this.sessions.set(updated.id, updated);
+      return structuredClone(updated);
+    },
+    updateMany: async () => ({ count: 0 }),
   };
 
   readonly shoppingList = { count: async () => 2 };

--- a/backend/test/integration/auth/shared-auth.integration.spec.ts
+++ b/backend/test/integration/auth/shared-auth.integration.spec.ts
@@ -27,6 +27,7 @@ type StoredUser = {
 
 class PrismaUserAccountMock {
   private readonly users = new Map<string, StoredUser>();
+  private readonly sessions = new Map<string, any>();
 
   seed(user: StoredUser): void {
     this.users.set(user.id, structuredClone(user));
@@ -153,6 +154,59 @@ class PrismaUserAccountMock {
       },
     }),
   };
+
+  readonly userSession = {
+    create: jest.fn().mockImplementation(async ({ data }: { data: any }) => {
+      const session = {
+        id: crypto.randomUUID(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        revokedAt: null,
+        ...data,
+      };
+      this.sessions.set(session.id, session);
+      return structuredClone(session);
+    }),
+    findUnique: jest.fn().mockImplementation(async ({ where }: { where: any }) => {
+      const session =
+        [...this.sessions.values()].find(
+          (entry) => entry.refreshTokenHash === where.refreshTokenHash,
+        ) ?? null;
+      if (!session) {
+        return null;
+      }
+      return {
+        ...structuredClone(session),
+        user: this.clone(this.users.get(session.userId) ?? null),
+      };
+    }),
+    update: jest.fn().mockImplementation(async ({ where, data }: { where: any; data: any }) => {
+      const session = this.sessions.get(where.id);
+      if (!session) {
+        throw new Error(`Session ${where.id} not found`);
+      }
+      const updated = {
+        ...session,
+        ...data,
+        updatedAt: new Date(),
+      };
+      this.sessions.set(updated.id, updated);
+      return structuredClone(updated);
+    }),
+    updateMany: jest.fn().mockImplementation(async ({ where, data }: { where: any; data: any }) => {
+      let count = 0;
+      for (const [id, session] of this.sessions.entries()) {
+        if (
+          session.refreshTokenHash === where.refreshTokenHash &&
+          (where.revokedAt === undefined || session.revokedAt === where.revokedAt)
+        ) {
+          this.sessions.set(id, { ...session, ...data, updatedAt: new Date() });
+          count += 1;
+        }
+      }
+      return { count };
+    }),
+  };
 }
 
 describe('Shared auth integration', () => {
@@ -174,6 +228,7 @@ describe('Shared auth integration', () => {
         receiptRecord: userAccountMock.receiptRecord,
         region: userAccountMock.region,
         userEntitlement: userAccountMock.userEntitlement,
+        userSession: userAccountMock.userSession,
         optimizationTokenLedgerEntry:
           userAccountMock.optimizationTokenLedgerEntry,
         $queryRaw: userAccountMock.$queryRaw,
@@ -207,6 +262,7 @@ describe('Shared auth integration', () => {
     expect(response.body).toEqual(
       expect.objectContaining({
         accessToken: expect.any(String),
+        accessTokenExpiresInSeconds: 900,
         user: expect.objectContaining({
           email: 'cliente@pricely.local',
           role: 'customer',
@@ -221,6 +277,60 @@ describe('Shared auth integration', () => {
         }),
       }),
     );
+    expect(response.body.refreshToken).toBeUndefined();
+    expect(response.headers['set-cookie']?.join(';')).toContain(
+      'pricely_refresh=',
+    );
+  });
+
+  it('refreshes access tokens through an httpOnly cookie and clears it on logout', async () => {
+    const registerResponse = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: 'refresh-user@pricely.local',
+        password: 'strong-password',
+        displayName: 'Refresh User',
+      })
+      .expect(201);
+    const cookie = registerResponse.headers['set-cookie'];
+
+    const refreshResponse = await request(app.getHttpServer())
+      .post('/auth/refresh')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(refreshResponse.body).toEqual(
+      expect.objectContaining({
+        accessToken: expect.any(String),
+        accessTokenExpiresInSeconds: 900,
+        user: expect.objectContaining({
+          email: 'refresh-user@pricely.local',
+        }),
+      }),
+    );
+    expect(refreshResponse.body.refreshToken).toBeUndefined();
+    expect(refreshResponse.headers['set-cookie']?.join(';')).toContain(
+      'pricely_refresh=',
+    );
+
+    await request(app.getHttpServer())
+      .post('/auth/refresh')
+      .set('Cookie', cookie)
+      .expect(401);
+
+    const rotatedCookie = refreshResponse.headers['set-cookie'];
+    const logoutResponse = await request(app.getHttpServer())
+      .post('/auth/logout')
+      .set('Cookie', rotatedCookie)
+      .expect(200);
+
+    expect(logoutResponse.headers['set-cookie']?.join(';')).toContain(
+      'pricely_refresh=;',
+    );
+    await request(app.getHttpServer())
+      .post('/auth/refresh')
+      .set('Cookie', rotatedCookie)
+      .expect(401);
   });
 
   it('authenticates an existing account and exposes /auth/me with the same identity', async () => {

--- a/backend/test/support/us1-app.factory.ts
+++ b/backend/test/support/us1-app.factory.ts
@@ -373,6 +373,7 @@ class PrismaUserAccountMock {
   private readonly userLocationPreferences = new Map<string, any>();
   private readonly userEntitlements: any[] = [];
   private readonly optimizationTokenLedgerEntries = new Map<string, any>();
+  private readonly userSessions = new Map<string, any>();
   private readonly regions = [
     {
       id: 'region-test-1',
@@ -507,6 +508,63 @@ class PrismaUserAccountMock {
       [...this.users.values()]
         .filter((user) => !where?.status || user.status === where.status)
         .map((user) => (select?.id ? { id: user.id } : structuredClone(user))),
+  };
+
+  readonly userSession = {
+    create: async ({ data }: { data: any }) => {
+      const session = {
+        id: crypto.randomUUID(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        revokedAt: null,
+        ...data,
+      };
+      this.userSessions.set(session.id, session);
+      return structuredClone(session);
+    },
+    findUnique: async ({ where }: { where: any }) => {
+      const session =
+        [...this.userSessions.values()].find(
+          (entry) => entry.refreshTokenHash === where.refreshTokenHash,
+        ) ?? null;
+      if (!session) {
+        return null;
+      }
+      return {
+        ...structuredClone(session),
+        user: this.clone(this.users.get(session.userId) ?? null),
+      };
+    },
+    update: async ({ where, data }: { where: { id: string }; data: any }) => {
+      const existing = this.userSessions.get(where.id);
+      if (!existing) {
+        throw new Error(`Session ${where.id} not found`);
+      }
+      const updated = {
+        ...existing,
+        ...data,
+        updatedAt: new Date(),
+      };
+      this.userSessions.set(updated.id, updated);
+      return structuredClone(updated);
+    },
+    updateMany: async ({ where, data }: { where: any; data: any }) => {
+      let count = 0;
+      for (const [id, session] of this.userSessions.entries()) {
+        if (
+          session.refreshTokenHash === where.refreshTokenHash &&
+          (where.revokedAt === undefined || session.revokedAt === where.revokedAt)
+        ) {
+          this.userSessions.set(id, {
+            ...session,
+            ...data,
+            updatedAt: new Date(),
+          });
+          count += 1;
+        }
+      }
+      return { count };
+    },
   };
 
   private async findUnique(args: {

--- a/backend/test/unit/auth/auth.service.spec.ts
+++ b/backend/test/unit/auth/auth.service.spec.ts
@@ -57,8 +57,17 @@ describe('AuthService', () => {
     const jwtService = {
       signAsync: jest.fn().mockResolvedValue('signed-token'),
     } as unknown as JwtService;
+    const prisma = {
+      userSession: {
+        create: jest.fn().mockResolvedValue({}),
+      },
+    };
 
-    const service = new AuthService(usersService as never, jwtService);
+    const service = new AuthService(
+      usersService as never,
+      jwtService,
+      prisma as never,
+    );
 
     await expect(
       service.register({
@@ -69,6 +78,8 @@ describe('AuthService', () => {
     ).resolves.toEqual(
       expect.objectContaining({
         accessToken: 'signed-token',
+        accessTokenExpiresInSeconds: 900,
+        refreshToken: expect.any(String),
         user: expect.objectContaining({
           email: 'cliente@pricely.local',
         }),
@@ -104,8 +115,17 @@ describe('AuthService', () => {
     const jwtService = {
       signAsync: jest.fn(),
     } as unknown as JwtService;
+    const prisma = {
+      userSession: {
+        create: jest.fn(),
+      },
+    };
 
-    const service = new AuthService(usersService as never, jwtService);
+    const service = new AuthService(
+      usersService as never,
+      jwtService,
+      prisma as never,
+    );
 
     await expect(
       service.login({
@@ -116,5 +136,78 @@ describe('AuthService', () => {
 
     expect(usersService.markSuccessfulLogin).not.toHaveBeenCalled();
     expect(jwtService.signAsync).not.toHaveBeenCalled();
+    expect(prisma.userSession.create).not.toHaveBeenCalled();
+  });
+
+  it('rotates refresh sessions and rejects reuse of revoked tokens', async () => {
+    const usersService = {
+      getProfileById: jest.fn().mockResolvedValue({
+        id: 'user-1',
+        email: 'cliente@pricely.local',
+        displayName: 'Cliente',
+        role: 'customer',
+        status: 'active',
+      }),
+    };
+    const jwtService = {
+      signAsync: jest.fn().mockResolvedValue('new-access-token'),
+    } as unknown as JwtService;
+    const session = {
+      id: 'session-1',
+      userId: 'user-1',
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+      user: {
+        id: 'user-1',
+        email: 'cliente@pricely.local',
+        displayName: 'Cliente',
+        role: 'customer',
+        status: 'active',
+        preferredRegionId: null,
+        lastLoginAt: null,
+        createdAt: new Date('2026-04-27T10:00:00Z'),
+        updatedAt: new Date('2026-04-27T10:00:00Z'),
+      },
+    };
+    const prisma = {
+      userSession: {
+        findUnique: jest.fn().mockResolvedValue(session),
+        update: jest.fn().mockResolvedValue({}),
+        create: jest.fn().mockResolvedValue({}),
+      },
+    };
+    const service = new AuthService(
+      usersService as never,
+      jwtService,
+      prisma as never,
+    );
+
+    await expect(service.refresh('refresh-token')).resolves.toEqual(
+      expect.objectContaining({
+        accessToken: 'new-access-token',
+        refreshToken: expect.any(String),
+      }),
+    );
+
+    expect(prisma.userSession.update).toHaveBeenCalledWith({
+      where: { id: 'session-1' },
+      data: { revokedAt: expect.any(Date) },
+    });
+    expect(prisma.userSession.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'user-1',
+        refreshTokenHash: expect.any(String),
+        expiresAt: expect.any(Date),
+      }),
+    });
+
+    prisma.userSession.findUnique.mockResolvedValue({
+      ...session,
+      revokedAt: new Date(),
+    });
+
+    await expect(service.refresh('refresh-token')).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
   });
 });

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -8,6 +8,7 @@ const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000';
 
 type AuthSessionResponse = {
   accessToken: string;
+  accessTokenExpiresInSeconds: number;
   user: {
     id: string;
     email: string;
@@ -767,6 +768,7 @@ async function apiFetch<T>(
   const response = await fetch(`${apiBaseUrl}${path}`, {
     ...init,
     headers,
+    credentials: 'include',
   });
 
   if (!response.ok) {
@@ -808,6 +810,18 @@ export async function signUp(
   return apiFetch<AuthSessionResponse>('/auth/register', {
     method: 'POST',
     body: JSON.stringify({ email, password, displayName }),
+  });
+}
+
+export async function refreshSession() {
+  return apiFetch<AuthSessionResponse>('/auth/refresh', {
+    method: 'POST',
+  });
+}
+
+export async function signOutSession() {
+  return apiFetch<{ status: 'ok' }>('/auth/logout', {
+    method: 'POST',
   });
 }
 

--- a/web/src/app/pricely-context.tsx
+++ b/web/src/app/pricely-context.tsx
@@ -21,7 +21,9 @@ import {
   replaceShoppingList,
   reportShoppingListItemPriceMismatch,
   runOptimization as runOptimizationRequest,
+  refreshSession,
   signIn as signInRequest,
+  signOutSession,
   signUp as signUpRequest,
   updatePreferredRegion as updatePreferredRegionRequest,
   updateShoppingListItemPurchaseStatus,
@@ -124,7 +126,6 @@ interface PricelyContextValue {
 }
 
 const STORAGE_KEY = 'pricely-web-state-v2';
-const TOKEN_KEY = 'pricely-auth-token';
 
 const PricelyContext = createContext<PricelyContextValue | null>(null);
 
@@ -222,12 +223,7 @@ export function PricelyProvider({ children }: PropsWithChildren) {
   }, []);
 
   useEffect(() => {
-    const storedToken = window.localStorage.getItem(TOKEN_KEY);
     const rawState = window.localStorage.getItem(STORAGE_KEY);
-
-    if (storedToken) {
-      setToken(storedToken);
-    }
 
     if (rawState) {
       try {
@@ -250,6 +246,37 @@ export function PricelyProvider({ children }: PropsWithChildren) {
         window.localStorage.removeItem(STORAGE_KEY);
       }
     }
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+
+    const restoreSession = async () => {
+      setIsBootstrapping(true);
+      try {
+        const session = await refreshSession();
+        if (disposed) {
+          return;
+        }
+        applySession(session);
+      } catch {
+        if (!disposed) {
+          setToken(null);
+          setCurrentUser(null);
+          setProfile(emptyProfile());
+        }
+      } finally {
+        if (!disposed) {
+          setIsBootstrapping(false);
+        }
+      }
+    };
+
+    void restoreSession();
+
+    return () => {
+      disposed = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -299,7 +326,6 @@ export function PricelyProvider({ children }: PropsWithChildren) {
         setCityIdState(user.preferredRegionSlug ?? null);
       } catch {
         if (!disposed) {
-          window.localStorage.removeItem(TOKEN_KEY);
           setToken(null);
           setLists([]);
           setLocationPreferences([]);
@@ -338,6 +364,18 @@ export function PricelyProvider({ children }: PropsWithChildren) {
     setProfile(mapProfile(updatedUser));
   };
 
+  const applySession = (session: Awaited<ReturnType<typeof signInRequest>>) => {
+    setCurrentUser({
+      id: session.user.id,
+      email: session.user.email,
+      displayName: session.user.displayName,
+      role: session.user.role,
+    });
+    setProfile(mapProfile(session.user));
+    setToken(session.accessToken);
+    setCityIdState(session.user.preferredRegionSlug ?? null);
+  };
+
   const value = useMemo<PricelyContextValue>(
     () => ({
       accessToken: token,
@@ -356,32 +394,14 @@ export function PricelyProvider({ children }: PropsWithChildren) {
       isBootstrapping,
       signIn: async (email, password) => {
         const session = await signInRequest(email, password);
-        window.localStorage.setItem(TOKEN_KEY, session.accessToken);
-        setCurrentUser({
-          id: session.user.id,
-          email: session.user.email,
-          displayName: session.user.displayName,
-          role: session.user.role,
-        });
-        setProfile(mapProfile(session.user));
-        setToken(session.accessToken);
-        setCityIdState(session.user.preferredRegionSlug ?? null);
+        applySession(session);
       },
       signUp: async (email, password, displayName) => {
         const session = await signUpRequest(email, password, displayName);
-        window.localStorage.setItem(TOKEN_KEY, session.accessToken);
-        setCurrentUser({
-          id: session.user.id,
-          email: session.user.email,
-          displayName: session.user.displayName,
-          role: session.user.role,
-        });
-        setProfile(mapProfile(session.user));
-        setToken(session.accessToken);
-        setCityIdState(session.user.preferredRegionSlug ?? null);
+        applySession(session);
       },
       signOut: () => {
-        window.localStorage.removeItem(TOKEN_KEY);
+        void signOutSession().catch(() => undefined);
         setToken(null);
         setCurrentUser(null);
         setLists([]);


### PR DESCRIPTION
## Summary
- add backend refresh sessions with hashed rotating refresh tokens and 15-minute access tokens
- set refresh tokens in HttpOnly SameSite cookies and clear them on logout
- enable credentialed CORS and move the web session restore flow off localStorage access tokens
- add tests for cookie refresh, token rotation, revoked-token reuse, and mocked admin auth flows

## Validation
- backend: npm run db:generate
- backend: npm test -- --runTestsByPath test/unit/auth/auth.service.spec.ts test/integration/auth/shared-auth.integration.spec.ts
- backend: npm run lint
- backend: npm run build
- backend: npm test
- web: npm test
- web: npm run lint
- web: npm run build