### PR TITLE
Improve mobile location receipt and trust evidence UX

### DIFF
--- a/mobile/lib/features/home/presentation/mobile_home_screen.dart
+++ b/mobile/lib/features/home/presentation/mobile_home_screen.dart
@@ -1511,8 +1511,12 @@ class _LocationPreviewCard extends StatelessWidget {
           const SizedBox(height: 8),
           Text(
             controller.message ??
-                'Quando houver localizacao salva, modos locais usam lojas dentro do raio. O modo cidade ignora distancia e compara a regiao selecionada.',
+                'Sem localizacao precisa, o app usa apenas a cidade e nao promete proximidade.',
             style: theme.textTheme.bodySmall,
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Modos locais exigem coordenadas salvas. O fallback manual por cidade compara ofertas da cidade inteira.',
           ),
           const SizedBox(height: 12),
           Wrap(
@@ -1553,6 +1557,11 @@ class _LocationPreviewCard extends StatelessWidget {
 
   String get _coverageSummary {
     final activePreference = controller.activePreference;
+    final preview = controller.coveragePreview;
+    if (preview != null) {
+      return 'Preview local: ${preview.activeEstablishmentCount} lojas dentro de ${preview.coverageRadiusKm.toStringAsFixed(0)} km.';
+    }
+
     if (activePreference != null &&
         (region == null || activePreference.regionSlug == region!.slug)) {
       return '${activePreference.activeEstablishmentCount} lojas dentro de ${activePreference.coverageRadiusKm.toStringAsFixed(0)} km.';
@@ -1561,7 +1570,7 @@ class _LocationPreviewCard extends StatelessWidget {
     if (region == null) {
       return 'Escolha uma cidade para carregar o preview local.';
     }
-    return '${region!.name} · ${region!.stateCode} · ${region!.activeEstablishmentCount} lojas candidatas na cidade.';
+    return '${region!.name} - ${region!.stateCode} - ${region!.activeEstablishmentCount} lojas candidatas na cidade.';
   }
 
   String _statusLabel(MobileLocationStatus status) {
@@ -1723,7 +1732,11 @@ class _StorePlanCard extends StatelessWidget {
                               style: theme.textTheme.titleMedium),
                           const SizedBox(height: 4),
                           Text(
-                              '${selection.quantity} ${selection.unit} • ${selection.confidenceLabel}'),
+                            '${selection.quantity} ${selection.unit} - ${_distanceLabel(selection)}',
+                          ),
+                          Text(_trustEvidenceLabel(selection)),
+                          if (selection.selectedVariantName != null)
+                            Text('Selecionado: ${selection.selectedVariantName}'),
                         ],
                       ),
                     ),
@@ -1736,6 +1749,27 @@ class _StorePlanCard extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  String _distanceLabel(OptimizationSelection selection) {
+    final distance = selection.distanceKm;
+    if (distance == null) {
+      return 'modo cidade';
+    }
+    return '${distance.toStringAsFixed(1)} km';
+  }
+
+  String _trustEvidenceLabel(OptimizationSelection selection) {
+    final source = selection.sourceLabel ?? 'fonte operacional';
+    final trustFactor = selection.trustFactor;
+    final trustText = trustFactor == null ? '' : ' - trust $trustFactor/100';
+    final evidenceCount = selection.trustEvidenceCount ?? 0;
+    final evidenceText = evidenceCount == 0
+        ? 'sem nota fiscal aceita'
+        : evidenceCount == 1
+            ? '1 nota fiscal aceita'
+            : '$evidenceCount notas fiscais aceitas';
+    return 'Confianca da oferta: $source$trustText - $evidenceText';
   }
 }
 
@@ -1762,13 +1796,34 @@ class _ReceiptSummaryCard extends StatelessWidget {
           if (summary.qrCodeUrl != null && summary.qrCodeUrl!.isNotEmpty)
             const Text('Origem: QR Code NFC-e'),
           Text('${summary.ingestedItems} itens ingeridos'),
-          Text('Fila: ${_processingLabel(summary.processingStatus)}'),
-          Text('Moderação: ${summary.moderationStatus}'),
-          Text('Reward: ${_rewardLabel(summary.rewardEligibilityStatus)}'),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: <Widget>[
+              _SignalChip(
+                label: 'Fila: ${_processingLabel(summary.processingStatus)}',
+                foreground: const Color(0xFF003EA8),
+                background: const Color(0xFFDDE7FF),
+              ),
+              _SignalChip(
+                label: 'Moderacao: ${_moderationLabel(summary.moderationStatus)}',
+                foreground: const Color(0xFF5C3B00),
+                background: const Color(0xFFFFF4D6),
+              ),
+              _SignalChip(
+                label: 'Reward: ${_rewardLabel(summary.rewardEligibilityStatus)}',
+                foreground: const Color(0xFF005C55),
+                background: const Color(0xFFEAF5F1),
+              ),
+            ],
+          ),
           if (summary.rewardPoints > 0 ||
               summary.rewardOptimizationTokens > 0)
             Text(
-              '${summary.rewardPoints} pontos · ${summary.rewardOptimizationTokens} tokens',
+              summary.rewardEligibilityStatus == 'granted'
+                  ? '${summary.rewardPoints} pontos - ${summary.rewardOptimizationTokens} creditos concedidos'
+                  : 'Previsto apos validacao: ${summary.rewardPoints} pontos - ${summary.rewardOptimizationTokens} creditos',
             ),
           Text('Motivo: ${summary.reviewReason}'),
           Text(summary.rewardMessage),
@@ -1810,6 +1865,23 @@ class _ReceiptSummaryCard extends StatelessWidget {
         return 'não elegível';
       case 'disabled':
         return 'desativado';
+      default:
+        return status;
+    }
+  }
+
+  String _moderationLabel(String status) {
+    switch (status) {
+      case 'accepted':
+        return 'aceita';
+      case 'duplicate':
+        return 'duplicada';
+      case 'pending':
+        return 'pendente';
+      case 'quarantined':
+        return 'em revisao';
+      case 'rejected':
+        return 'rejeitada';
       default:
         return status;
     }

--- a/mobile/lib/features/location/application/mobile_location_controller.dart
+++ b/mobile/lib/features/location/application/mobile_location_controller.dart
@@ -59,10 +59,12 @@ class MobileLocationController extends ChangeNotifier {
 
   MobileLocationStatus _status = MobileLocationStatus.manual;
   UserLocationPreferenceSummary? _activePreference;
+  LocationCoveragePreviewSummary? _coveragePreview;
   String? _message;
 
   MobileLocationStatus get status => _status;
   UserLocationPreferenceSummary? get activePreference => _activePreference;
+  LocationCoveragePreviewSummary? get coveragePreview => _coveragePreview;
   String? get message => _message;
 
   bool get isRequesting => _status == MobileLocationStatus.requesting;
@@ -99,6 +101,7 @@ class MobileLocationController extends ChangeNotifier {
     final capture = await _locationService.captureCurrentLocation();
     if (capture.reading == null || capture.status != MobileLocationStatus.allowed) {
       _activePreference = null;
+      _coveragePreview = null;
       _status = capture.status;
       _message = _messageForStatus(capture.status);
       notifyListeners();
@@ -107,6 +110,13 @@ class MobileLocationController extends ChangeNotifier {
 
     try {
       final reading = capture.reading!;
+      _coveragePreview = await _backendGateway.previewLocationCoverage(
+        accessToken: accessToken,
+        regionId: region.id,
+        latitude: reading.latitude,
+        longitude: reading.longitude,
+        coverageRadiusKm: coverageRadiusKm,
+      );
       final saved = await _backendGateway.upsertLocationPreference(
         accessToken: accessToken,
         regionId: region.id,
@@ -120,7 +130,7 @@ class MobileLocationController extends ChangeNotifier {
       _activePreference = saved;
       _status = MobileLocationStatus.allowed;
       _message =
-          '${saved.activeEstablishmentCount} lojas dentro de ${saved.coverageRadiusKm.toStringAsFixed(0)} km.';
+          'Preview local: ${_coveragePreview!.activeEstablishmentCount} lojas dentro de ${_coveragePreview!.coverageRadiusKm.toStringAsFixed(0)} km. Localizacao salva.';
     } catch (_) {
       _status = MobileLocationStatus.error;
       _message = 'Nao foi possivel salvar a localizacao agora.';

--- a/mobile/lib/features/optimization/domain/optimization_result.dart
+++ b/mobile/lib/features/optimization/domain/optimization_result.dart
@@ -98,6 +98,14 @@ class OptimizationSelection {
     required this.confidenceLabel,
     required this.decisionReason,
     required this.rejectedReason,
+    this.sourceLabel,
+    this.trustFactor,
+    this.trustLevel,
+    this.trustEvidenceCount,
+    this.trustFreshnessDays,
+    this.selectedVariantName,
+    this.selectedPackageLabel,
+    this.confidenceNotice,
   });
 
   final String itemName;
@@ -110,6 +118,14 @@ class OptimizationSelection {
   final String confidenceLabel;
   final String? decisionReason;
   final String? rejectedReason;
+  final String? sourceLabel;
+  final int? trustFactor;
+  final String? trustLevel;
+  final int? trustEvidenceCount;
+  final int? trustFreshnessDays;
+  final String? selectedVariantName;
+  final String? selectedPackageLabel;
+  final String? confidenceNotice;
 
   factory OptimizationSelection.fromJson(Map<String, dynamic> json) {
     return OptimizationSelection(
@@ -123,6 +139,14 @@ class OptimizationSelection {
       confidenceLabel: json['confidenceLabel'] as String? ?? 'medium',
       decisionReason: json['decisionReason'] as String?,
       rejectedReason: json['rejectedReason'] as String?,
+      sourceLabel: json['sourceLabel'] as String?,
+      trustFactor: json['trustFactor'] as int?,
+      trustLevel: json['trustLevel'] as String?,
+      trustEvidenceCount: json['trustEvidenceCount'] as int?,
+      trustFreshnessDays: json['trustFreshnessDays'] as int?,
+      selectedVariantName: json['selectedVariantName'] as String?,
+      selectedPackageLabel: json['selectedPackageLabel'] as String?,
+      confidenceNotice: json['confidenceNotice'] as String?,
     );
   }
 
@@ -138,6 +162,14 @@ class OptimizationSelection {
       'confidenceLabel': confidenceLabel,
       'decisionReason': decisionReason,
       'rejectedReason': rejectedReason,
+      'sourceLabel': sourceLabel,
+      'trustFactor': trustFactor,
+      'trustLevel': trustLevel,
+      'trustEvidenceCount': trustEvidenceCount,
+      'trustFreshnessDays': trustFreshnessDays,
+      'selectedVariantName': selectedVariantName,
+      'selectedPackageLabel': selectedPackageLabel,
+      'confidenceNotice': confidenceNotice,
     };
   }
 }

--- a/mobile/lib/features/optimization/presentation/multi_market_result_screen.dart
+++ b/mobile/lib/features/optimization/presentation/multi_market_result_screen.dart
@@ -182,8 +182,19 @@ class MultiMarketResultView extends StatelessWidget {
                                 )
                               : null,
                           title: Text(selection.itemName),
-                          subtitle: Text(
-                            '${selection.quantity} ${selection.unit} - ${_brandRuleLabel(draftItem)} - ${_distanceLabel(selection)} - confianca ${selection.confidenceLabel}',
+                          subtitle: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: <Widget>[
+                              Text(
+                                '${selection.quantity} ${selection.unit} - ${_brandRuleLabel(draftItem)} - ${_distanceLabel(selection)}',
+                              ),
+                              if (_variantLabel(selection).isNotEmpty)
+                                Text(_variantLabel(selection)),
+                              Text(_trustEvidenceLabel(selection)),
+                              if (selection.confidenceNotice != null &&
+                                  selection.confidenceNotice!.isNotEmpty)
+                                Text(_confidenceNoticeLabel(selection)),
+                            ],
                           ),
                           trailing: Text(_formatCurrency(selection.subtotal)),
                         );
@@ -245,5 +256,45 @@ class MultiMarketResultView extends StatelessWidget {
       return 'modo cidade';
     }
     return '${distance.toStringAsFixed(1)} km';
+  }
+
+  String _variantLabel(OptimizationSelection selection) {
+    final variant = selection.selectedVariantName;
+    if (variant == null || variant.isEmpty) {
+      return '';
+    }
+    final package = selection.selectedPackageLabel;
+    if (package == null || package.isEmpty || variant.contains(package)) {
+      return 'Selecionado: $variant';
+    }
+    return 'Selecionado: $variant - $package';
+  }
+
+  String _trustEvidenceLabel(OptimizationSelection selection) {
+    final source = selection.sourceLabel ?? 'fonte operacional';
+    final trustFactor = selection.trustFactor;
+    final trustText = trustFactor == null ? '' : ' - trust $trustFactor/100';
+    final evidenceCount = selection.trustEvidenceCount ?? 0;
+    final evidenceText = evidenceCount == 0
+        ? 'sem nota fiscal aceita ainda'
+        : evidenceCount == 1
+            ? '1 nota fiscal aceita'
+            : '$evidenceCount notas fiscais aceitas';
+    final freshness = selection.trustFreshnessDays;
+    final freshnessText = freshness == null
+        ? ''
+        : freshness == 0
+            ? ' - validado hoje'
+            : ' - validado ha ${freshness}d';
+
+    return 'Confianca da oferta: $source$trustText - $evidenceText$freshnessText';
+  }
+
+  String _confidenceNoticeLabel(OptimizationSelection selection) {
+    final notice = selection.confidenceNotice ?? selection.confidenceLabel;
+    if (notice.toLowerCase().contains('low')) {
+      return 'Alerta: evidencia de preco com baixa confianca.';
+    }
+    return 'Alerta: $notice';
   }
 }

--- a/mobile/lib/features/shared/data/pricely_backend_gateway.dart
+++ b/mobile/lib/features/shared/data/pricely_backend_gateway.dart
@@ -85,6 +85,30 @@ class PricelyBackendGateway {
     return UserLocationPreferenceSummary.fromJson(response);
   }
 
+  Future<LocationCoveragePreviewSummary> previewLocationCoverage({
+    required String accessToken,
+    required String regionId,
+    double? latitude,
+    double? longitude,
+    String? postalCode,
+    double coverageRadiusKm = 5,
+  }) async {
+    final response = await _apiClient.post<Map<String, dynamic>>(
+      '/locations/coverage-preview',
+      accessToken: accessToken,
+      body: <String, dynamic>{
+        'regionId': regionId,
+        'coverageRadiusKm': coverageRadiusKm,
+        if (latitude != null) 'latitude': latitude,
+        if (longitude != null) 'longitude': longitude,
+        if (postalCode != null && postalCode.trim().isNotEmpty)
+          'postalCode': postalCode.trim(),
+      },
+    );
+    return LocationCoveragePreviewSummary.fromJson(response);
+  }
+
+
   List<Map<String, dynamic>> _parseManualReceiptItems(String? rawReceipt) {
     if (rawReceipt == null || rawReceipt.trim().isEmpty) {
       return <Map<String, dynamic>>[];
@@ -393,6 +417,16 @@ class PricelyBackendGateway {
               selection['confidenceNotice'] as String? ?? 'confirmado',
           decisionReason: selection['decisionReason'] as String?,
           rejectedReason: selection['rejectedReason'] as String?,
+          sourceLabel: selection['sourceLabel'] as String?,
+          trustFactor: (selection['trustFactor'] as num?)?.toInt(),
+          trustLevel: selection['trustLevel'] as String?,
+          trustEvidenceCount:
+              (selection['trustEvidenceCount'] as num?)?.toInt(),
+          trustFreshnessDays:
+              (selection['trustFreshnessDays'] as num?)?.toInt(),
+          selectedVariantName: selection['selectedVariantName'] as String?,
+          selectedPackageLabel: selection['selectedPackageLabel'] as String?,
+          confidenceNotice: selection['confidenceNotice'] as String?,
         ),
       );
     }
@@ -664,6 +698,30 @@ class UserLocationPreferenceSummary {
           (json['activeEstablishmentCount'] as num? ?? 0).toInt(),
       isDefault: json['isDefault'] as bool? ?? false,
       locationSource: json['locationSource'] as String? ?? 'manual',
+    );
+  }
+}
+
+class LocationCoveragePreviewSummary {
+  LocationCoveragePreviewSummary({
+    required this.regionId,
+    required this.coverageRadiusKm,
+    required this.activeEstablishmentCount,
+    required this.fallbackUsed,
+  });
+
+  final String regionId;
+  final double coverageRadiusKm;
+  final int activeEstablishmentCount;
+  final bool fallbackUsed;
+
+  factory LocationCoveragePreviewSummary.fromJson(Map<String, dynamic> json) {
+    return LocationCoveragePreviewSummary(
+      regionId: json['regionId'] as String? ?? '',
+      coverageRadiusKm: (json['coverageRadiusKm'] as num? ?? 5).toDouble(),
+      activeEstablishmentCount:
+          (json['activeEstablishmentCount'] as num? ?? 0).toInt(),
+      fallbackUsed: json['fallbackUsed'] as bool? ?? false,
     );
   }
 }

--- a/mobile/test/unit/features/location/mobile_location_controller_test.dart
+++ b/mobile/test/unit/features/location/mobile_location_controller_test.dart
@@ -17,6 +17,7 @@ void main() {
     final cacheService = LocalCacheService(InMemoryKeyValueStore());
     await cacheService.saveAuthToken('token-123');
     Map<String, dynamic>? savedLocationPayload;
+    Map<String, dynamic>? previewPayload;
 
     final backendGateway = PricelyBackendGateway(
       HttpApiClient(
@@ -53,6 +54,20 @@ void main() {
             );
           }
 
+          if (request.url.path == '/locations/coverage-preview') {
+            previewPayload = jsonDecode(request.body) as Map<String, dynamic>;
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'regionId': 'region-1',
+                'coverageRadiusKm': 5,
+                'activeEstablishmentCount': 2,
+                'fallbackUsed': false,
+                'establishments': <dynamic>[],
+              }),
+              200,
+            );
+          }
+
           return http.Response('{}', 404);
         }),
       ),
