### PR TITLE
Add AI screen generation prompts

### DIFF
--- a/docs/design-system/screen-prompts/00-shared-context.md
+++ b/docs/design-system/screen-prompts/00-shared-context.md
@@ -1,0 +1,68 @@
+# Shared Prompt Context
+
+Paste this before any screen-specific prompt.
+
+```text
+You are a senior product designer creating implementation-ready UI screens for
+Pricely.
+
+Product:
+Pricely is an evidence-first grocery savings app. It helps shoppers choose a city,
+build a grocery list, optimize the list across stores, shop with a checklist, and
+contribute receipts. Admins manage cities, stores, catalog products, offers, receipts,
+queues, users, and operational trust.
+
+Design thesis:
+The UI must feel practical, local, compact, trustworthy, and evidence-driven. It must
+not feel like a generic SaaS template, a supermarket flyer, a decorative marketing
+page, or a raw admin console.
+
+Canonical visual system:
+- Primary: deep teal (#0F766E)
+- Savings: green/lime (#65A30D)
+- Location/info: blue (#2563EB)
+- Warning/pending/stale: amber (#D97706)
+- Critical/rejected/failed: coral/red (#E11D48)
+- Background: off-white green-gray (#F7FAF8)
+- Raised surface: white (#FFFFFF)
+- Default radius: 8px
+- Use pills only for status badges
+- Use tabular numbers for prices, savings, counts, queue metrics, and trust scores
+- Use familiar line icons
+- No decorative orbs, bokeh, abstract gradients, or purple/blue SaaS gradients
+- No cards inside cards
+- Cards are for repeated entities, forms, modals, and framed tools only
+
+Content rules:
+- Use PT-BR interface copy.
+- Use "Confianca da oferta" for shopper-facing trust.
+- Use "Origem operacional" when price evidence is seed/admin/manual.
+- Use "Validado por nota fiscal" when receipt evidence exists.
+- Never show "0 notas fiscais confiaveis".
+- Do not promise reward credits before validation.
+- Do not imply nearby-store accuracy unless location and radius coverage are explicit.
+
+Interaction rules:
+- Generate only the requested screen.
+- Do not create the entire flow.
+- Do not mix web, mobile, and admin in one canvas.
+- Include loading, empty, error, permission, and partial-data states when relevant.
+- Icon-only actions need accessible labels/tooltips.
+- Destructive or irreversible actions require confirmation.
+- Main actions must be obvious and reachable.
+- Text must not overflow containers on mobile or desktop.
+
+Implementation context:
+- Web app: React + Vite + Tailwind + shadcn/ui + lucide icons.
+- Mobile app: Flutter.
+- Admin dashboard: React + Vite + Tailwind + shadcn/ui.
+- Repo source of truth lives in docs/design-system/.
+
+Deliverable:
+Create a polished, implementation-ready screen. Also list:
+1. Components used.
+2. Important states.
+3. Responsive behavior.
+4. Implementation notes for Codex.
+```
+

--- a/docs/design-system/screen-prompts/README.md
+++ b/docs/design-system/screen-prompts/README.md
@@ -1,0 +1,44 @@
+# AI Screen Generation Prompts
+
+Use these prompts to create visual screens in ChatGPT, Stitch, Figma, Claude Design,
+or another UI generation tool.
+
+Recommended workflow:
+
+1. Open `00-shared-context.md`.
+2. Copy the shared context into the design tool.
+3. Copy one screen prompt from `web-public/`, `mobile/`, or `admin-dashboard/`.
+4. Generate only that one screen.
+5. Review the result against `docs/design-system/`.
+6. Implement approved screens in Codex with tests.
+
+Do not ask a design tool to generate the whole product at once. Generate components
+and screens in small batches so the visual system stays consistent.
+
+## Folders
+
+- `web-public/`: shopper web app screens.
+- `mobile/`: Flutter shopper app screens.
+- `admin-dashboard/`: operational dashboard screens.
+
+## Output Expectations
+
+Ask the design tool for:
+
+- one screen only
+- light and dark mode notes
+- loading, empty, error, and partial-data states where relevant
+- component names
+- responsive notes
+- implementation notes that map to the repo
+
+## Approved Source Of Truth
+
+Use these docs as the source of truth:
+
+- `docs/design-system/pricely-design-system.md`
+- `docs/design-system/ui-inventory.md`
+- `docs/design-system/web-public-guidelines.md`
+- `docs/design-system/mobile-guidelines.md`
+- `docs/design-system/admin-dashboard-guidelines.md`
+

