### PR TITLE
Map web button integration gaps

### DIFF
--- a/docs/product/web-button-integration-audit.md
+++ b/docs/product/web-button-integration-audit.md
@@ -1,0 +1,76 @@
+# Web Button Integration Audit
+
+Date: 2026-06-17
+Issue: #370
+
+## Scope
+
+Audited app-facing TSX surfaces under:
+
+- `web/src/public/`
+- `web/src/dashboard/`
+- `web/src/components/design-system/`
+- `web/src/routes/`
+
+Excluded shadcn/Radix primitive internals and test-only files.
+
+## Inventory Summary
+
+AST extraction found 136 button-like actions:
+
+- 57 route/navigation actions via `Button asChild`, `Link`, or `a`
+- 9 form submit actions
+- 55 explicit click handlers
+- 13 no-handler candidates
+- 2 disabled placeholders
+- 1 explicit noop handler
+
+The candidates below are the actions that need product decisions, existing-feature
+wiring, or new Spec Kit tasks.
+
+## Candidate Map
+
+| Surface | Button | Current state | Existing support | Classification |
+| --- | --- | --- | --- | --- |
+| `web/src/public/public-pages.tsx:1256` | Location state action (`Abrir configurações`) | Renders a button with no handler | Location permission and fallback flows exist, but browsers do not expose a universal settings opener | Existing feature needs UI correction |
+| `web/src/public/public-pages.tsx:2525` | `Comprar Premium` / `Premium indisponível` | Disabled placeholder | Billing is intentionally disabled; mapped to Phase 19 tasks T141-T148, especially T146 | Already specified, no new task |
+| `web/src/public/public-pages.tsx:3482` | Share list icon | No handler | No public share link/export feature found | New feature gap |
+| `web/src/public/public-pages.tsx:3860` | `Adicionar produto não encontrado` | No handler | Public catalog search and admin catalog exist, but no shopper missing-product request queue exists | New feature gap |
+| `web/src/public/public-pages.tsx:4103` | Notifications bell | No handler | No notification preference, alert, or delivery feature found | New feature gap |
+| `web/src/public/public-pages.tsx:4306` | Optimization-result tabs | Visual active state only, no tab state | Result data already contains optimized items, unavailable items, store plan, and savings analysis | Existing data needs UI wiring |
+| `web/src/public/public-pages.tsx:4319` | `Exibir: Todos os itens` | No handler | Result item data exists; no filter/dropdown behavior exists | Existing data needs UI wiring |
+| `web/src/public/public-pages.tsx:4490` | `Ver evidência` | No handler | `ShopperEvidenceModule` already exists and is rendered for selected rows | Existing feature needs UI wiring |
+| `web/src/public/public-pages.tsx:5075` | `Ver no mapa` | No handler | Establishment coordinates/distance exist, but no map/deep-link route UX exists | New feature gap |
+| `web/src/dashboard/dashboard-pages.tsx:5176` | Job `Tentar novamente` | Disabled unless failed, no handler | Receipt reprocess exists; generic processing-job retry does not | New feature gap |
+| `web/src/dashboard/dashboard-pages.tsx:5184` | `Marcar como revisado` | No handler | No processing-job reviewed state or endpoint found | New feature gap |
+| `web/src/dashboard/dashboard-pages.tsx:5187` | `Cancelar job` | No handler | No processing-job cancellation endpoint or queue cancellation policy found | New feature gap |
+| `web/src/components/design-system/admin-action-queue-item.tsx:60` | Default `Ver detalhe` | Fallback button has no handler | Real usages pass an integrated `action`; fallback should not render a dead CTA | Component contract cleanup |
+| `web/src/components/design-system/app-sidebar-shell.tsx:514` | Location dialog `Confirmado` | Explicit noop handler | Selected city/location state already exists; button should close dialog or be removed | Existing feature needs UI wiring |
+| `web/src/components/design-system/evidence-module.tsx:111` | Default `Enviar nota` | Fallback button has no handler | Real receipt submission route exists; component should receive an integrated action or render no fallback | Component contract cleanup |
+| `web/src/components/design-system/next-action-strip.tsx:61` | Default `Continuar` | Fallback button has no handler | Callers should provide a route/action; fallback should not render a dead CTA | Component contract cleanup |
+
+## Existing-Feature Wiring Recommendations
+
+- Replace the location settings placeholder with explanatory copy plus the existing
+  retry/location setup action where appropriate.
+- Make the location dialog confirmation close the dialog after a valid city is selected,
+  or remove the button if the select itself persists immediately.
+- Convert optimization result tabs and item filters into local UI state over the
+  already-present result arrays.
+- Use `ShopperEvidenceModule` for per-item evidence expansion instead of a dead
+  `Ver evidência` button.
+- Tighten design-system component defaults so reusable components do not emit
+  non-functional fallback CTAs.
+
+## New Feature Gaps
+
+These do not currently have a complete feature behind the button:
+
+1. Shareable shopping-list links or exports.
+2. Shopper missing-product request intake and admin triage.
+3. User notification preferences and alert delivery.
+4. Map/deep-link route view for optimized store plans.
+5. Generic processing-job retry, reviewed, and cancellation operations.
+
+The corresponding Spec Kit tasks were added to
+`specs/001-grocery-optimizer/tasks.md` as Phase 28.

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -555,6 +555,20 @@ Premium access and extra optimization credits are support/admin operations for n
 - [X] T216 Adopt `web/src/assets/pricely-icon.png` as the official brand icon in web shell/header and plan reuse for favicon/mobile app assets.
 - [~] T217 Continue location web/mobile UX refactors with explicit location/radius preview, manual fallback, denied-permission states, and no-proximity claims until distance-aware optimization is fully active.
 
