### PR TITLE
Add auth screen prompts and shell QA tasks

### DIFF
--- a/docs/design-system/screen-prompts/README.md
+++ b/docs/design-system/screen-prompts/README.md
@@ -32,6 +32,10 @@ Ask the design tool for:
 - responsive notes
 - implementation notes that map to the repo
 
+For authentication work, generate `web-public/05-auth-login-register.md` first,
+then `web-public/06-protected-auth-required.md`. The protected-state prompt is
+the source for improving "precisa entrar" screens on lists and receipts.
+
 ## Approved Source Of Truth
 
 Use these docs as the source of truth:
@@ -41,4 +45,3 @@ Use these docs as the source of truth:
 - `docs/design-system/web-public-guidelines.md`
 - `docs/design-system/mobile-guidelines.md`
 - `docs/design-system/admin-dashboard-guidelines.md`
-

--- a/docs/design-system/screen-prompts/web-public/05-auth-login-register.md
+++ b/docs/design-system/screen-prompts/web-public/05-auth-login-register.md
@@ -1,0 +1,64 @@
+# Prompt: Public Web Login and Register
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely public web authentication entry.
+
+Viewport:
+- Desktop web, 1366px wide.
+- Include mobile behavior notes for 390px width.
+
+Scenario:
+- User is logged out.
+- Selected city may exist, but account is required to save lists, reuse monthly
+  shopping, submit receipts, and keep preferences across web and mobile.
+- The user can switch between "Entrar" and "Criar conta" without leaving the
+  screen.
+
+Screen goal:
+Make authentication feel like a continuation of the shopper workflow, not a
+generic account wall.
+
+Required content:
+- Public app shell matching the approved home reference:
+  - Pricely brand mark and wordmark.
+  - Sidebar navigation.
+  - Header with city/location context, notification icon, and account action.
+- Login panel with email, password, forgot password link, submit action, and
+  "Criar conta" switch.
+- Register panel variant with name, email, password, confirm password, terms
+  acknowledgement, submit action, and "Ja tenho conta" switch.
+- Context panel explaining what the account unlocks:
+  - salvar listas
+  - continuar no celular
+  - receber status de nota fiscal
+  - preservar cidade/localizacao
+- Trust copy that does not mention payments or rewards.
+
+Required states:
+- empty fields
+- invalid email
+- wrong password
+- email already registered
+- loading submit
+- backend unavailable
+- successful login redirecting back to the requested screen
+
+Visual rules:
+- Compact form, no marketing hero.
+- Use one primary action per panel.
+- Do not use nested cards.
+- Keep form labels visible, not placeholder-only.
+- Password visibility toggle must have tooltip/accessibility label.
+- Error text must appear near the relevant field.
+
+Implementation notes:
+Map likely components to:
+- web/src/public/public-pages.tsx
+- web/src/public/public-shell.tsx
+- web/src/components/ui/input.tsx
+- web/src/components/ui/button.tsx
+- web/src/components/ui/card.tsx
+```
+

--- a/docs/design-system/screen-prompts/web-public/06-protected-auth-required.md
+++ b/docs/design-system/screen-prompts/web-public/06-protected-auth-required.md
@@ -1,0 +1,66 @@
+# Prompt: Public Web Protected Auth Required
+
+Use with `../00-shared-context.md`.
+
+```text
+Create only one screen: Pricely protected public-web state for a logged-out
+visitor trying to access a screen that requires an account.
+
+Viewport:
+- Desktop web, 1366px wide.
+- Include mobile behavior notes for 390px width.
+
+Scenario:
+- User is logged out.
+- User opened a protected route such as "Minhas listas" or "Notas fiscais".
+- City context may be selected or pending.
+- The app should show useful next actions instead of an empty page.
+
+Screen goal:
+Explain exactly why account access is needed, keep the user oriented in the
+product, and provide safe alternatives that work without login.
+
+Required content:
+- Public app shell matching the approved home reference:
+  - Pricely brand mark and wordmark.
+  - Sidebar navigation.
+  - Header with city/location context, notification icon, and account action.
+- Main panel title variants:
+  - "Entre para salvar suas listas" for lists.
+  - "Entre para acompanhar suas notas fiscais" for receipts.
+- Primary CTA: "Entrar agora".
+- Secondary CTA: "Criar conta".
+- Tertiary text/button to continue public browsing:
+  - "Ver ofertas da cidade"
+  - "Escolher cidade"
+- Action-oriented placeholders:
+  - If no lists: "Crie sua primeira lista para comparar precos por loja."
+  - If no receipts: "Envie sua primeira nota fiscal para acompanhar a validacao."
+  - "Saiba como funciona" link/button for receipts and saved lists.
+- Mini preview of what will appear after login, using skeleton/placeholder data
+  rather than fake personal values.
+
+Required states:
+- no selected city
+- selected city available
+- protected route for lists
+- protected route for receipts
+- submit/loading after clicking login
+- auth error returned from login
+
+Visual rules:
+- Do not leave a mostly empty page.
+- Do not show monetary savings, receipt totals, list counts, or personal metrics
+  for logged-out users.
+- Avoid alarmist copy; this is a normal account step.
+- Use compact evidence/status badges only when they explain state.
+- Keep the sidebar and header fixed and consistent with the home shell.
+
+Implementation notes:
+Map likely components to:
+- web/src/public/public-pages.tsx
+- web/src/public/public-shell.tsx
+- web/src/components/design-system/
+- web/src/components/ui/*
+```
+

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -586,6 +586,13 @@ sensitive monetary values across web surfaces.
 - [ ] T233 [P] Add required tooltips for admin icon buttons, status badges, destructive actions, technical IDs, billing-disabled copy, receipt moderation terms, and queue/job actions in `web/src/dashboard/`
 - [ ] T234 Add Playwright and unit coverage for action placeholders, tooltip presence, and hidden monetary values across public and admin web views in `web/src/` and `web/e2e/`
 
+### Phase 30: Web Shell, Auth Prompts, and Offer Card Visual QA
+
+- [ ] T235 [P] Align public web shell with `docs/design-system/reference-screens/web-public/public_web_home.png`: brand mark/wordmark, sidebar menu labels/order, fixed sidebar/header behavior, and header account/location/notification controls in `web/src/public/` and `web/src/components/design-system/`
+- [X] T236 [P] Add ChatGPT/Stitch-ready prompts for login, registration, and protected auth-required screens in `docs/design-system/screen-prompts/web-public/`
+- [ ] T237 [P] Fix public offer-card grid alignment, card height stability, action footer placement, and responsive spacing across logged-out/logged-in desktop and mobile states in `web/src/public/` and `web/e2e/`
+- [ ] T238 Extend smoke screenshot extraction to validate logged-out/logged-in shell state, protected auth-required state, offer-card alignment, and home placeholder copy against generated artifacts in `.tmp/smoke-screens-*` and `web/e2e/`
+
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.
 Validated public bundle load, customer login, receipt submission with


### PR DESCRIPTION
## Summary
- add ChatGPT/Stitch-ready prompts for login/register and protected auth-required screens
- add Phase 30 tasks for public shell parity with the reference home, offer-card alignment, and screenshot extraction coverage
- document the auth prompt generation order in the screen prompt README

## Validation
- `npm run e2e -- --project=chromium` from `web/`: 10 passed, 1 skipped
- smoke screenshots captured in `.tmp/smoke-screens-2026-06-18/`
- focused logged-out/logged-in screenshots captured in `.tmp/smoke-screens-2026-06-18/focused/`
- `git diff --check`

Refs #374