### PR TITLE
Add web design-system component foundation

### DIFF
--- a/web/src/components/design-system/README.md
+++ b/web/src/components/design-system/README.md
@@ -1,0 +1,41 @@
+# Web Design-System Components
+
+Implementation-facing component layer for the Pricely design system.
+
+Use these components before adding screen-local badge, evidence, price, or queue
+patterns.
+
+```tsx
+import {
+  EvidenceModule,
+  PriceRow,
+  StatusBadge,
+} from '@/components/design-system';
+```
+
+## Components
+
+- `StatusBadge`: semantic status chips for trust, receipt, queue, reward, city,
+  freshness, and severity states.
+- `EvidenceModule`: shopper-facing offer confidence block.
+- `PriceRow`: product/variant/store price row with source metadata.
+- `NextActionStrip`: public shopper workflow prompt.
+- `StickyActionBar`: safe-area-aware sticky action container.
+- `AdminActionQueueItem`: admin operational queue row.
+- `TechnicalDisclosure`: disclosure for raw IDs, payloads, and debug metadata.
+
+## Theme
+
+Semantic CSS variables live in `web/src/index.css` and are defined for both `:root`
+and `.dark`:
+
+- `--ds-primary`
+- `--ds-savings`
+- `--ds-location`
+- `--ds-warning`
+- `--ds-critical`
+- `--ds-neutral-*`
+
+The existing `ThemeProvider` toggles `.dark` on `document.documentElement`, so these
+components automatically switch between light and dark mode.
+

