### PR TITLE
Plan action placeholders, tooltips, and monetary privacy

### DIFF
--- a/docs/product/web-action-placeholder-tooltip-privacy-plan.md
+++ b/docs/product/web-action-placeholder-tooltip-privacy-plan.md
@@ -1,0 +1,136 @@
+# Web Action Placeholder, Tooltip, and Monetary Privacy Plan
+
+Date: 2026-06-17
+Issue: #372
+
+## Principles
+
+- Empty states must be action-oriented. If a user has no data yet, the state should
+  explain the next useful action, such as "Envie sua primeira nota fiscal" or
+  "Saiba como funciona".
+- Disabled or deferred actions must explain why they are unavailable and what unlocks
+  them.
+- Tooltips should clarify icons, status badges, sensitive operational terms, truncated
+  technical labels, and destructive actions. They should not replace visible labels for
+  primary workflows.
+- Monetary information is sensitive. Users and admins need a persistent hide/show
+  control for prices, savings, paid totals, token value-adjacent metrics, and billing
+  diagnostics.
+
+## Action Placeholder Inventory
+
+### Public Web
+
+- Home contextual states in `web/src/public/public-pages.tsx`
+  - No city selected: offer "Selecionar cidade" and explain city-scoped pricing.
+  - Location denied: show "Saiba como ativar" and keep manual city/CEP fallback.
+  - No stores in radius: offer "Ampliar raio" once radius editing exists; until then
+    route to city/global mode guidance.
+  - Loading data: use skeleton and explain what is being loaded.
+- Receipts page in `web/src/public/public-pages.tsx`
+  - Never submitted a receipt: show "Envie sua primeira nota fiscal", "Saiba como
+    funciona", and "O reward depende de validação".
+  - Submitted waiting manual release: show next action and expected admin review state.
+  - Failed/rejected/duplicate receipt: show recovery action and support-safe reason.
+- Lists/profile page in `web/src/public/public-pages.tsx`
+  - No lists: show "Crie sua primeira lista".
+  - No estimated savings yet: show "Otimize uma lista para ver economia estimada".
+  - Billing disabled: keep "Premium indisponivel" but add "Saiba por que".
+- Checklist page in `web/src/public/public-pages.tsx`
+  - Completed checklist without receipt: show "Envie a nota desta compra".
+  - No paid total captured: explain optional field and privacy.
+- List editor in `web/src/public/public-pages.tsx`
+  - Product not found: currently mapped by T221, but placeholder should explain
+    "Solicitar produto para o catalogo".
+  - Empty item list: focus product search and show examples.
+- Optimization result in `web/src/public/public-pages.tsx`
+  - Processing/no result: show "Recalcular", "Voltar para lista", and what status means.
+  - No unavailable items: show positive empty state.
+  - No store plan: show "Resultado por cidade" or "Sem parada definida".
+  - Evidence/action sections: show what happens when there are no receipts behind a
+    price.
+
+### Admin Web
+
+- Admin overview in `web/src/dashboard/dashboard-pages.tsx`
+  - No pending receipts: show "Sem notas para revisar" plus "Ver como chegam notas".
+  - No failed jobs: show "Sem falhas recentes" plus health explanation.
+  - No low-trust offers: show "Sem ofertas críticas".
+- Admin users in `web/src/dashboard/dashboard-pages.tsx`
+  - User with no receipts/lists/locations: show support-safe next actions.
+  - Billing disabled: explain that premium is admin-managed for MVP.
+- Admin receipts in `web/src/dashboard/dashboard-pages.tsx`
+  - Empty queue: show "Nenhuma nota pendente" and expected route from shopper receipt
+    submission.
+  - Receipt with no extracted items: show "Aguardando extração" or "Reprocessar".
+  - Missing maker action: explain what action can be taken.
+- Admin processing jobs in `web/src/dashboard/dashboard-pages.tsx`
+  - Empty jobs: show "Nenhum job recente" and monitored queues.
+  - Job actions disabled: explain status requirements for retry/cancel/review.
+
+## Tooltip Inventory
+
+### Required Shared Tooltips
+
+- Icon-only buttons: sidebar trigger, theme toggle, location button, notifications,
+  share, remove items, external-link buttons, refresh/reprocess buttons.
+- Status badges: queue status, trust/confidence, freshness, reward status, city
+  activation, receipt moderation, availability.
+- Sensitive/technical terms: confidence score, freshness, reward pending, billing
+  disabled, token balance, manual release, quarantine, moderation, CNPJ, NFC-e, EAN,
+  technical IDs.
+- Destructive/admin operations: reject receipt, delete product, delete variant,
+  deactivate city/product, cancel job, revoke premium.
+- Truncated labels: product variants, establishment names, user email, job/resource IDs.
+
+### Implementation Notes
+
+- Prefer a small design-system helper such as `InfoTooltip` or `WithTooltip` in
+  `web/src/components/design-system/`.
+- Use existing `web/src/components/ui/tooltip.tsx` primitives.
+- Do not add tooltips to every text label. Use them where the action/status is compact,
+  icon-only, operationally risky, or materially ambiguous.
+
+## Monetary Privacy Inventory
+
+### Public Web Monetary Values
+
+- Home offers: price and "Economize" cards.
+- Offer explorer/detail: offer price, regional average, alternative prices.
+- Profile/list summary: accumulated estimated savings, tokens/free plan counters when
+  treated as value, premium state.
+- Checklist: expected total, expected item prices, paid total.
+- Optimization result: estimated cost, savings, item prices, store totals, selected
+  offer prices, price evidence, comparison math.
+- Receipt submission: unit price and reward/token outcomes.
+
+### Admin Monetary Values
+
+- Admin overview: global estimated savings, offer prices, low-trust price diagnostics.
+- Catalog/offers: base price, promotional price, effective price, historical/current
+  offer prices.
+- Receipt processing: extracted line item prices, suspicious price changes, reward
+  status.
+- User operations: token grants, premium status, billing disabled/payment diagnostics.
+- List operations and queue detail: estimated cost, estimated savings, paid totals.
+
+## Recommended Privacy Behavior
+
+- Add a global monetary visibility preference in the web context with persistence in
+  `localStorage`.
+- Default to visible for now to avoid surprising current users, but make the toggle
+  obvious in the sidebar/account area.
+- Mask monetary values with a stable placeholder such as `R$ •••` while preserving
+  layout width and tabular-number alignment.
+- Keep non-sensitive counts visible unless they are explicitly value-adjacent in a user
+  account context.
+- Add tests ensuring hidden values are not rendered as text in public/profile/result and
+  admin offer/receipt/list views.
+
+## Dependencies
+
+- T219 should happen before final action-placeholder polish because it removes existing
+  dead actions.
+- T220-T224 can proceed independently from tooltip/privacy work.
+- The monetary privacy layer should be implemented before broad screenshot QA so
+  screenshots can verify both visible and hidden modes.

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -569,6 +569,23 @@ the missing feature.
 - [ ] T223 [P] Add map/deep-link support for optimized store plans using saved establishment address/coordinates without exposing precise user location in `backend/src/establishments/`, `backend/src/optimization/`, and `web/src/public/`
 - [ ] T224 Add generic processing-job lifecycle operations for retry, mark-reviewed, and cancel with queue safety rules, audit logging, admin API endpoints, and dashboard actions in `backend/src/processing/`, `backend/src/admin/`, and `web/src/dashboard/`
 