--- a/docs/design-system/screen-prompts/admin-dashboard/01-admin-overview.md
+++ b/docs/design-system/screen-prompts/admin-dashboard/01-admin-overview.md
@@ -1,0 +1,54 @@
+# Prompt: Admin Overview
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely admin dashboard overview.
+
+Viewport:
+- Desktop admin, 1440px wide.
+- Include tablet/mobile responsive notes.
+
+Scenario:
+- Admin signed in.
+- Active users: 3.
+- Active regions: 2.
+- Active offers: 42.
+- Queued jobs: 2.
+- Failed jobs: 2.
+- Pending receipts: 3.
+- Low-trust offers: 5.
+
+Screen goal:
+Make the admin overview an operational command center, not just a metrics page.
+
+Required content:
+- Admin sidebar.
+- Operator identity.
+- Action queue at top.
+- Severity grouped cards: critical, warning, info, healthy.
+- Queue health summary.
+- Receipt moderation summary.
+- Offer trust/freshness summary.
+- City coverage summary.
+- Metrics panel below action queue.
+
+Required states:
+- healthy/no action needed
+- backend loading skeleton
+- metrics unavailable
+- high severity failure
+
+Visual rules:
+- Dense but breathable.
+- Metrics support action hierarchy.
+- Raw IDs hidden behind detail affordance.
+- Status uses icon + text + color.
+
+Implementation notes:
+Map likely components to:
+- web/src/dashboard/dashboard-home.tsx
+- web/src/dashboard/admin-shell.tsx
+- web/src/dashboard/dashboard-pages.tsx
+```
+

--- a/docs/design-system/screen-prompts/admin-dashboard/02-admin-receipts.md
+++ b/docs/design-system/screen-prompts/admin-dashboard/02-admin-receipts.md
@@ -1,0 +1,50 @@
+# Prompt: Admin Receipt Processing
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely admin receipt processing queue.
+
+Viewport:
+- Desktop admin, 1440px wide.
+- Include responsive notes for tablet and mobile web.
+
+Scenario:
+- 6 receipt records.
+- States include waiting manual release, pending review, duplicate, quarantined,
+  rejected, accepted.
+- One receipt has reward eligible pending.
+- One receipt has low extraction confidence.
+
+Screen goal:
+Help an operator decide which receipts need release, reprocess, rejection, or review.
+
+Required content:
+- Admin sidebar.
+- Top action summary.
+- Receipt queue table/card hybrid.
+- Status columns: processing, moderation, reward.
+- Quality indicators: line count, match confidence, useful data ratio.
+- Primary actions: liberar processamento, reprocessar, rejeitar.
+- Detail drawer preview with extracted payload and line items.
+- Technical IDs hidden in disclosure.
+
+Required states:
+- no receipts
+- release action success
+- release action failure
+- destructive reject confirmation
+- low confidence detail
+
+Visual rules:
+- Actionable rows before raw data.
+- Use severity badges.
+- Destructive actions require confirmation.
+- Keep reward copy pending-safe.
+
+Implementation notes:
+Map likely components to:
+- web/src/dashboard/dashboard-pages.tsx
+- web/src/dashboard/dashboard-pages.spec.tsx
+```
+