--- a/web/src/components/design-system/admin-action-queue-item.tsx
+++ b/web/src/components/design-system/admin-action-queue-item.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { ArrowRightIcon } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { StatusBadge } from '@/components/design-system/status-badge';
+import { cn } from '@/lib/utils';
+
+type AdminActionQueueItemProps = React.ComponentProps<'article'> & {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  severity?: 'critical' | 'warning' | 'info' | 'healthy';
+  context?: React.ReactNode;
+  age?: React.ReactNode;
+  action?: React.ReactNode;
+  meta?: React.ReactNode;
+};
+
+function AdminActionQueueItem({
+  action,
+  age,
+  className,
+  context,
+  description,
+  meta,
+  severity = 'info',
+  title,
+  ...props
+}: AdminActionQueueItemProps) {
+  return (
+    <article
+      data-slot="admin-action-queue-item"
+      className={cn(
+        'grid gap-3 rounded-lg border border-border/80 bg-card p-3 text-sm sm:grid-cols-[1fr_auto] sm:items-center',
+        className,
+      )}
+      {...props}
+    >
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusBadge family="severity" status={severity} />
+          {age ? (
+            <span className="text-xs text-muted-foreground">{age}</span>
+          ) : null}
+        </div>
+        <div className="mt-2 truncate font-medium text-foreground">{title}</div>
+        {description ? (
+          <div className="mt-1 text-pretty text-muted-foreground">
+            {description}
+          </div>
+        ) : null}
+        {context || meta ? (
+          <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+            {context ? <span>{context}</span> : null}
+            {meta ? <span>{meta}</span> : null}
+          </div>
+        ) : null}
+      </div>
+      <div className="flex shrink-0 justify-end">
+        {action ?? (
+          <Button size="sm" variant="outline">
+            Ver detalhe
+            <ArrowRightIcon />
+          </Button>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export { AdminActionQueueItem };
+export type { AdminActionQueueItemProps };

--- a/web/src/components/design-system/design-system.spec.tsx
+++ b/web/src/components/design-system/design-system.spec.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  AdminActionQueueItem,
+  EvidenceModule,
+  NextActionStrip,
+  PriceRow,
+  StatusBadge,
+  StickyActionBar,
+  TechnicalDisclosure,
+} from './index';
+
+afterEach(cleanup);
+
+describe('design-system component foundation', () => {
+  it('renders semantic status badges with accessible text', () => {
+    render(<StatusBadge family="trust" status="high" />);
+
+    expect(screen.getByText('Confianca alta')).toBeTruthy();
+  });
+
+  it('renders an evidence module with trust score and receipt evidence', () => {
+    render(
+      <EvidenceModule
+        selectedVariant="Camil Arroz tipo 1 1kg"
+        requestedRule="Qualquer variante"
+        store="Mercado Centro"
+        price="R$ 7,90"
+        sourceLabel="Recibo de usuario"
+        trustScore={82}
+        trustLevel="high"
+        evidenceCount={4}
+        freshnessLabel="Validado ha 3d"
+        confidenceNotice="Preco observado em recibo recente."
+      />,
+    );
+
+    expect(screen.getByText('Confianca da oferta')).toBeTruthy();
+    expect(screen.getByText('82/100')).toBeTruthy();
+    expect(screen.getByText('4 notas fiscais aceitas')).toBeTruthy();
+    expect(screen.getByText('Camil Arroz tipo 1 1kg')).toBeTruthy();
+  });
+
+  it('renders a reusable price row', () => {
+    render(
+      <PriceRow
+        title="Arroz tipo 1"
+        subtitle="Mercado Centro"
+        price="R$ 7,90"
+        comparison="R$ 1,50 abaixo da proxima alternativa"
+      />,
+    );
+
+    expect(screen.getByText('Arroz tipo 1')).toBeTruthy();
+    expect(screen.getByText('R$ 7,90')).toBeTruthy();
+  });
+
+  it('renders workflow and admin primitives', () => {
+    render(
+      <>
+        <NextActionStrip
+          eyebrow="Proximo passo"
+          title="Otimize sua lista"
+          description="Compare lojas antes de sair para comprar."
+        />
+        <StickyActionBar>Acao fixa</StickyActionBar>
+        <AdminActionQueueItem
+          title="Nota aguardando liberacao"
+          severity="warning"
+          context="Mercado Centro"
+        />
+        <TechnicalDisclosure>
+          <code>receipt-1</code>
+        </TechnicalDisclosure>
+      </>,
+    );
+
+    expect(screen.getByText('Otimize sua lista')).toBeTruthy();
+    expect(screen.getByText('Acao fixa')).toBeTruthy();
+    expect(screen.getByText('Nota aguardando liberacao')).toBeTruthy();
+    expect(screen.getByText('receipt-1')).toBeTruthy();
+  });
+});

--- a/web/src/components/design-system/evidence-module.tsx
+++ b/web/src/components/design-system/evidence-module.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+import { GaugeIcon, ReceiptTextIcon, StoreIcon, UploadIcon } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { StatusBadge } from '@/components/design-system/status-badge';
+import { cn } from '@/lib/utils';
+
+type EvidenceModuleProps = React.ComponentProps<'section'> & {
+  title?: string;
+  selectedVariant?: React.ReactNode;
+  requestedRule?: React.ReactNode;
+  store?: React.ReactNode;
+  price?: React.ReactNode;
+  sourceLabel?: React.ReactNode;
+  trustScore?: number;
+  trustLevel?: 'high' | 'medium' | 'low' | 'unknown';
+  evidenceCount?: number;
+  freshnessLabel?: React.ReactNode;
+  confidenceNotice?: React.ReactNode;
+  reportAction?: React.ReactNode;
+  uploadAction?: React.ReactNode;
+};
+
+function EvidenceModule({
+  className,
+  confidenceNotice,
+  evidenceCount,
+  freshnessLabel,
+  price,
+  reportAction,
+  requestedRule,
+  selectedVariant,
+  sourceLabel,
+  store,
+  title = 'Confianca da oferta',
+  trustLevel = 'unknown',
+  trustScore,
+  uploadAction,
+  ...props
+}: EvidenceModuleProps) {
+  const evidenceLabel =
+    evidenceCount === undefined
+      ? 'Sem contagem de evidencia'
+      : evidenceCount === 0
+        ? 'Origem operacional'
+        : evidenceCount === 1
+          ? '1 nota fiscal aceita'
+          : `${evidenceCount} notas fiscais aceitas`;
+
+  return (
+    <section
+      data-slot="evidence-module"
+      className={cn(
+        'rounded-lg border border-border/80 bg-card p-3 text-sm text-card-foreground',
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="font-medium">{title}</div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <StatusBadge family="trust" status={trustLevel} />
+          {trustScore !== undefined ? (
+            <StatusBadge icon={GaugeIcon} tone="neutral">
+              <span className="tabular-nums">{trustScore}/100</span>
+            </StatusBadge>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        {selectedVariant ? (
+          <EvidenceDetail label="Selecionado" value={selectedVariant} />
+        ) : null}
+        {requestedRule ? (
+          <EvidenceDetail label="Regra pedida" value={requestedRule} />
+        ) : null}
+        {store ? (
+          <EvidenceDetail icon={StoreIcon} label="Loja" value={store} />
+        ) : null}
+        {price ? <EvidenceDetail label="Preco" value={price} tabular /> : null}
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        <StatusBadge icon={ReceiptTextIcon} tone={evidenceCount ? 'savings' : 'neutral'}>
+          {sourceLabel ?? 'Origem operacional'}
+        </StatusBadge>
+        <StatusBadge tone={evidenceCount ? 'savings' : 'neutral'}>
+          {evidenceLabel}
+        </StatusBadge>
+        {freshnessLabel ? (
+          <StatusBadge family="freshness" status="aging">
+            {freshnessLabel}
+          </StatusBadge>
+        ) : null}
+      </div>
+
+      {confidenceNotice ? (
+        <p className="mt-3 text-pretty text-sm text-muted-foreground">
+          {confidenceNotice}
+        </p>
+      ) : null}
+
+      {reportAction || uploadAction ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {reportAction}
+          {uploadAction ?? (
+            <Button size="sm" variant="ghost">
+              <UploadIcon />
+              Enviar nota
+            </Button>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function EvidenceDetail({
+  icon: Icon,
+  label,
+  tabular,
+  value,
+}: {
+  icon?: React.ElementType;
+  label: string;
+  tabular?: boolean;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="min-w-0 rounded-lg bg-muted/45 p-2">
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        {Icon ? <Icon aria-hidden="true" className="size-3.5" /> : null}
+        {label}
+      </div>
+      <div
+        className={cn(
+          'mt-0.5 truncate font-medium text-foreground',
+          tabular && 'tabular-nums',
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export { EvidenceModule };
+export type { EvidenceModuleProps };

--- a/web/src/components/design-system/index.ts
+++ b/web/src/components/design-system/index.ts
@@ -1,0 +1,14 @@
+export { AdminActionQueueItem } from './admin-action-queue-item';
+export type { AdminActionQueueItemProps } from './admin-action-queue-item';
+export { EvidenceModule } from './evidence-module';
+export type { EvidenceModuleProps } from './evidence-module';
+export { NextActionStrip } from './next-action-strip';
+export type { NextActionStripProps } from './next-action-strip';
+export { PriceRow } from './price-row';
+export type { PriceRowProps } from './price-row';
+export { StatusBadge, statusBadgeVariants, statusPresets } from './status-badge';
+export type { StatusBadgeProps, StatusFamily } from './status-badge';
+export { StickyActionBar } from './sticky-action-bar';
+export type { StickyActionBarProps } from './sticky-action-bar';
+export { TechnicalDisclosure } from './technical-disclosure';
+export type { TechnicalDisclosureProps } from './technical-disclosure';

--- a/web/src/components/design-system/next-action-strip.tsx
+++ b/web/src/components/design-system/next-action-strip.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { ArrowRightIcon } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type NextActionStripProps = React.ComponentProps<'section'> & {
+  eyebrow?: React.ReactNode;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  primaryAction?: React.ReactNode;
+  secondaryAction?: React.ReactNode;
+  icon?: React.ReactNode;
+};
+
+function NextActionStrip({
+  className,
+  description,
+  eyebrow,
+  icon,
+  primaryAction,
+  secondaryAction,
+  title,
+  ...props
+}: NextActionStripProps) {
+  return (
+    <section
+      data-slot="next-action-strip"
+      className={cn(
+        'rounded-lg border border-[var(--ds-primary-border)] bg-[var(--ds-primary-soft)] p-4 text-sm',
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 gap-3">
+          {icon ? (
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[var(--ds-primary)] text-[var(--ds-primary-foreground)]">
+              {icon}
+            </div>
+          ) : null}
+          <div className="min-w-0">
+            {eyebrow ? (
+              <div className="text-xs font-medium text-[var(--ds-primary)]">
+                {eyebrow}
+              </div>
+            ) : null}
+            <div className="text-pretty font-heading text-base font-semibold text-foreground">
+              {title}
+            </div>
+            {description ? (
+              <div className="mt-1 text-pretty text-muted-foreground">
+                {description}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          {secondaryAction}
+          {primaryAction ?? (
+            <Button>
+              Continuar
+              <ArrowRightIcon />
+            </Button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export { NextActionStrip };
+export type { NextActionStripProps };

--- a/web/src/components/design-system/price-row.tsx
+++ b/web/src/components/design-system/price-row.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+type PriceRowProps = React.ComponentProps<'div'> & {
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  price: React.ReactNode;
+  comparison?: React.ReactNode;
+  image?: React.ReactNode;
+  meta?: React.ReactNode;
+  actions?: React.ReactNode;
+};
+
+function PriceRow({
+  actions,
+  className,
+  comparison,
+  image,
+  meta,
+  price,
+  subtitle,
+  title,
+  ...props
+}: PriceRowProps) {
+  return (
+    <div
+      data-slot="price-row"
+      className={cn(
+        'grid gap-3 rounded-lg border border-border/80 bg-card p-3 text-sm sm:grid-cols-[auto_1fr_auto] sm:items-center',
+        className,
+      )}
+      {...props}
+    >
+      {image ? (
+        <div
+          data-slot="price-row-image"
+          className="size-12 overflow-hidden rounded-lg bg-muted"
+        >
+          {image}
+        </div>
+      ) : null}
+      <div className="min-w-0 space-y-1">
+        <div
+          data-slot="price-row-title"
+          className="truncate font-medium text-foreground"
+        >
+          {title}
+        </div>
+        {subtitle ? (
+          <div
+            data-slot="price-row-subtitle"
+            className="line-clamp-2 text-sm text-muted-foreground"
+          >
+            {subtitle}
+          </div>
+        ) : null}
+        {meta ? (
+          <div
+            data-slot="price-row-meta"
+            className="flex flex-wrap items-center gap-1.5"
+          >
+            {meta}
+          </div>
+        ) : null}
+      </div>
+      <div className="flex items-center justify-between gap-3 sm:justify-end">
+        <div className="text-right">
+          <div
+            data-slot="price-row-price"
+            className="tabular-nums font-semibold text-foreground"
+          >
+            {price}
+          </div>
+          {comparison ? (
+            <div
+              data-slot="price-row-comparison"
+              className="text-xs text-muted-foreground"
+            >
+              {comparison}
+            </div>
+          ) : null}
+        </div>
+        {actions ? (
+          <div data-slot="price-row-actions" className="shrink-0">
+            {actions}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export { PriceRow };
+export type { PriceRowProps };

--- a/web/src/components/design-system/status-badge.tsx
+++ b/web/src/components/design-system/status-badge.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import {
+  AlertTriangleIcon,
+  CheckCircle2Icon,
+  CircleIcon,
+  Clock3Icon,
+  InfoIcon,
+  ShieldCheckIcon,
+  XCircleIcon,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+const statusBadgeVariants = cva(
+  'border font-medium [&_svg]:size-3.5',
+  {
+    variants: {
+      tone: {
+        neutral:
+          'border-[var(--ds-neutral-border)] bg-[var(--ds-neutral-soft)] text-foreground',
+        primary:
+          'border-[var(--ds-primary-border)] bg-[var(--ds-primary-soft)] text-[var(--ds-primary)]',
+        savings:
+          'border-[var(--ds-savings-border)] bg-[var(--ds-savings-soft)] text-[var(--ds-savings)]',
+        location:
+          'border-[var(--ds-location-border)] bg-[var(--ds-location-soft)] text-[var(--ds-location)]',
+        warning:
+          'border-[var(--ds-warning-border)] bg-[var(--ds-warning-soft)] text-[var(--ds-warning)]',
+        critical:
+          'border-[var(--ds-critical-border)] bg-[var(--ds-critical-soft)] text-[var(--ds-critical)]',
+      },
+    },
+    defaultVariants: {
+      tone: 'neutral',
+    },
+  },
+);
+
+type StatusFamily =
+  | 'city'
+  | 'freshness'
+  | 'queue'
+  | 'receipt'
+  | 'reward'
+  | 'severity'
+  | 'trust';
+
+type StatusBadgePreset = {
+  icon: React.ElementType;
+  label: string;
+  tone: NonNullable<VariantProps<typeof statusBadgeVariants>['tone']>;
+};
+
+const statusPresets = {
+  city: {
+    active: { icon: CheckCircle2Icon, label: 'Cidade ativa', tone: 'location' },
+    activating: { icon: Clock3Icon, label: 'Em ativacao', tone: 'warning' },
+    collecting_data: { icon: InfoIcon, label: 'Coletando dados', tone: 'neutral' },
+    hidden: { icon: CircleIcon, label: 'Oculta', tone: 'neutral' },
+  },
+  freshness: {
+    fresh: { icon: CheckCircle2Icon, label: 'Atualizado', tone: 'savings' },
+    aging: { icon: Clock3Icon, label: 'Cobertura parcial', tone: 'warning' },
+    stale: { icon: AlertTriangleIcon, label: 'Dado antigo', tone: 'warning' },
+    expired: { icon: XCircleIcon, label: 'Expirado', tone: 'critical' },
+  },
+  queue: {
+    queued: { icon: Clock3Icon, label: 'Na fila', tone: 'location' },
+    running: { icon: Clock3Icon, label: 'Executando', tone: 'primary' },
+    retrying: { icon: AlertTriangleIcon, label: 'Tentando novamente', tone: 'warning' },
+    failed: { icon: XCircleIcon, label: 'Falhou', tone: 'critical' },
+    completed: { icon: CheckCircle2Icon, label: 'Concluido', tone: 'savings' },
+  },
+  receipt: {
+    accepted: { icon: CheckCircle2Icon, label: 'Aceita', tone: 'savings' },
+    pending_review: { icon: Clock3Icon, label: 'Aguardando revisao', tone: 'warning' },
+    duplicate: { icon: AlertTriangleIcon, label: 'Duplicada', tone: 'warning' },
+    quarantined: { icon: AlertTriangleIcon, label: 'Em quarentena', tone: 'warning' },
+    rejected: { icon: XCircleIcon, label: 'Rejeitada', tone: 'critical' },
+    low_confidence: { icon: AlertTriangleIcon, label: 'Baixa confianca', tone: 'warning' },
+  },
+  reward: {
+    eligible_pending: { icon: Clock3Icon, label: 'Reward pendente', tone: 'warning' },
+    granted: { icon: CheckCircle2Icon, label: 'Reward concedido', tone: 'savings' },
+    disabled: { icon: CircleIcon, label: 'Reward desativado', tone: 'neutral' },
+    rejected: { icon: XCircleIcon, label: 'Reward rejeitado', tone: 'critical' },
+  },
+  severity: {
+    critical: { icon: XCircleIcon, label: 'Critico', tone: 'critical' },
+    warning: { icon: AlertTriangleIcon, label: 'Revisar', tone: 'warning' },
+    info: { icon: InfoIcon, label: 'Informativo', tone: 'location' },
+    healthy: { icon: CheckCircle2Icon, label: 'Saudavel', tone: 'savings' },
+  },
+  trust: {
+    high: { icon: ShieldCheckIcon, label: 'Confianca alta', tone: 'savings' },
+    medium: { icon: ShieldCheckIcon, label: 'Confianca media', tone: 'warning' },
+    low: { icon: AlertTriangleIcon, label: 'Confianca baixa', tone: 'critical' },
+    unknown: { icon: InfoIcon, label: 'Confianca indefinida', tone: 'neutral' },
+  },
+} satisfies Record<StatusFamily, Record<string, StatusBadgePreset>>;
+
+type StatusBadgeProps = React.ComponentProps<typeof Badge> &
+  VariantProps<typeof statusBadgeVariants> & {
+    family?: StatusFamily;
+    status?: string;
+    icon?: React.ElementType | null;
+    label?: string;
+  };
+
+function getStatusPreset(family?: StatusFamily, status?: string) {
+  if (!family || !status) {
+    return null;
+  }
+
+  const familyPresets = statusPresets[family] as Record<
+    string,
+    StatusBadgePreset | undefined
+  >;
+
+  return familyPresets[status] ?? null;
+}
+
+function StatusBadge({
+  className,
+  family,
+  status,
+  icon,
+  label,
+  tone,
+  children,
+  ...props
+}: StatusBadgeProps) {
+  const preset = getStatusPreset(family, status);
+  const Icon = icon === null ? null : icon ?? preset?.icon ?? CircleIcon;
+  const badgeTone = tone ?? preset?.tone ?? 'neutral';
+  const content = children ?? label ?? preset?.label ?? status;
+
+  return (
+    <Badge
+      data-slot="status-badge"
+      variant="outline"
+      className={cn(statusBadgeVariants({ tone: badgeTone }), className)}
+      {...props}
+    >
+      {Icon ? <Icon aria-hidden="true" /> : null}
+      {content}
+    </Badge>
+  );
+}
+
+export { StatusBadge, statusBadgeVariants, statusPresets };
+export type { StatusBadgeProps, StatusFamily };

--- a/web/src/components/design-system/sticky-action-bar.tsx
+++ b/web/src/components/design-system/sticky-action-bar.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+type StickyActionBarProps = React.ComponentProps<'div'> & {
+  align?: 'between' | 'end' | 'start';
+};
+
+function StickyActionBar({
+  align = 'between',
+  className,
+  ...props
+}: StickyActionBarProps) {
+  return (
+    <div
+      data-slot="sticky-action-bar"
+      className={cn(
+        'sticky bottom-0 z-30 -mx-4 mt-4 border-t bg-background/95 px-4 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur supports-[backdrop-filter]:bg-background/85',
+        align === 'between' && 'flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between',
+        align === 'end' && 'flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end',
+        align === 'start' && 'flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-start',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { StickyActionBar };
+export type { StickyActionBarProps };

--- a/web/src/components/design-system/technical-disclosure.tsx
+++ b/web/src/components/design-system/technical-disclosure.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { ChevronDownIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+type TechnicalDisclosureProps = React.ComponentProps<'details'> & {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+function TechnicalDisclosure({
+  children,
+  className,
+  description,
+  title = 'Detalhes tecnicos',
+  ...props
+}: TechnicalDisclosureProps) {
+  return (
+    <details
+      data-slot="technical-disclosure"
+      className={cn(
+        'group rounded-lg border border-border/80 bg-muted/30 text-sm',
+        className,
+      )}
+      {...props}
+    >
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 p-3 font-medium marker:hidden">
+        <span>
+          {title}
+          {description ? (
+            <span className="ml-2 font-normal text-muted-foreground">
+              {description}
+            </span>
+          ) : null}
+        </span>
+        <ChevronDownIcon
+          aria-hidden="true"
+          className="size-4 shrink-0 transition-transform group-open:rotate-180"
+        />
+      </summary>
+      <div className="border-t p-3 text-muted-foreground">{children}</div>
+    </details>
+  );
+}
+
+export { TechnicalDisclosure };
+export type { TechnicalDisclosureProps };

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -38,6 +38,25 @@
   --sidebar-accent-foreground: oklch(0.96 0.01 180);
   --sidebar-border: oklch(0.33 0.02 205);
   --sidebar-ring: oklch(0.64 0.09 202);
+  --ds-primary: #0f766e;
+  --ds-primary-foreground: #f7fafa;
+  --ds-primary-soft: #ddf3ee;
+  --ds-primary-border: #a7d8cf;
+  --ds-savings: #65a30d;
+  --ds-savings-soft: #ecfcca;
+  --ds-savings-border: #bef264;
+  --ds-location: #2563eb;
+  --ds-location-soft: #dbeafe;
+  --ds-location-border: #93c5fd;
+  --ds-warning: #d97706;
+  --ds-warning-soft: #fef3c7;
+  --ds-warning-border: #fbbf24;
+  --ds-critical: #e11d48;
+  --ds-critical-soft: #ffe4e6;
+  --ds-critical-border: #fda4af;
+  --ds-neutral-soft: #edf5f2;
+  --ds-neutral-border: #dde8e4;
+  --ds-muted-text: #5f6f69;
 }
 
 .dark {
@@ -67,6 +86,25 @@
   --sidebar-accent-foreground: oklch(0.96 0.01 180);
   --sidebar-border: oklch(0.28 0.01 205);
   --sidebar-ring: oklch(0.67 0.11 191);
+  --ds-primary: #5eead4;
+  --ds-primary-foreground: #071311;
+  --ds-primary-soft: #123a35;
+  --ds-primary-border: #1f6f65;
+  --ds-savings: #a3e635;
+  --ds-savings-soft: #25340f;
+  --ds-savings-border: #4d7c0f;
+  --ds-location: #60a5fa;
+  --ds-location-soft: #172a47;
+  --ds-location-border: #1d4ed8;
+  --ds-warning: #fbbf24;
+  --ds-warning-soft: #3d2a09;
+  --ds-warning-border: #b45309;
+  --ds-critical: #fb7185;
+  --ds-critical-soft: #43131c;
+  --ds-critical-border: #be123c;
+  --ds-neutral-soft: #1a2a26;
+  --ds-neutral-border: #2f4640;
+  --ds-muted-text: #aebcb7;
 }
 
 @theme inline {


### PR DESCRIPTION
## Summary
- Adds semantic light/dark design-system tokens to web/src/index.css
- Adds shadcn-style design-system components: StatusBadge, EvidenceModule, PriceRow, NextActionStrip, StickyActionBar, AdminActionQueueItem, TechnicalDisclosure
- Adds component README and focused tests for the new foundation

## Context
- References issue #329
- Implements Batch 1 from docs/design-system/reference-screen-review.md

## Validation
- npm run build
- npm run lint
- npm test
- npm test -- src/components/design-system/design-system.spec.tsx
- git diff --check