+### Phase 28: Web Button Integration Audit and Action Gaps
+
+**Purpose**: Ensure every visible web button either performs an existing action, routes to
+an implemented surface, clearly communicates disabled scope, or has a Spec Kit task for
+the missing feature.
+
+- [X] T218 Map web button integration state, existing-feature coverage, dead placeholders, and missing feature gaps in `docs/product/web-button-integration-audit.md`
+- [ ] T219 [P] Wire existing public UI affordances for location confirmation, optimization-result tabs, result item filtering, per-item evidence expansion, and browser-settings guidance in `web/src/public/` and `web/src/components/design-system/`
+- [ ] T220 [P] Add shopper shareable-list support with access policy, public/share route behavior, and copy-link UI in `specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml`, `backend/src/lists/`, and `web/src/public/`
+- [ ] T221 [P] Add shopper missing-product request intake, admin triage, and catalog conversion workflow in `backend/src/catalog/`, `backend/src/admin/`, `web/src/public/`, and `web/src/dashboard/`
+- [ ] T222 [P] Specify and implement user notification preferences, alert triggers, and web notification-center states for price changes, receipt outcomes, and optimization readiness in `backend/src/users/`, `backend/src/receipts/`, `backend/src/optimization/`, and `web/src/public/`
+- [ ] T223 [P] Add map/deep-link support for optimized store plans using saved establishment address/coordinates without exposing precise user location in `backend/src/establishments/`, `backend/src/optimization/`, and `web/src/public/`
+- [ ] T224 Add generic processing-job lifecycle operations for retry, mark-reviewed, and cancel with queue safety rules, audit logging, admin API endpoints, and dashboard actions in `backend/src/processing/`, `backend/src/admin/`, and `web/src/dashboard/`
+
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.
 Validated public bundle load, customer login, receipt submission with


### PR DESCRIPTION
## Summary
- audits web button/CTA integration state across public, admin, design-system, and route surfaces
- maps dead/placeholder actions to existing features, intentional disabled scope, or true feature gaps
- adds Spec Kit Phase 28 tasks T218-T224 for web button integration cleanup and missing feature work

## Validation
- git diff --check
- Spec Kit task format check for T218-T224

Refs #370