@@ -76,8 +91,12 @@ void main() {
     await controller.captureAndSave();
 
     expect(controller.status, MobileLocationStatus.allowed);
+    expect(controller.coveragePreview?.activeEstablishmentCount, 2);
+    expect(controller.message, contains('Preview local: 2 lojas'));
     expect(controller.activePreference?.id, 'location-1');
     expect(controller.preferenceIdForRegionSlug('sao-paulo-sp'), 'location-1');
+    expect(previewPayload?['regionId'], 'region-1');
+    expect(previewPayload?['latitude'], -23.56);
     expect(savedLocationPayload?['regionId'], 'region-1');
     expect(savedLocationPayload?['latitude'], -23.56);
     expect(savedLocationPayload?['longitude'], -46.65);

--- a/mobile/test/unit/features/receipts/receipt_backend_gateway_test.dart
+++ b/mobile/test/unit/features/receipts/receipt_backend_gateway_test.dart
@@ -7,6 +7,44 @@ import 'package:pricely_mobile/core/networking/http_api_client.dart';
 import 'package:pricely_mobile/features/shared/data/pricely_backend_gateway.dart';
 
 void main() {
+  test('requests location coverage preview before local optimization claims', () async {
+    Map<String, dynamic>? capturedBody;
+    String? authorizationHeader;
+    final gateway = PricelyBackendGateway(
+      HttpApiClient(
+        client: MockClient((request) async {
+          expect(request.url.path, '/locations/coverage-preview');
+          authorizationHeader = request.headers['authorization'];
+          capturedBody = jsonDecode(request.body) as Map<String, dynamic>;
+
+          return http.Response(
+            jsonEncode(<String, dynamic>{
+              'regionId': 'region-1',
+              'coverageRadiusKm': 5,
+              'activeEstablishmentCount': 3,
+              'fallbackUsed': false,
+            }),
+            200,
+          );
+        }),
+      ),
+    );
+
+    final preview = await gateway.previewLocationCoverage(
+      accessToken: 'token-123',
+      regionId: 'region-1',
+      latitude: -23.56,
+      longitude: -46.65,
+      coverageRadiusKm: 5,
+    );
+
+    expect(authorizationHeader, 'Bearer token-123');
+    expect(capturedBody?['regionId'], 'region-1');
+    expect(capturedBody?['latitude'], -23.56);
+    expect(preview.activeEstablishmentCount, 3);
+    expect(preview.coverageRadiusKm, 5);
+  });
+
   test('submits qr code receipt to backend with manual-release feedback', () async {
     Map<String, dynamic>? capturedBody;
     String? authorizationHeader;

--- a/mobile/test/widget/features/optimization/multi_market_result_screen_test.dart
+++ b/mobile/test/widget/features/optimization/multi_market_result_screen_test.dart
@@ -56,6 +56,14 @@ void main() {
               confidenceLabel: 'high',
               decisionReason: 'selected_confirmed_offer',
               rejectedReason: null,
+              sourceLabel: 'Recibo de usuario',
+              trustFactor: 82,
+              trustLevel: 'high',
+              trustEvidenceCount: 4,
+              trustFreshnessDays: 3,
+              selectedVariantName: 'Arroz tipo 1 1kg',
+              selectedPackageLabel: '1 kg',
+              confidenceNotice: 'Preco observado em recibo recente.',
             ),
           ],
         ),
@@ -99,6 +107,13 @@ void main() {
     expect(find.textContaining('Modos locais usam a localizacao salva'), findsOneWidget);
     expect(find.textContaining('1.2 km'), findsOneWidget);
     expect(find.textContaining('variante exata: Camil · Arroz'), findsOneWidget);
+    expect(find.textContaining('Selecionado: Arroz tipo 1 1kg'), findsOneWidget);
+    expect(
+      find.textContaining('Confianca da oferta: Recibo de usuario'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('trust 82/100'), findsOneWidget);
+    expect(find.textContaining('4 notas fiscais aceitas'), findsOneWidget);
     await tester.scrollUntilVisible(find.text('- Leite vegetal'), 220);
     expect(find.text('- Leite vegetal'), findsOneWidget);
   });

--- a/mobile/test/widget/features/optimization/multi_market_result_screen_test.dart
+++ b/mobile/test/widget/features/optimization/multi_market_result_screen_test.dart
@@ -100,7 +100,6 @@ void main() {
 
     expect(find.text('Lista da semana'), findsOneWidget);
     expect(find.text('Mercado Azul'), findsOneWidget);
-    expect(find.text('Super Verde'), findsOneWidget);
     expect(find.textContaining('Economia estimada'), findsOneWidget);
     expect(find.text('Localização e raio'), findsOneWidget);
     expect(find.text('Raio local padrao: 5 km.'), findsOneWidget);
@@ -114,6 +113,8 @@ void main() {
     );
     expect(find.textContaining('trust 82/100'), findsOneWidget);
     expect(find.textContaining('4 notas fiscais aceitas'), findsOneWidget);
+    await tester.scrollUntilVisible(find.text('Super Verde'), 220);
+    expect(find.text('Super Verde'), findsOneWidget);
     await tester.scrollUntilVisible(find.text('- Leite vegetal'), 220);
     expect(find.text('- Leite vegetal'), findsOneWidget);
   });

--- a/mobile/test/widget/features/regions/mobile_home_public_regions_test.dart
+++ b/mobile/test/widget/features/regions/mobile_home_public_regions_test.dart
@@ -58,7 +58,7 @@ void main() {
     );
     expect(find.text('Localização e raio'), findsOneWidget);
     expect(find.text('Raio local padrao: 5 km.'), findsOneWidget);
-    expect(find.textContaining('modos locais usam lojas dentro do raio'), findsOneWidget);
+    expect(find.textContaining('nao promete proximidade'), findsOneWidget);
   });
 
   testWidgets('renders active city offers and opens the offer detail sheet', (tester) async {


### PR DESCRIPTION
## Summary
- Adds mobile coverage-preview contract support and calls it before saving current-location preferences.
- Updates mobile location copy to avoid proximity claims until coordinates are saved.
- Enriches mobile optimization result cards with source labels, trust factor, receipt evidence count, freshness, selected variant, and confidence notices.
- Improves mobile receipt summary states for queue, moderation, and reward-pending outcomes without promising rewards before validation.
- Adds focused unit/widget coverage for coverage preview and trust evidence rendering.

Refs #320

## Validation
- git diff --check
- Could not run Flutter locally: flutter/dart SDK is not available in this shell PATH. CI should run mobile analyze/tests.