--- a/docs/design-system/screen-prompts/admin-dashboard/03-admin-catalog-offers.md
+++ b/docs/design-system/screen-prompts/admin-dashboard/03-admin-catalog-offers.md
@@ -1,0 +1,50 @@
+# Prompt: Admin Catalog And Offers
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely admin catalog and offers management.
+
+Viewport:
+- Desktop admin, 1440px wide.
+- Include responsive notes.
+
+Scenario:
+- Catalog has products with variants.
+- Some products are missing images.
+- Some variants have stale or low-trust offers.
+- Offers include receipt-derived and admin-seeded sources.
+
+Screen goal:
+Make product, variant, and offer quality easy to inspect and fix.
+
+Required content:
+- Admin sidebar.
+- Product search/filter.
+- Product list with image status, variant count, active offer count.
+- Variant detail panel/tab.
+- Offer rows with store, price, source, trust, freshness.
+- Quality flags: missing image, stale offer, low confidence.
+- Actions: edit product, add variant, add offer, review offer.
+- Technical metadata hidden behind disclosure.
+
+Required states:
+- empty catalog
+- no variants
+- long variant list
+- stale offer warning
+- low-trust offer warning
+- save validation error
+
+Visual rules:
+- Do not show raw IDs as primary labels.
+- Variant images visible where available.
+- Long lists searchable/collapsible.
+- Tables collapse to cards on small widths.
+
+Implementation notes:
+Map likely components to:
+- web/src/dashboard/dashboard-pages.tsx
+- web/src/app/api.ts
+```
+

--- a/docs/design-system/screen-prompts/admin-dashboard/04-admin-queue-job-detail.md
+++ b/docs/design-system/screen-prompts/admin-dashboard/04-admin-queue-job-detail.md
@@ -1,0 +1,53 @@
+# Prompt: Admin Queue Job Detail
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely admin queue job detail.
+
+Viewport:
+- Desktop admin, 1366px wide.
+- Include responsive notes.
+
+Scenario:
+- Queue: receipts.
+- Job type: receipt.extract.
+- Status: failed after retry.
+- Resource: receipt for Mercado Centro.
+- Owner: Cliente Pricely.
+- Failure reason available.
+- Related receipt moderation status: quarantined.
+
+Screen goal:
+Let an operator understand job failure context and choose the right next action.
+
+Required content:
+- Admin sidebar.
+- Job status summary.
+- Human-readable owner/resource context.
+- Timeline: queued, running, failed, retrying.
+- Failure reason panel.
+- Related receipt/card.
+- Actions: retry, open receipt, mark reviewed.
+- Technical payload/log disclosure.
+- Correlation/debug metadata hidden until expanded.
+
+Required states:
+- queued job
+- running job
+- completed job
+- failed job
+- retry action success/failure
+
+Visual rules:
+- Human-readable context before raw job IDs.
+- Critical severity for failed state.
+- Technical details remain accessible but secondary.
+- Use tabular numbers for attempts/timing.
+
+Implementation notes:
+Map likely components to:
+- web/src/dashboard/dashboard-pages.tsx
+- web/src/dashboard/dashboard-pages.spec.tsx
+```
+

