### PR TITLE
Add backend health endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { AdminModule } from './admin/admin.module';
 import { AuthModule } from './auth/auth.module';
 import { CatalogModule } from './catalog/catalog.module';
 import { EstablishmentsModule } from './establishments/establishments.module';
+import { HealthModule } from './health/health.module';
 import { JobsModule } from './jobs/jobs.module';
 import { ListsModule } from './lists/lists.module';
 import { LocationsModule } from './locations/locations.module';
@@ -19,6 +20,7 @@ import { StoresModule } from './stores/stores.module';
   imports: [
     LoggingModule,
     PrismaModule,
+    HealthModule,
     AuthModule,
     QueueModule,
     ReceiptsModule,

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  getHealth() {
+    return {
+      status: 'ok',
+      service: 'pricely-backend',
+    };
+  }
+}

--- a/backend/src/health/health.module.ts
+++ b/backend/src/health/health.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+import { HealthController } from './health.controller';
+
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/backend/test/integration/health/health.integration.spec.ts
+++ b/backend/test/integration/health/health.integration.spec.ts
@@ -1,0 +1,31 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+import { HealthModule } from '../../../src/health/health.module';
+
+describe('Health endpoint', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [HealthModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('exposes a public health check for deploy probes', async () => {
+    const response = await request(app.getHttpServer()).get('/health').expect(200);
+
+    expect(response.body).toEqual({
+      status: 'ok',
+      service: 'pricely-backend',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add public GET /health for deploy/load balancer probes
- register HealthModule in the backend app
- cover the endpoint with an integration test first

## Validation
- npm test -- --runTestsByPath test/integration/health/health.integration.spec.ts
- npm run lint
- npm test