+### Phase 29: Action Placeholders, Tooltips, and Monetary Privacy
+
+**Purpose**: Make every action/status state explain the next useful step, add tooltips
+where compact controls or operational terms need clarification, and let users/admins hide
+sensitive monetary values across web surfaces.
+
+- [X] T225 Map web action placeholders, tooltip needs, and monetary privacy surfaces in `docs/product/web-action-placeholder-tooltip-privacy-plan.md`
+- [ ] T226 [P] Add design-system primitives for action-oriented empty states, contextual help tooltips, and masked monetary values in `web/src/components/design-system/`
+- [ ] T227 [P] Add web context support for persistent hide/show monetary visibility with sidebar/account controls and tests in `web/src/app/`, `web/src/components/design-system/`, and `web/src/public/`
+- [ ] T228 [P] Apply monetary masking to public home, offers, offer detail, profile/list summary, checklist, receipt submission, and optimization result values in `web/src/public/`
+- [ ] T229 [P] Apply monetary masking to admin overview, catalog/offers, receipt processing, user operations, list operations, and queue detail values in `web/src/dashboard/`
+- [ ] T230 [P] Replace passive public placeholders with action-oriented states for no city, no receipt, no list, no savings, no paid total, no result, no evidence, and no store plan in `web/src/public/`
+- [ ] T231 [P] Replace passive admin placeholders with action-oriented states for empty receipt queues, healthy/empty job queues, no failed jobs, no low-trust offers, no user activity, and disabled job actions in `web/src/dashboard/`
+- [ ] T232 [P] Add required tooltips for public icon buttons, status badges, trust/freshness/reward copy, receipt terms, location states, and sensitive monetary toggles in `web/src/public/` and `web/src/components/design-system/`
+- [ ] T233 [P] Add required tooltips for admin icon buttons, status badges, destructive actions, technical IDs, billing-disabled copy, receipt moderation terms, and queue/job actions in `web/src/dashboard/`
+- [ ] T234 Add Playwright and unit coverage for action placeholders, tooltip presence, and hidden monetary values across public and admin web views in `web/src/` and `web/e2e/`
+
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.
 Validated public bundle load, customer login, receipt submission with


### PR DESCRIPTION
## Summary
- adds a web inventory for action-oriented placeholders, tooltip coverage, and monetary privacy
- creates Spec Kit Phase 29 with executable tasks T225-T234
- separates public placeholders, admin placeholders, shared tooltip primitives, public/admin tooltip coverage, monetary masking, and validation

## Validation
- git diff --check
- Spec Kit task format check for T225-T234

Refs #372