--- a/docs/design-system/screen-prompts/mobile/01-mobile-home.md
+++ b/docs/design-system/screen-prompts/mobile/01-mobile-home.md
@@ -1,0 +1,52 @@
+# Prompt: Mobile Home
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely mobile app home.
+
+Viewport:
+- Native mobile viewport, 390px wide.
+- Flutter implementation target.
+
+Scenario:
+- User is signed in.
+- City: Sao Paulo, SP.
+- Localizacao salva.
+- Coverage preview: 8 stores inside 5 km.
+- Active list: "Compra da semana", 12 items.
+- Latest savings: R$ 18,40.
+- Receipt: waiting manual release.
+
+Screen goal:
+Make the home screen a next-action hub for shopping, not a marketing page.
+
+Required content:
+- Top account/city summary.
+- Compact local coverage preview.
+- Next action card.
+- Active list continuation.
+- Latest optimization/savings summary.
+- Receipt status summary.
+- Bottom navigation.
+- Primary thumb-zone CTA.
+
+Required states:
+- location denied
+- no city selected
+- no active list
+- receipt processing
+- offline/backend error
+
+Visual rules:
+- Use mobile-native spacing and touch targets.
+- Avoid long prose blocks.
+- Use structured evidence/status chips.
+- Keep text inside containers at 390px.
+
+Implementation notes:
+Map likely components to:
+- mobile/lib/features/home/presentation/mobile_home_screen.dart
+- mobile/lib/core/widgets/app_scaffold.dart
+```
+

--- a/docs/design-system/screen-prompts/mobile/02-mobile-list-checklist.md
+++ b/docs/design-system/screen-prompts/mobile/02-mobile-list-checklist.md
@@ -1,0 +1,51 @@
+# Prompt: Mobile List And Checklist
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely mobile list/checklist screen.
+
+Viewport:
+- Native mobile viewport, 390px wide.
+- Flutter implementation target.
+
+Scenario:
+- List: "Compra da semana".
+- 12 items.
+- User is in shopping mode.
+- Items are grouped by store after optimization.
+- Some items are pending, some purchased.
+- One item has a price mismatch report.
+
+Screen goal:
+Let the shopper use the phone in-store with minimum friction.
+
+Required content:
+- Compact list and city context.
+- Store group header.
+- Item cards with purchased checkbox/toggle.
+- Selected variant, expected price, source/confidence chip.
+- Price mismatch/report action.
+- Completion progress.
+- Sticky bottom CTA: concluir compra.
+- Optional paid total field when completed.
+
+Required states:
+- list not optimized
+- all purchased
+- save failure
+- price mismatch form open
+- no network
+
+Visual rules:
+- No desktop table.
+- Stable row/card dimensions.
+- One-handed use.
+- Use status color plus text/icon.
+
+Implementation notes:
+Map likely components to:
+- mobile/lib/features/shopping_lists/presentation/shopping_list_screen.dart
+- mobile/lib/features/home/presentation/mobile_home_screen.dart
+```
+

--- a/docs/design-system/screen-prompts/mobile/03-mobile-optimization-result.md
+++ b/docs/design-system/screen-prompts/mobile/03-mobile-optimization-result.md
@@ -1,0 +1,52 @@
+# Prompt: Mobile Optimization Result
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely mobile optimization result.
+
+Viewport:
+- Native mobile viewport, 390px wide.
+- Flutter implementation target.
+
+Scenario:
+- Total estimated cost: R$ 142,80.
+- Estimated savings: R$ 18,40.
+- Mode: menor preco perto de mim.
+- Local radius: 5 km.
+- Store plan includes two stores.
+- First item has trust score 82/100 and 4 accepted receipts.
+- One item unavailable.
+
+Screen goal:
+Show the optimized plan and evidence in a compact mobile-native format.
+
+Required content:
+- Summary top block with total, savings, mode, coverage.
+- Local radius/coverage note.
+- Store plan cards.
+- Item cards with selected variant, quantity, price, distance.
+- Evidence block: Confianca da oferta, source, trust score, receipt count, freshness.
+- Unavailable item section.
+- Sticky CTA: abrir checklist.
+- Secondary action: recalcular.
+
+Required states:
+- queued/running
+- stale result
+- low confidence
+- no local coverage
+- failed optimization
+
+Visual rules:
+- Avoid long paragraph evidence.
+- Use compact chips and rows.
+- Distance only when available.
+- Prices use tabular numbers.
+
+Implementation notes:
+Map likely components to:
+- mobile/lib/features/optimization/presentation/multi_market_result_screen.dart
+- mobile/lib/features/optimization/domain/optimization_result.dart
+```
+

--- a/docs/design-system/screen-prompts/mobile/04-mobile-receipt-submission.md
+++ b/docs/design-system/screen-prompts/mobile/04-mobile-receipt-submission.md
@@ -1,0 +1,54 @@
+# Prompt: Mobile Receipt Submission
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely mobile receipt submission.
+
+Viewport:
+- Native mobile viewport, 390px wide.
+- Flutter implementation target.
+
+Scenario:
+- User finished shopping.
+- App offers QR/NFC-e URL submission and manual item entry.
+- Submitted receipt waits for manual release.
+- Reward is pending validation.
+
+Screen goal:
+Make receipt contribution feel useful and honest before reward is granted.
+
+Required content:
+- Entry tabs or segmented control: QR/NFC-e, manual.
+- QR/NFC-e URL field.
+- Manual store/date/CNPJ fields.
+- Manual item rows.
+- Submission status timeline:
+  - enviada
+  - aguardando liberacao manual
+  - liberada para processamento
+  - validada
+- Reward pending state.
+- Explanation that credits are granted only after validation.
+- Sticky submit CTA.
+
+Required states:
+- invalid URL
+- manual field error
+- duplicate receipt
+- rejected receipt
+- low confidence
+- reward granted
+
+Visual rules:
+- Do not promise reward upfront.
+- Use receipt/moderation/reward chips.
+- Keep form labels visible.
+- Error messages near fields.
+
+Implementation notes:
+Map likely components to:
+- mobile/lib/features/receipts/presentation/receipt_submission_screen.dart
+- mobile/lib/features/receipts/application/receipt_flow_controller.dart
+```
+

