### PR TITLE
Polish web/admin MVP smoke and location flow

### DIFF
--- a/web/e2e/mvp-smoke.spec.ts
+++ b/web/e2e/mvp-smoke.spec.ts
@@ -115,7 +115,87 @@ const optimizationResult = {
   ],
 };
 
+const receiptAudit = {
+  id: 'receipt-1',
+  storeName: 'Mercado Centro',
+  storeCnpj: '00.000.000/0001-00',
+  parseStatus: 'queued',
+  trustLevel: 'pending_review',
+  moderationStatus: 'pending',
+  rewardEligibilityStatus: 'eligible_pending',
+  reviewReason: 'receipt_reward_ready',
+  purchaseDate: '2026-05-05T09:30:00.000Z',
+  createdAt: '2026-05-05T10:10:00.000Z',
+  updatedAt: '2026-05-05T10:10:00.000Z',
+  owner: {
+    id: 'user-1',
+    displayName: 'Cliente Pricely',
+    email: 'cliente@pricely.test',
+  },
+  processingJob: null,
+  quality: {
+    lineItemCount: 1,
+    highConfidenceLineItemCount: 1,
+    averageMatchConfidence: 0.91,
+    usefulDataRatio: 1,
+  },
+  reward: {
+    points: 100,
+    optimizationTokens: 1,
+    label: '100 pontos + 1 credito pendente',
+  },
+  extractedPayload: {
+    accessKey: null,
+    sefazUrl: null,
+    rawReference: 'Entrada manual',
+    purchaseDate: '2026-05-05T09:30:00.000Z',
+    lineItemCount: 1,
+    totalLineAmount: 15.8,
+  },
+  lineItems: [
+    {
+      id: 'line-1',
+      rawProductName: 'Arroz tipo 1 1kg',
+      normalizedName: 'Arroz tipo 1 1kg',
+      ean: null,
+      quantity: 2,
+      unitPrice: 7.9,
+      lineTotal: 15.8,
+      originalUnitPrice: null,
+      promotionalUnitPrice: null,
+      matchConfidence: 0.91,
+      matcherStatus: 'matched_offer',
+      makerAction: 'offer_created',
+      offers: [
+        {
+          id: 'offer-1',
+          catalogProductName: 'Arroz tipo 1',
+          variantName: 'Arroz tipo 1 1kg',
+          brandName: null,
+          establishmentName: 'Mercado Centro',
+          neighborhood: 'Centro',
+          displayName: 'Arroz tipo 1 1kg',
+          packageLabel: '1 kg',
+          priceAmount: 7.9,
+          observedAt: '2026-05-05T10:10:00.000Z',
+          comparison: {
+            previousPriceAmount: 9.4,
+            newPriceAmount: 7.9,
+            deltaAmount: -1.5,
+            direction: 'down',
+            previousObservedAt: '2026-05-01T10:10:00.000Z',
+          },
+        },
+      ],
+    },
+  ],
+};
+
 async function mockApi(page: Page) {
+  let sessionToken: 'customer-token' | 'admin-token' | null = null;
+  let receiptReleased = false;
+  let receiptRejected = false;
+
   await page.route('http://localhost:3000/**', async (route) => {
     const request = route.request();
     const url = new URL(request.url());
@@ -131,13 +211,75 @@ async function mockApi(page: Page) {
         body: JSON.stringify(body),
       });
 
+    const receiptSubmissionResponse = (
+      processingStatus:
+        | 'waiting_manual_release'
+        | 'queued'
+        | 'running'
+        | 'completed'
+        | 'failed'
+        | 'retrying',
+    ) => ({
+      id: receiptAudit.id,
+      storeName: receiptAudit.storeName,
+      storeCnpj: receiptAudit.storeCnpj,
+      parseStatus: receiptAudit.parseStatus,
+      trustLevel: receiptRejected ? 'rejected' : receiptAudit.trustLevel,
+      moderationStatus: receiptRejected ? 'rejected' : receiptAudit.moderationStatus,
+      rewardEligibilityStatus: receiptRejected
+        ? 'disabled'
+        : receiptAudit.rewardEligibilityStatus,
+      rewardPoints: receiptAudit.reward.points,
+      rewardOptimizationTokens: receiptAudit.reward.optimizationTokens,
+      rewardMessage:
+        'Nota recebida: reward em processamento ate a liberacao e validacao.',
+      processingStatus,
+    });
+
+    const receiptProcessingRecord = () => ({
+      ...receiptAudit,
+      trustLevel: receiptRejected ? 'rejected' : receiptAudit.trustLevel,
+      moderationStatus: receiptRejected ? 'rejected' : receiptAudit.moderationStatus,
+      rewardEligibilityStatus: receiptRejected
+        ? 'disabled'
+        : receiptAudit.rewardEligibilityStatus,
+      processingJob: receiptReleased
+        ? {
+            id: 'job-1',
+            queueName: 'receipts',
+            jobType: 'receipt.extract',
+            status: 'queued',
+            attemptCount: 0,
+            createdAt: '2026-05-05T10:12:00.000Z',
+            updatedAt: '2026-05-05T10:12:00.000Z',
+          }
+        : null,
+    });
+
     if (method === 'POST' && path === '/auth/login') {
       const body = JSON.parse(request.postData() ?? '{}') as { email?: string };
+      sessionToken =
+        body.email === adminUser.email ? 'admin-token' : 'customer-token';
       return json({
-        accessToken:
-          body.email === adminUser.email ? 'admin-token' : 'customer-token',
+        accessToken: sessionToken,
         user: body.email === adminUser.email ? adminUser : customerUser,
       });
+    }
+
+    if (method === 'POST' && path === '/auth/refresh') {
+      if (!sessionToken) {
+        return json({ message: 'No refresh session' }, 401);
+      }
+
+      return json({
+        accessToken: sessionToken,
+        user: sessionToken === 'admin-token' ? adminUser : customerUser,
+      });
+    }
+
+    if (method === 'POST' && path === '/auth/logout') {
+      sessionToken = null;
+      return json({ status: 'ok' });
     }
 
     if (path === '/auth/me') {
@@ -279,6 +421,12 @@ async function mockApi(page: Page) {
       return json([]);
     }
 
+    if (path === '/receipts' && method === 'POST') {
+      receiptReleased = false;
+      receiptRejected = false;
+      return json(receiptSubmissionResponse('waiting_manual_release'), 201);
+    }
+
     if (path === '/admin/metrics') {
       return json({
         activeUsers: 12,
@@ -291,6 +439,38 @@ async function mockApi(page: Page) {
         queuedJobs: 1,
         globalEstimatedSavings: 450,
       });
+    }
+
+    if (path === '/admin/receipt-processing' && method === 'GET') {
+      return json([receiptProcessingRecord()]);
+    }
+
+    if (path === '/admin/receipt-processing/receipt-1' && method === 'GET') {
+      return json(receiptProcessingRecord());
+    }
+
+    if (
+      path === '/admin/receipt-processing/receipt-1/release' &&
+      method === 'POST'
+    ) {
+      receiptReleased = true;
+      return json(receiptSubmissionResponse('queued'));
+    }
+
+    if (
+      path === '/admin/receipt-processing/receipt-1/reprocess' &&
+      method === 'POST'
+    ) {
+      receiptReleased = true;
+      return json(receiptSubmissionResponse('queued'));
+    }
+
+    if (
+      path === '/admin/receipt-processing/receipt-1/reject' &&
+      method === 'POST'
+    ) {
+      receiptRejected = true;
+      return json(receiptSubmissionResponse('failed'));
     }
 
     if (path === '/admin/processing-jobs') {
@@ -400,7 +580,7 @@ test('MVP shopper flow covers sign-in, city, list, optimization, checklist, and 
   ).toBeVisible();
   await expect(page.getByText('2 de 2 listas no mês')).toBeVisible();
   await expect(
-    page.getByRole('button', { name: 'Comprar Premium' }),
+    page.getByRole('button', { name: /Premium indispon/i }),
   ).toBeDisabled();
 
   await page.goto('/cidades');
@@ -445,18 +625,78 @@ test('location-aware web flow saves browser coordinates and shows local result d
     latitude: -23.566263,
     longitude: -46.683677,
   });
-  await page.addInitScript(() => {
-    window.localStorage.setItem('pricely-auth-token', 'customer-token');
-  });
+  await page.goto('/entrar');
+  await page.getByLabel('E-mail').fill(customerUser.email);
+  await page.getByLabel('Senha').fill('password');
+  await page.getByRole('button', { name: 'Entrar' }).click();
+  await expect(
+    page.getByRole('heading', { name: 'Minhas listas' }),
+  ).toBeVisible();
 
   await page.goto('/');
   await page.getByRole('button', { name: /Usar localizacao/i }).click();
-  await expect(page.getByText(/2 lojas dentro de 5 km/)).toBeVisible();
+  await expect(page.getByText(/Preview local: 2 lojas dentro de 5 km/)).toBeVisible();
 
   await page.goto('/otimizacao/list-1');
   await page.getByText('Menor preco perto de mim').click();
   await page.getByText('Usar este modo').nth(1).click();
   await expect(page.getByText('0.8 km do local salvo')).toBeVisible();
+});
+
+test('MVP receipt flow covers submission, admin audit release, and reward state', async ({
+  page,
+}) => {
+  await page.goto('/entrar');
+  await page.getByLabel('E-mail').fill(customerUser.email);
+  await page.getByLabel('Senha').fill('password');
+  await page.getByRole('button', { name: 'Entrar' }).click();
+  await expect(
+    page.getByRole('heading', { name: 'Minhas listas' }),
+  ).toBeVisible();
+
+  await page.goto('/notas');
+  await expect(page.getByText('Enviar nota fiscal').first()).toBeVisible();
+  await page.getByLabel('Estabelecimento').fill('Mercado Centro');
+  await page.getByLabel('Data da compra').fill('2026-05-05');
+  await page.getByLabel('CNPJ').fill('00.000.000/0001-00');
+  await page.getByLabel('Produto').fill('Arroz tipo 1 1kg');
+  await page.getByLabel('Qtd.').fill('2');
+  await page.getByLabel('Preço').fill('7.90');
+  await page.getByRole('button', { name: 'Enviar nota' }).click();
+
+  await expect(page.getByText('Nota recebida', { exact: true })).toBeVisible();
+  await expect(
+    page.getByText('Aguardando liberação manual', { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText(/Reward previsto/i)).toBeVisible();
+  await expect(page.getByText('Admin libera no dashboard')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Sair' }).click();
+  await page.goto('/entrar');
+  await page.getByLabel('E-mail').fill(adminUser.email);
+  await page.getByLabel('Senha').fill('password');
+  await page.getByRole('button', { name: 'Entrar' }).click();
+  await expect(
+    page.getByRole('heading', { name: 'Minhas listas' }),
+  ).toBeVisible();
+
+  await page.goto('/dashboard/notas');
+  await expect(page.getByText('Notas fiscais processadas')).toBeVisible();
+  await expect(page.getByText('Mercado Centro')).toBeVisible();
+  await expect(page.getByText('Rewards prontos')).toBeVisible();
+  await expect(page.getByText('100 pontos + 1 credito pendente')).toBeVisible();
+  await page.getByRole('link', { name: /Auditar nota fiscal/i }).click();
+
+  await expect(page.getByText('Auditoria da nota fiscal')).toBeVisible();
+  await expect(page.getByText('receipt_reward_ready')).toBeVisible();
+  await expect(
+    page.getByText('Arroz tipo 1 1kg', { exact: true }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Liberar processamento' }).click();
+  await expect(
+    page.getByText('Nota fiscal liberada para processamento.'),
+  ).toBeVisible();
+  await expect(page.getByRole('link', { name: /Ver execu/i })).toBeVisible();
 });
 
 test('MVP admin flow covers route protection and queue detail', async ({
@@ -465,15 +705,19 @@ test('MVP admin flow covers route protection and queue detail', async ({
   await page.goto('/dashboard');
   await expect(page.getByText('Acesso restrito')).toBeVisible();
 
-  await page.evaluate(() => {
-    window.localStorage.setItem('pricely-auth-token', 'admin-token');
-  });
+  await page.goto('/entrar');
+  await page.getByLabel('E-mail').fill(adminUser.email);
+  await page.getByLabel('Senha').fill('password');
+  await page.getByRole('button', { name: 'Entrar' }).click();
+  await expect(
+    page.getByRole('heading', { name: 'Minhas listas' }),
+  ).toBeVisible();
 
   await page.goto('/dashboard/fila');
   await expect(page.getByText('Saude da fila')).toBeVisible();
   await expect(page.getByText('Nota fiscal: Mercado Centro')).toBeVisible();
   await expect(
-    page.getByText('ID tecnico: receipt · receipt-1 · job job-1'),
+    page.getByText(/ID t.cnico: receipt .* receipt-1 .* job job-1/),
   ).toBeVisible();
   await page.goto('/dashboard/fila/job-1');
 

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -7,13 +7,13 @@ export default defineConfig({
     timeout: 5_000,
   },
   use: {
-    baseURL: 'http://127.0.0.1:5173',
+    baseURL: 'http://127.0.0.1:5174',
     trace: 'retain-on-failure',
   },
   webServer: {
-    command: 'npm run dev -- --host 127.0.0.1',
-    url: 'http://127.0.0.1:5173',
-    reuseExistingServer: true,
+    command: 'npm run dev -- --host 127.0.0.1 --port 5174 --strictPort',
+    url: 'http://127.0.0.1:5174',
+    reuseExistingServer: false,
     timeout: 60_000,
   },
   projects: [

--- a/web/src/app/pricely-context.tsx
+++ b/web/src/app/pricely-context.tsx
@@ -10,6 +10,7 @@ import {
 import {
   completeShoppingListCheckout,
   createLocationPreference,
+  previewLocationCoverage as previewLocationCoverageRequest,
   createShoppingList,
   fetchLocationPreferences,
   fetchPublicRegions,
@@ -28,6 +29,7 @@ import {
   updatePreferredRegion as updatePreferredRegionRequest,
   updateShoppingListItemPurchaseStatus,
   type OptimizationResultApiResponse,
+  type CoveragePreviewResponse,
   type UserLocationPreferenceResponse,
 } from './api';
 import { profileSnapshot, supportedCities } from './mock-data';
@@ -120,6 +122,12 @@ interface PricelyContextValue {
     postalCode: string;
     coverageRadiusKm?: number;
   }) => Promise<UserLocationPreferenceResponse>;
+  previewLocationCoverage: (input: {
+    latitude?: number;
+    longitude?: number;
+    postalCode?: string;
+    coverageRadiusKm?: number;
+  }) => Promise<CoveragePreviewResponse>;
   loadLatestOptimization: (
     listId: string,
   ) => Promise<OptimizationResultApiResponse | null>;
@@ -595,6 +603,24 @@ export function PricelyProvider({ children }: PropsWithChildren) {
             ),
         ]);
         return saved;
+      },
+      previewLocationCoverage: async (input) => {
+        if (!token) {
+          throw new Error('Voce precisa entrar para prever a cobertura local.');
+        }
+
+        const activeCity = cities.find((city) => city.id === cityId);
+        if (!activeCity) {
+          throw new Error('Escolha uma cidade antes de prever a cobertura.');
+        }
+
+        return previewLocationCoverageRequest(token, {
+          regionId: activeCity.regionId ?? activeCity.id,
+          coverageRadiusKm: input.coverageRadiusKm ?? 5,
+          latitude: input.latitude,
+          longitude: input.longitude,
+          postalCode: input.postalCode,
+        });
       },
       loadLatestOptimization: async (listId) => {
         if (!token) {

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -397,10 +397,10 @@ describe('Admin dashboard pages', () => {
     expect(await screen.findByText('Saude da fila')).toBeTruthy();
     expect(screen.getByText('Jobs recentes')).toBeTruthy();
     expect(screen.getByText('optimization · optimization')).toBeTruthy();
-    expect(screen.getByText(/Cliente Teste/)).toBeTruthy();
-    expect(screen.getByText(/recurso shopping list/)).toBeTruthy();
-    expect(screen.queryByText('Lista: Compra da semana')).toBeNull();
-    expect(screen.queryByText(/Modo Menor total na cidade/)).toBeNull();
+    expect(screen.getAllByText(/Cliente Teste/).length).toBeGreaterThan(0);
+    expect(screen.getByText('Lista: Compra da semana')).toBeTruthy();
+    expect(screen.getByText(/Menor total na cidade/)).toBeTruthy();
+    expect(screen.getByText(/Fila optimization/)).toBeTruthy();
     expect(screen.getByLabelText('Abrir detalhe do job job-1')).toBeTruthy();
     expect(screen.queryByText('Go to link')).toBeNull();
   });

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -3580,11 +3580,20 @@ export function AdminQueuePage() {
                   </div>
                   <div className="min-w-0">
                     <div className="truncate font-medium">
-                      {job.queueName} · {job.jobType}
+                      {jobResourceTitle(job)}
                     </div>
                     <div className="text-sm text-muted-foreground">
-                      tentativa {job.attemptCount} · recurso{' '}
-                      {job.resourceType.replace(/_/g, ' ')}
+                      {jobOwnerLabel(job)} · {jobStatusLabel(job.status)}
+                      {job.optimizationRun
+                        ? ` · ${optimizationModeLabel(job.optimizationRun.mode)}`
+                        : ''}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      <span className="sr-only">
+                        {job.queueName} · {job.jobType}
+                      </span>
+                      Fila {job.queueName} · {job.jobType} · tentativa{' '}
+                      {job.attemptCount}
                     </div>
                   </div>
                 </div>
@@ -3728,6 +3737,53 @@ export function AdminQueueDetailPage() {
                   <ExternalLinkIcon className="size-4" />
                 </a>
               </Button>
+            </div>
+          ) : null}
+          {job.receiptRecord?.lineItems?.length ? (
+            <div className="rounded-lg border border-border/70 bg-background/80 p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm font-medium">Recibo contribuído</div>
+                  <div className="text-sm text-muted-foreground">
+                    {job.receiptRecord.storeName ?? 'Loja nao identificada'} ·{' '}
+                    {receiptTrustLabel(job.receiptRecord.trustLevel)}
+                  </div>
+                </div>
+                <Badge variant="outline">
+                  {receiptModerationLabel(job.receiptRecord.moderationStatus)}
+                </Badge>
+              </div>
+              {job.receiptRecord.reviewReason ? (
+                <div className="mt-3 rounded-md border border-amber-300/60 bg-amber-50/70 px-3 py-2 text-sm text-amber-900">
+                  {job.receiptRecord.reviewReason}
+                </div>
+              ) : null}
+              <div className="mt-3 overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Item lido</TableHead>
+                      <TableHead>Normalizado</TableHead>
+                      <TableHead>Quantidade</TableHead>
+                      <TableHead>Preço</TableHead>
+                      <TableHead>Confiança</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {job.receiptRecord.lineItems.map((item) => (
+                      <TableRow key={item.id}>
+                        <TableCell>{item.rawProductName}</TableCell>
+                        <TableCell>{item.normalizedName}</TableCell>
+                        <TableCell>{item.quantity}</TableCell>
+                        <TableCell>{formatCurrency(item.unitPrice)}</TableCell>
+                        <TableCell>
+                          {Math.round(item.matchConfidence * 100)}%
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
             </div>
           ) : null}
         </CardContent>

--- a/web/src/public/public-shell.spec.tsx
+++ b/web/src/public/public-shell.spec.tsx
@@ -21,6 +21,7 @@ import { PublicLayout } from './public-shell';
 const setCityId = vi.fn();
 const saveBrowserLocation = vi.fn();
 const savePostalCodeLocation = vi.fn();
+const previewLocationCoverage = vi.fn();
 
 vi.mock('@/app/pricely-context', () => ({
   usePricely: () => ({
@@ -30,6 +31,7 @@ vi.mock('@/app/pricely-context', () => ({
     isAuthenticated: false,
     signOut: vi.fn(),
     locationPreferences: [],
+    previewLocationCoverage,
     saveBrowserLocation,
     savePostalCodeLocation,
     cities: [
@@ -156,6 +158,14 @@ describe('PublicLayout', () => {
     setCityId.mockReset();
     saveBrowserLocation.mockReset();
     savePostalCodeLocation.mockReset();
+    previewLocationCoverage.mockReset();
+    previewLocationCoverage.mockResolvedValue({
+      regionId: 'campinas-sp',
+      coverageRadiusKm: 5,
+      activeEstablishmentCount: 2,
+      fallbackUsed: false,
+      establishments: [],
+    });
   });
 
   afterEach(() => {
@@ -252,12 +262,20 @@ describe('PublicLayout', () => {
     fireEvent.click(screen.getByRole('button', { name: /usar localizacao/i }));
 
     await waitFor(() =>
+      expect(previewLocationCoverage).toHaveBeenCalledWith({
+        latitude: -22.9,
+        longitude: -47.06,
+        coverageRadiusKm: 5,
+      }),
+    );
+    await waitFor(() =>
       expect(saveBrowserLocation).toHaveBeenCalledWith({
         latitude: -22.9,
         longitude: -47.06,
         coverageRadiusKm: 5,
       }),
     );
+    expect(document.body.textContent).toMatch(/Preview local: 2 lojas/i);
     await waitFor(() =>
       expect(document.body.textContent).toMatch(/capturada para preview/),
     );
@@ -292,12 +310,19 @@ describe('PublicLayout', () => {
     fireEvent.click(screen.getByRole('button', { name: /salvar cep/i }));
 
     await waitFor(() =>
+      expect(previewLocationCoverage).toHaveBeenCalledWith({
+        postalCode: '13010000',
+        coverageRadiusKm: 5,
+      }),
+    );
+    await waitFor(() =>
       expect(savePostalCodeLocation).toHaveBeenCalledWith({
         postalCode: '13010000',
         coverageRadiusKm: 5,
       }),
     );
     expect(document.body.textContent).toMatch(/nao prometem proximidade/i);
+    expect(document.body.textContent).toMatch(/Preview por CEP: 2 lojas/i);
     await waitFor(() =>
       expect(document.body.textContent).toMatch(/CEP salvo como fallback/i),
     );

--- a/web/src/public/public-shell.tsx
+++ b/web/src/public/public-shell.tsx
@@ -64,6 +64,7 @@ export function PublicLayout() {
     isAuthenticated,
     isBootstrapping,
     locationPreferences,
+    previewLocationCoverage,
     saveBrowserLocation,
     savePostalCodeLocation,
     setCityId,
@@ -80,6 +81,7 @@ export function PublicLayout() {
   >('manual');
   const [postalCode, setPostalCode] = useState('');
   const [locationFeedback, setLocationFeedback] = useState<string | null>(null);
+  const [locationPreview, setLocationPreview] = useState<string | null>(null);
   const activeCity = cityId
     ? (cities.find((city) => city.id === cityId) ?? null)
     : null;
@@ -124,23 +126,32 @@ export function PublicLayout() {
     setLocationPermissionState('requesting');
     navigator.geolocation.getCurrentPosition(
       (position) => {
-        void saveBrowserLocation({
-          latitude: position.coords.latitude,
-          longitude: position.coords.longitude,
-          coverageRadiusKm: 5,
-        })
-          .then(() => {
+        void (async () => {
+          try {
+            const preview = await previewLocationCoverage({
+              latitude: position.coords.latitude,
+              longitude: position.coords.longitude,
+              coverageRadiusKm: 5,
+            });
+            setLocationPreview(
+              `Preview local: ${preview.activeEstablishmentCount} lojas dentro de ${preview.coverageRadiusKm} km.`,
+            );
+            await saveBrowserLocation({
+              latitude: position.coords.latitude,
+              longitude: position.coords.longitude,
+              coverageRadiusKm: 5,
+            });
             setLocationPermissionState('allowed');
             setLocationFeedback(
               'Localizacao salva. Modos locais podem calcular distancia dentro do raio.',
             );
-          })
-          .catch(() => {
+          } catch {
             setLocationPermissionState('denied');
             setLocationFeedback(
               'Nao foi possivel salvar a localizacao. Use o CEP como fallback manual.',
             );
-          });
+          }
+        })();
       },
       () => {
         setLocationPermissionState('denied');
@@ -162,23 +173,31 @@ export function PublicLayout() {
       return;
     }
 
-    void savePostalCodeLocation({
-      postalCode: normalizedPostalCode,
-      coverageRadiusKm: 5,
-    })
-      .then(() => {
+    void (async () => {
+      try {
+        const preview = await previewLocationCoverage({
+          postalCode: normalizedPostalCode,
+          coverageRadiusKm: 5,
+        });
+        setLocationPreview(
+          `Preview por CEP: ${preview.activeEstablishmentCount} lojas ativas na cidade; sem calculo de distancia.`,
+        );
+        await savePostalCodeLocation({
+          postalCode: normalizedPostalCode,
+          coverageRadiusKm: 5,
+        });
         setLocationPermissionState('postal_fallback');
         setLocationFeedback(
           'CEP salvo como fallback. A cobertura fica por cidade ate uma localizacao precisa ser liberada.',
         );
-      })
-      .catch((error: unknown) => {
+      } catch (error: unknown) {
         setLocationFeedback(
           error instanceof Error
             ? error.message
             : 'Nao foi possivel salvar o CEP agora.',
         );
-      });
+      }
+    })();
   };
 
   return (
@@ -311,6 +330,11 @@ export function PublicLayout() {
             {locationFeedback ? (
               <div className="mt-2 rounded-md border border-border/70 bg-card px-2.5 py-1 text-xs text-muted-foreground">
                 {locationFeedback}
+              </div>
+            ) : null}
+            {locationPreview ? (
+              <div className="mt-2 rounded-md border border-teal-200 bg-teal-50 px-2.5 py-1 text-xs text-teal-950">
+                {locationPreview}
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## Summary
- Adds Chromium smoke coverage for receipt submission, admin receipt audit, manual release, and reward-pending state.
- Makes Playwright use an isolated strict dev-server port so smoke tests do not hit a stale local server.
- Shows location coverage preview before saving browser coordinates or CEP fallback, and improves admin queue readability for receipt jobs.

Refs #318

## Validation
- npm run e2e -- --project=chromium mvp-smoke.spec.ts
- npm test
- npm run build
- npm run lint