### PR TITLE
Clean up remaining public web visual tokens

### DIFF
--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -1309,7 +1309,7 @@ export function OffersPage() {
               </div>
               {(group.savingsVsSecondCheapest ?? 0) > 0 &&
               group.secondCheapestPriceAmount ? (
-                <div className="text-sm font-medium text-emerald-700">
+                <div className="text-sm font-medium text-[var(--ds-savings)]">
                   {formatCurrency(group.savingsVsSecondCheapest ?? 0)} abaixo do
                   próximo menor preço (
                   {formatCurrency(group.secondCheapestPriceAmount)}).
@@ -1478,7 +1478,7 @@ export function OfferDetailPage() {
             />
             {offer.activeOffer.savingsVsComparison &&
             offer.activeOffer.savingsVsComparison > 0 ? (
-              <p className="text-sm font-medium text-emerald-700">
+              <p className="text-sm font-medium text-[var(--ds-savings)]">
                 Economize{' '}
                 {formatCurrency(offer.activeOffer.savingsVsComparison)} versus o
                 segundo menor preco elegivel para esta variante.
@@ -2098,7 +2098,7 @@ export function ReceiptSubmissionPage() {
                 </div>
                 {submission.rewardEligibilityStatus === 'eligible_pending' ||
                 submission.rewardEligibilityStatus === 'granted' ? (
-                  <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-950">
+                  <div className="rounded-lg border border-[var(--ds-savings-border)] bg-[var(--ds-savings-soft)] p-3 text-sm text-[var(--ds-savings)]">
                     {submission.rewardEligibilityStatus === 'granted'
                       ? 'Reward validado: '
                       : 'Reward previsto após validação: '}
@@ -2119,7 +2119,7 @@ export function ReceiptSubmissionPage() {
           </CardContent>
         </Card>
 
-        <Card className="border-border/70 bg-emerald-50/80 shadow-sm">
+        <Card className="border-[var(--ds-savings-border)] bg-[var(--ds-savings-soft)]/70 shadow-sm">
           <CardHeader>
             <CardTitle>Como o reward funciona</CardTitle>
             <CardDescription>
@@ -2135,7 +2135,7 @@ export function ReceiptSubmissionPage() {
               'Reward sai de processamento para validado quando a nota é confiável.',
             ].map((step, index) => (
               <div
-                className="flex items-center gap-3 rounded-lg border border-emerald-200 bg-white/70 p-3"
+                className="flex items-center gap-3 rounded-lg border border-[var(--ds-savings-border)] bg-card/80 p-3"
                 key={step}
               >
                 <StatusBadge icon={null} tone="savings">
@@ -2284,7 +2284,7 @@ export function ListsPage() {
           </Card>
         </div>
 
-        <Card className="border-border/70 bg-emerald-50/80 shadow-sm">
+        <Card className="border-[var(--ds-savings-border)] bg-[var(--ds-savings-soft)]/70 shadow-sm">
           <CardHeader className="gap-3">
             <div className="flex flex-wrap items-center gap-2">
               <StatusBadge

--- a/web/src/public/public-shell.tsx
+++ b/web/src/public/public-shell.tsx
@@ -201,7 +201,7 @@ export function PublicLayout() {
   };
 
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(15,118,110,0.14),transparent_28%),radial-gradient(circle_at_85%_15%,rgba(37,99,235,0.10),transparent_22%),linear-gradient(180deg,#f8fafb_0%,#f3f8f6_48%,#eef7f8_100%)]">
+    <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-40 border-b border-border/70 bg-background/92 backdrop-blur">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-3 px-4 py-3 lg:flex-row lg:items-center lg:justify-between lg:px-6">
           <div className="flex items-center gap-6">
@@ -333,7 +333,7 @@ export function PublicLayout() {
               </div>
             ) : null}
             {locationPreview ? (
-              <div className="mt-2 rounded-md border border-teal-200 bg-teal-50 px-2.5 py-1 text-xs text-teal-950">
+              <div className="mt-2 rounded-md border border-[var(--ds-location-border)] bg-[var(--ds-location-soft)] px-2.5 py-1 text-xs text-[var(--ds-location)]">
                 {locationPreview}
               </div>
             ) : null}


### PR DESCRIPTION
## Summary
- replace remaining public web emerald/teal hardcoded utility styling with design-system semantic tokens
- simplify public shell background away from hardcoded decorative gradients
- keep behavior, routes, and copy intact

## Validation
- npm run lint
- npm test -- src/public/public-pages.spec.tsx src/public/public-shell.spec.tsx src/routes/app-router.spec.tsx
- npm test
- npm run build
- npm run e2e

References #345