--- a/docs/design-system/screen-prompts/web-public/01-public-home.md
+++ b/docs/design-system/screen-prompts/web-public/01-public-home.md
@@ -1,0 +1,54 @@
+# Prompt: Public Web Home
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely public web home for a signed-in shopper.
+
+Viewport:
+- Desktop-first web screen, 1440px wide.
+- Include responsive notes for tablet and mobile.
+
+Scenario:
+- User is signed in as a customer.
+- Selected city: Sao Paulo, SP.
+- Localizacao salva with 5 km coverage preview.
+- Coverage preview: 8 active stores inside radius.
+- User has one active list: "Compra da semana", 12 items.
+- Latest optimization saved R$ 18,40.
+- One receipt is waiting manual release.
+
+Screen goal:
+Make the first screen answer "what should I do next?" without becoming a marketing
+landing page.
+
+Required content:
+- Public app shell/header with brand, city/location context, account state.
+- Compact next-best-action strip.
+- Active list continuation card.
+- Local coverage preview.
+- Offer preview section with 3 grouped offer cards.
+- Receipt status card with "Aguardando liberacao manual".
+- Savings summary using tabular numbers.
+- Clear primary CTA: continue list or optimize.
+
+Required states to include as small side annotations or variants:
+- no selected city
+- location permission denied
+- no stores in radius
+- backend loading skeleton
+
+Visual rules:
+- Functional app screen, not marketing hero.
+- No oversized decorative hero.
+- Use cards for repeated offers/list/receipt only.
+- Keep city/location context compact.
+- Use evidence/status badges with icon + text.
+
+Implementation notes:
+Map likely components to:
+- web/src/public/public-pages.tsx
+- web/src/public/public-shell.tsx
+- web/src/components/ui/*
+```
+

--- a/docs/design-system/screen-prompts/web-public/02-list-editor.md
+++ b/docs/design-system/screen-prompts/web-public/02-list-editor.md
@@ -1,0 +1,58 @@
+# Prompt: Public Web List Editor
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely public web list editor.
+
+Viewport:
+- Desktop web, 1366px wide.
+- Include mobile behavior notes for 390px width.
+
+Scenario:
+- User is signed in.
+- City: Sao Paulo, SP.
+- List title: "Compra da semana".
+- Items:
+  - Arroz tipo 1, quantity 2, any variant
+  - Cafe torrado, quantity 1, preferred brand: Melitta
+  - Leite integral, quantity 6, exact variant selected
+- Catalog search is open with product suggestions.
+- One item has partial match warning.
+
+Screen goal:
+Make adding grocery items and brand rules fast, clear, and ready for optimization.
+
+Required content:
+- Compact city/list context.
+- List title field.
+- Catalog-backed product search.
+- Quantity/unit controls.
+- Brand rule selector: qualquer variante, marcas preferidas, variante exata.
+- Item cards with image/fallback, quantity, brand rule, match confidence.
+- Inline validation near fields.
+- Sticky action area on small screens.
+- Primary CTA: salvar e otimizar.
+- Secondary CTA: salvar rascunho.
+
+Required states:
+- empty list
+- product search loading
+- no catalog match
+- partial match
+- save failed
+
+Visual rules:
+- No wide dense table for shopper UI.
+- Use stable item card dimensions.
+- Keep primary action reachable.
+- Use warning color only for partial/uncertain match.
+
+Implementation notes:
+Map likely components to:
+- web/src/public/public-pages.tsx
+- web/src/components/ui/input.tsx
+- web/src/components/ui/select.tsx
+- web/src/components/ui/card.tsx
+```
+

--- a/docs/design-system/screen-prompts/web-public/03-optimization-result.md
+++ b/docs/design-system/screen-prompts/web-public/03-optimization-result.md
@@ -1,0 +1,65 @@
+# Prompt: Public Web Optimization Result
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely public web optimization result.
+
+Viewport:
+- Desktop web, 1440px wide.
+- Include responsive notes for mobile stacked cards.
+
+Scenario:
+- List: "Compra da semana".
+- Mode: menor preco perto de mim.
+- Total estimated cost: R$ 142,80.
+- Estimated savings: R$ 18,40 versus next eligible alternatives.
+- Coverage: partial, 10 of 12 items matched.
+- Local coverage: 8 stores inside 5 km.
+- Two store stops.
+- One unavailable item.
+
+Required selected item evidence:
+- Product: Arroz tipo 1
+- Requested rule: qualquer variante
+- Selected variant: Camil Arroz tipo 1 1kg
+- Store: Mercado Centro, Centro
+- Price: R$ 7,90
+- Source: Recibo de usuario
+- Trust: 82/100, alta
+- Evidence: 4 notas fiscais aceitas
+- Freshness: validado ha 3d
+- Confidence notice: preco observado em recibo recente
+
+Screen goal:
+Explain the recommendation without overwhelming the shopper.
+
+Required content:
+- Result summary with total, savings, coverage, stores.
+- Mode and local coverage context.
+- Store plan cards.
+- Item-level price rows.
+- Evidence module for each selected item.
+- Unavailable items section.
+- Actions: abrir checklist, reportar preco, enviar nota, recalcular.
+
+Required states:
+- queued/running result
+- stale result
+- low-confidence item
+- no local coverage
+- failed optimization
+
+Visual rules:
+- Do not show naked prices without source/freshness/trust.
+- Separate requested brand rule from selected variant.
+- Use "Confianca da oferta".
+- Use tabular numbers.
+
+Implementation notes:
+Map likely components to:
+- web/src/public/public-pages.tsx
+- web/src/app/types.ts
+- web/e2e/mvp-smoke.spec.ts
+```
+

--- a/docs/design-system/screen-prompts/web-public/04-checklist-receipt-handoff.md
+++ b/docs/design-system/screen-prompts/web-public/04-checklist-receipt-handoff.md
@@ -1,0 +1,51 @@
+# Prompt: Public Web Checklist And Receipt Handoff
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely public web in-store checklist.
+
+Viewport:
+- Mobile web first, 390px wide.
+- Include desktop behavior notes.
+
+Scenario:
+- User is shopping from an optimized list.
+- 9 of 12 items marked purchased.
+- One item has reported shelf price mismatch.
+- All items can lead to optional paid total and receipt submission.
+
+Screen goal:
+Make checklist completion naturally lead to receipt contribution without forcing it.
+
+Required content:
+- Compact list/store context.
+- Grouped checklist by store.
+- Purchased toggle per item.
+- Selected variant and expected price.
+- Price mismatch affordance.
+- Optional reported price/note state.
+- Completion panel when all items are checked.
+- Optional paid total field.
+- CTA: concluir lista.
+- CTA after completion: enviar nota fiscal.
+
+Required states:
+- no optimized result
+- all purchased
+- mismatch reported
+- receipt handoff skipped
+- save purchased state failed
+
+Visual rules:
+- Thumb-friendly.
+- Sticky bottom action.
+- No horizontal overflow.
+- Do not promise reward until receipt validation.
+
+Implementation notes:
+Map likely components to:
+- web/src/public/public-pages.tsx
+- web/src/public/checklist-page.spec.tsx
+```
+


### PR DESCRIPTION
## Summary
- Adds reusable AI screen-generation prompt context under docs/design-system/screen-prompts
- Adds prompt packs for public web, mobile, and admin dashboard screens
- Provides usage instructions for GPT/Stitch/Figma/Claude Design before implementation in Codex

## Context
- References issue #325
- Uses the new design system as source of truth

## Validation
- git diff --check