### PR TITLE
Add TDD guards for receipt audit actions

### DIFF
--- a/backend/test/unit/jobs/optimization-run.processor.spec.ts
+++ b/backend/test/unit/jobs/optimization-run.processor.spec.ts
@@ -172,6 +172,64 @@ describe('OptimizationRunProcessor', () => {
     });
   });
 
+  it('does not consume an optimization token when computation fails before completion', async () => {
+    const transaction = jest.fn().mockResolvedValue([]);
+    const prisma = {
+      optimizationRun: {
+        update: jest.fn().mockResolvedValue(undefined),
+      },
+      optimizationSelection: {
+        deleteMany: jest.fn().mockResolvedValue(undefined),
+        createMany: jest.fn().mockResolvedValue(undefined),
+      },
+      shoppingList: {
+        update: jest.fn().mockResolvedValue(undefined),
+      },
+      $transaction: transaction,
+    };
+    const shoppingListsService = {
+      getById: jest.fn().mockResolvedValue({
+        id: 'list-1',
+        items: [{ id: 'item-1', normalizedName: 'arroz' }],
+      }),
+    };
+    const storeOfferRepository = {
+      findByListItems: jest.fn().mockResolvedValue([]),
+    };
+    const multiMarketOptimizerService = {
+      optimize: jest.fn().mockImplementation(() => {
+        throw new Error('No active establishments with coordinates are available');
+      }),
+    };
+    const optimizationRunRepository = {
+      findById: jest.fn().mockResolvedValue({
+        id: 'run-1',
+        userId: 'user-1',
+        shoppingListId: 'list-1',
+        mode: 'global_multi',
+        regionId: 'region-1',
+      }),
+    };
+    const entitlementsService = {
+      consumeOptimizationToken: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const processor = new OptimizationRunProcessor(
+      prisma as never,
+      shoppingListsService as never,
+      storeOfferRepository as never,
+      multiMarketOptimizerService as never,
+      optimizationRunRepository as never,
+      entitlementsService as never,
+    );
+
+    await expect(processor.process('run-1')).rejects.toThrow(
+      'No active establishments with coordinates are available',
+    );
+    expect(transaction).not.toHaveBeenCalled();
+    expect(entitlementsService.consumeOptimizationToken).not.toHaveBeenCalled();
+  });
+
   it('uses catalog-backed list items to load offers even when normalizedName is broader than the product canonical name', async () => {
     const transaction = jest.fn().mockResolvedValue([]);
     const prisma = {

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -931,6 +931,9 @@ describe('Admin dashboard pages', () => {
         'receipt-1',
       );
     });
+    expect(
+      await screen.findByText('Nota fiscal liberada para processamento.'),
+    ).toBeTruthy();
 
     fetchAdminReceiptProcessingDetail.mockResolvedValue(buildReceiptAudit());
     reprocessAdminReceiptProcessing.mockResolvedValue(buildReceiptAudit());
@@ -947,6 +950,40 @@ describe('Admin dashboard pages', () => {
         'receipt-1',
       );
     });
+    expect(
+      await screen.findByText('Nota fiscal reenfileirada para processamento.'),
+    ).toBeTruthy();
+  });
+
+  it('can reject a receipt from the dedicated receipt audit page', async () => {
+    fetchAdminReceiptProcessingDetail.mockResolvedValue(
+      buildReceiptAudit({
+        processingJob: null,
+        moderationStatus: 'pending',
+        trustLevel: 'pending_review',
+        rewardEligibilityStatus: 'disabled',
+      }),
+    );
+    rejectAdminReceiptProcessing.mockResolvedValue(
+      buildReceiptAudit({
+        moderationStatus: 'rejected',
+        trustLevel: 'rejected',
+        reviewReason: 'manual_admin_rejection',
+      }),
+    );
+
+    render(<AdminReceiptAuditPage />);
+
+    expect(await screen.findByText('Auditoria da nota fiscal')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Recusar' }));
+
+    await waitFor(() => {
+      expect(rejectAdminReceiptProcessing).toHaveBeenCalledWith(
+        'token',
+        'receipt-1',
+      );
+    });
+    expect(await screen.findByText('Nota fiscal recusada.')).toBeTruthy();
   });
 
   it('renders admin users and supports premium and token actions', async () => {

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -3214,18 +3214,22 @@ export function AdminReceiptAuditPage() {
     reload,
   } = useAdminData<AdminReceiptProcessingResponse | null>(loader, null);
   const [acting, setActing] = useState(false);
+  const [actionNotice, setActionNotice] = useState<string | null>(null);
 
   const runReceiptAction = async (
     action: (token: string, id: string) => Promise<unknown>,
+    successMessage: string,
   ) => {
     if (!accessToken || !receipt) {
       return;
     }
 
     setActing(true);
+    setActionNotice(null);
     try {
       await action(accessToken, receipt.id);
       await reload();
+      setActionNotice(successMessage);
     } finally {
       setActing(false);
     }
@@ -3275,7 +3279,10 @@ export function AdminReceiptAuditPage() {
                   <Button
                     disabled={acting}
                     onClick={() =>
-                      void runReceiptAction(reprocessAdminReceiptProcessing)
+                      void runReceiptAction(
+                        reprocessAdminReceiptProcessing,
+                        'Nota fiscal reenfileirada para processamento.',
+                      )
                     }
                     size="sm"
                     type="button"
@@ -3288,7 +3295,10 @@ export function AdminReceiptAuditPage() {
                 <Button
                   disabled={acting}
                   onClick={() =>
-                    void runReceiptAction(releaseAdminReceiptProcessing)
+                    void runReceiptAction(
+                      releaseAdminReceiptProcessing,
+                      'Nota fiscal liberada para processamento.',
+                    )
                   }
                   size="sm"
                   type="button"
@@ -3299,7 +3309,12 @@ export function AdminReceiptAuditPage() {
               <Button
                 className="border-destructive/40 text-destructive hover:bg-destructive/10"
                 disabled={acting || receipt.moderationStatus === 'rejected'}
-                onClick={() => void runReceiptAction(rejectAdminReceiptProcessing)}
+                onClick={() =>
+                  void runReceiptAction(
+                    rejectAdminReceiptProcessing,
+                    'Nota fiscal recusada.',
+                  )
+                }
                 size="sm"
                 type="button"
                 variant="outline"
@@ -3310,6 +3325,12 @@ export function AdminReceiptAuditPage() {
           </div>
         </CardHeader>
         <CardContent className="grid gap-4">
+          {actionNotice ? (
+            <Alert>
+              <AlertTitle>Ação registrada</AlertTitle>
+              <AlertDescription>{actionNotice}</AlertDescription>
+            </Alert>
+          ) : null}
           <div className="grid gap-3 md:grid-cols-4">
             <div className="rounded-md border border-border/70 p-3">
               <div className="text-xs text-muted-foreground">Leitura</div>


### PR DESCRIPTION
## Summary
- add receipt audit feedback for release, reprocess, and reject actions
- add dashboard tests for manual receipt audit actions from /dashboard/nota/:id
- add backend regression coverage to ensure optimization tokens are not consumed when computation fails before completion

## Validation
- web: npm run lint
- web: npm test
- web: npm run build
- backend: npm run lint
- backend: npm test
- backend: npm run build