### PR TITLE
Group flat public offers by variant

### DIFF
--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -350,6 +350,12 @@ describe('public pages', () => {
 
     expect(await screen.findByText('Ofertas por cidade')).toBeTruthy();
     expect(
+      screen.getByText('Nenhuma oferta agrupada disponível'),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/Esta cidade está em ativação/),
+    ).toBeTruthy();
+    expect(
       screen.getByText(
         'Campinas. Ofertas públicas mostram loja, frescor, confiança e detalhe completo do item.',
       ),
@@ -443,6 +449,80 @@ describe('public pages', () => {
       screen.getByText(/Média da variante na cidade: R\$ 22,40/),
     ).toBeTruthy();
     expect(screen.getByText('Ver outros estabelecimentos')).toBeTruthy();
+  });
+
+  it('deduplicates regional offers by variant when the API only returns flat offers', async () => {
+    fetchRegionOffers.mockResolvedValue({
+      region: {
+        id: 'sao-paulo-sp',
+        slug: 'sao-paulo-sp',
+        name: 'Sao Paulo',
+        stateCode: 'SP',
+      },
+      activeEstablishmentCount: 2,
+      offerCoverageStatus: 'live',
+      offers: [
+        {
+          id: 'offer-1',
+          catalogProductId: 'product-1',
+          productVariantId: 'variant-1',
+          productName: 'Feijao carioca 1kg',
+          variantName: 'Feijao Carioca Camil 1kg',
+          imageUrl: 'https://example.com/feijao-camil.png',
+          displayName: 'Feijao Carioca Camil 1kg',
+          packageLabel: '1 kg',
+          priceAmount: 7.99,
+          basePriceAmount: 8.79,
+          promotionalPriceAmount: 7.99,
+          regionalAveragePriceAmount: 8.24,
+          comparisonPriceAmount: 8.49,
+          savingsVsComparison: 0.5,
+          observedAt: '2026-05-10T00:00:00.000Z',
+          sourceLabel: 'Nota fiscal',
+          storeName: 'Unidade Santo Amaro',
+          neighborhood: 'Santo Amaro',
+          confidenceLevel: 'high',
+        },
+        {
+          id: 'offer-2',
+          catalogProductId: 'product-1',
+          productVariantId: 'variant-1',
+          productName: 'Feijao carioca 1kg',
+          variantName: 'Feijao Carioca Camil 1kg',
+          imageUrl: 'https://example.com/feijao-camil.png',
+          displayName: 'Feijao Carioca Camil 1kg',
+          packageLabel: '1 kg',
+          priceAmount: 8.49,
+          basePriceAmount: 8.79,
+          promotionalPriceAmount: 8.49,
+          regionalAveragePriceAmount: 8.24,
+          comparisonPriceAmount: 7.99,
+          savingsVsComparison: 0,
+          observedAt: '2026-05-09T00:00:00.000Z',
+          sourceLabel: 'Nota fiscal',
+          storeName: 'Unidade Pinheiros',
+          neighborhood: 'Pinheiros',
+          confidenceLevel: 'medium',
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <OffersPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText('Feijao Carioca Camil 1kg'),
+    ).toBeTruthy();
+    expect(screen.getAllByText('Feijao Carioca Camil 1kg')).toHaveLength(1);
+    expect(screen.getByText('2 estabelecimentos')).toBeTruthy();
+    expect(
+      screen.getByText(/Menor preço em Unidade Santo Amaro/),
+    ).toBeTruthy();
+    expect(screen.getByText('Ver outros estabelecimentos')).toBeTruthy();
+    expect(screen.getAllByText(/Unidade Pinheiros/).length).toBeGreaterThan(0);
   });
 
   it('renders detailed public offer content', async () => {

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -653,6 +653,71 @@ function buildOfferGroupFromOffers(
   };
 }
 
+function groupFlatRegionalOffers(
+  offers: RegionOffersApiResponse['offers'],
+): NonNullable<RegionOffersApiResponse['groupedOffers']> {
+  const grouped = new Map<string, RegionOffersApiResponse['offers']>();
+
+  for (const offer of offers) {
+    const key = offer.productVariantId;
+    grouped.set(key, [...(grouped.get(key) ?? []), offer]);
+  }
+
+  return [...grouped.entries()]
+    .map(([productVariantId, entries]) => {
+      const sorted = [...entries].sort((left, right) => {
+        if (left.priceAmount !== right.priceAmount) {
+          return left.priceAmount - right.priceAmount;
+        }
+
+        return (
+          new Date(right.observedAt).getTime() -
+          new Date(left.observedAt).getTime()
+        );
+      });
+      const bestOffer = sorted[0];
+      const prices = sorted.map((offer) => offer.priceAmount);
+      const secondCheapestPriceAmount = sorted[1]?.priceAmount;
+      const averagePriceAmount = Number(
+        (prices.reduce((sum, price) => sum + price, 0) / prices.length).toFixed(
+          2,
+        ),
+      );
+
+      return {
+        id: productVariantId,
+        catalogProductId: bestOffer.catalogProductId,
+        productVariantId,
+        productName: bestOffer.productName,
+        variantName: bestOffer.variantName,
+        imageUrl: bestOffer.imageUrl,
+        packageLabel: bestOffer.packageLabel,
+        bestOffer,
+        alternativeOffers: sorted.slice(1),
+        offers: sorted,
+        establishmentCount: sorted.length,
+        cheapestPriceAmount: bestOffer.priceAmount,
+        secondCheapestPriceAmount,
+        savingsVsSecondCheapest: Number(
+          Math.max(
+            0,
+            (secondCheapestPriceAmount ?? bestOffer.priceAmount) -
+              bestOffer.priceAmount,
+          ).toFixed(2),
+        ),
+        averagePriceAmount,
+        highestPriceAmount: Math.max(...prices),
+      };
+    })
+    .sort((left, right) => {
+      if (left.productName !== right.productName) {
+        return left.productName.localeCompare(right.productName);
+      }
+
+      return left.cheapestPriceAmount - right.cheapestPriceAmount;
+    });
+}
+
 function RequireAuthentication({
   children,
   title,
@@ -1089,25 +1154,7 @@ export function OffersPage() {
         const response = await fetchRegionOffers(cityId);
         if (!disposed) {
           setOfferGroups(
-            response.groupedOffers ??
-              response.offers.map((offer) => ({
-                id: offer.productVariantId,
-                catalogProductId: offer.catalogProductId,
-                productVariantId: offer.productVariantId,
-                productName: offer.productName,
-                variantName: offer.variantName,
-                imageUrl: offer.imageUrl,
-                packageLabel: offer.packageLabel,
-                bestOffer: offer,
-                alternativeOffers: [],
-                offers: [offer],
-                establishmentCount: 1,
-                cheapestPriceAmount: offer.priceAmount,
-                secondCheapestPriceAmount: undefined,
-                savingsVsSecondCheapest: 0,
-                averagePriceAmount: offer.priceAmount,
-                highestPriceAmount: offer.priceAmount,
-              })),
+            response.groupedOffers ?? groupFlatRegionalOffers(response.offers),
           );
         }
       } catch {


### PR DESCRIPTION
## Summary
- groups flat public offer API responses by product variant before rendering
- keeps the cheapest store as the primary card and exposes other stores in details
- adds regression coverage for activation empty states and deduplicated flat offers

## Validation
- npm test -- src/public/public-pages.spec.tsx
- npm test -- src/public/optimization-page.spec.tsx
- npm test
- npm run lint
- npm run build