### PR TITLE
Align public web shell and offer cards

### DIFF
--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -588,10 +588,10 @@ sensitive monetary values across web surfaces.
 
 ### Phase 30: Web Shell, Auth Prompts, and Offer Card Visual QA
 
-- [ ] T235 [P] Align public web shell with `docs/design-system/reference-screens/web-public/public_web_home.png`: brand mark/wordmark, sidebar menu labels/order, fixed sidebar/header behavior, and header account/location/notification controls in `web/src/public/` and `web/src/components/design-system/`
+- [X] T235 [P] Align public web shell with `docs/design-system/reference-screens/web-public/public_web_home.png`: brand mark/wordmark, sidebar menu labels/order, fixed sidebar/header behavior, and header account/location/notification controls in `web/src/public/` and `web/src/components/design-system/`
 - [X] T236 [P] Add ChatGPT/Stitch-ready prompts for login, registration, and protected auth-required screens in `docs/design-system/screen-prompts/web-public/`
-- [ ] T237 [P] Fix public offer-card grid alignment, card height stability, action footer placement, and responsive spacing across logged-out/logged-in desktop and mobile states in `web/src/public/` and `web/e2e/`
-- [ ] T238 Extend smoke screenshot extraction to validate logged-out/logged-in shell state, protected auth-required state, offer-card alignment, and home placeholder copy against generated artifacts in `.tmp/smoke-screens-*` and `web/e2e/`
+- [X] T237 [P] Fix public offer-card grid alignment, card height stability, action footer placement, and responsive spacing across logged-out/logged-in desktop and mobile states in `web/src/public/` and `web/e2e/`
+- [X] T238 Extend smoke screenshot extraction to validate logged-out/logged-in shell state, protected auth-required state, offer-card alignment, and home placeholder copy against generated artifacts in `.tmp/smoke-screens-*` and `web/e2e/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.

--- a/web/e2e/shell-layout.spec.ts
+++ b/web/e2e/shell-layout.spec.ts
@@ -247,9 +247,11 @@ test('public shell uses fixed sidebar navigation instead of topbar nav', async (
   await expect(page.locator('[data-slot="sidebar-header"]')).toBeVisible();
   await expect(page.locator('[data-slot="sidebar-footer"]')).toBeVisible();
   await expect(page.locator('header nav')).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /Minha lista/i })).toBeVisible();
   await expect(
-    page.getByRole('link', { name: /Minhas listas/i }),
+    page.getByRole('button', { name: /Configurar localização/i }),
   ).toBeVisible();
+  await expect(page.getByRole('button', { name: /Notificacoes/i })).toBeVisible();
 
   const extraction = await extractShell(page, 'public-home-sidebar');
   expect(extraction.header).not.toBeNull();
@@ -257,7 +259,13 @@ test('public shell uses fixed sidebar navigation instead of topbar nav', async (
   expect(extraction.sidebarFooter).not.toBeNull();
   expect(extraction.headerNavCount).toBe(0);
   expect(extraction.navLabels).toEqual(
-    expect.arrayContaining(['Início', 'Ofertas', 'Cidades', 'Minhas listas']),
+    expect.arrayContaining([
+      'Inicio',
+      'Minha lista',
+      'Ofertas',
+      'Lojas',
+      'Notas fiscais',
+    ]),
   );
 });
 

--- a/web/src/components/design-system/app-sidebar-shell.tsx
+++ b/web/src/components/design-system/app-sidebar-shell.tsx
@@ -1,6 +1,9 @@
 import { useState, type FormEvent, type PropsWithChildren } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import {
+  BellIcon,
+  Building2Icon,
+  HistoryIcon,
   HomeIcon,
   LayoutDashboardIcon,
   ListChecksIcon,
@@ -9,7 +12,10 @@ import {
   MoonStarIcon,
   ReceiptTextIcon,
   SearchIcon,
+  SettingsIcon,
+  ShoppingCartIcon,
   SunMediumIcon,
+  TagsIcon,
   UserIcon,
 } from 'lucide-react';
 
@@ -51,16 +57,23 @@ import {
 } from '@/components/ui/sidebar';
 
 const publicNavItems = [
-  { label: 'Início', to: '/', icon: HomeIcon },
+  { label: 'Inicio', to: '/', icon: HomeIcon },
+  { label: 'Minha lista', to: '/listas', icon: ListChecksIcon },
   { label: 'Ofertas', to: '/ofertas', icon: SearchIcon },
-  { label: 'Cidades', to: '/cidades', icon: MapPinIcon },
-  { label: 'Minhas listas', to: '/listas', icon: ListChecksIcon },
+  { label: 'Lojas', to: '/cidades', icon: Building2Icon },
+  { label: 'Cupons', icon: TagsIcon, disabledReason: 'Cupons em breve' },
   { label: 'Notas fiscais', to: '/notas', icon: ReceiptTextIcon },
+  { label: 'Historico', icon: HistoryIcon, disabledReason: 'Historico em breve' },
+  {
+    label: 'Configuracoes',
+    icon: SettingsIcon,
+    disabledReason: 'Configuracoes em breve',
+  },
 ];
 
 function SidebarLogo() {
   return (
-    <Link className="flex items-center gap-3 rounded-lg px-2 py-2" to="/">
+    <Link className="flex items-center gap-2.5 rounded-lg px-2 py-2" to="/">
       <div className="flex size-9 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
         <img
           alt=""
@@ -69,7 +82,9 @@ function SidebarLogo() {
         />
       </div>
       <div className="flex flex-col gap-0.5 group-data-[collapsible=icon]:hidden">
-        <span className="text-sm font-semibold tracking-tight">Pricely</span>
+        <span className="font-heading text-base font-semibold tracking-tight">
+          pricely
+        </span>
         <span className="text-xs text-sidebar-foreground/70">
           economia com contexto real
         </span>
@@ -230,21 +245,34 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
             <SidebarGroupContent>
               <SidebarMenu aria-label="Navegacao principal">
                 {publicNavItems.map((item) => (
-                  <SidebarMenuItem key={item.to}>
-                    <SidebarMenuButton asChild tooltip={item.label}>
-                      <NavLink
-                        className={({ isActive }) =>
-                          isActive
-                            ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-                            : ''
-                        }
-                        end={item.to === '/'}
-                        to={item.to}
+                  <SidebarMenuItem key={item.label}>
+                    {item.to ? (
+                      <SidebarMenuButton asChild tooltip={item.label}>
+                        <NavLink
+                          className={({ isActive }) =>
+                            isActive
+                              ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                              : ''
+                          }
+                          end={item.to === '/'}
+                          to={item.to}
+                        >
+                          <item.icon />
+                          <span>{item.label}</span>
+                        </NavLink>
+                      </SidebarMenuButton>
+                    ) : (
+                      <SidebarMenuButton
+                        aria-disabled="true"
+                        className="opacity-55"
+                        disabled
+                        tooltip={item.disabledReason}
+                        type="button"
                       >
                         <item.icon />
                         <span>{item.label}</span>
-                      </NavLink>
-                    </SidebarMenuButton>
+                      </SidebarMenuButton>
+                    )}
                   </SidebarMenuItem>
                 ))}
                 {currentUser?.role === 'admin' ? (
@@ -267,56 +295,18 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
-
-          <SidebarGroup className="group-data-[collapsible=icon]:hidden">
-            <SidebarGroupLabel>Contexto</SidebarGroupLabel>
-            <SidebarGroupContent className="grid gap-2">
-              <Select
-                onValueChange={(value) => void setCityId(value)}
-                value={cityId ?? ''}
-              >
-                <SelectTrigger className="h-9 w-full bg-background">
-                  <MapPinIcon />
-                  <SelectValue placeholder="Escolha sua cidade" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    {cities.map((city) => (
-                      <SelectItem key={city.id} value={city.id}>
-                        {city.name} - {city.activeStoreCount} estabelecimentos
-                        ativos
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-
-              <Button
-                className="justify-start"
-                onClick={() => setIsLocationDialogOpen(true)}
-                size="sm"
-                type="button"
-                variant="outline"
-              >
-                <LocateFixedIcon data-icon="inline-start" />
-                Configurar localização
-              </Button>
-            </SidebarGroupContent>
-          </SidebarGroup>
         </SidebarContent>
 
         <SidebarFooter className="shrink-0">
           <div className="grid gap-2 rounded-lg border border-sidebar-border p-2 group-data-[collapsible=icon]:hidden">
             <div className="min-w-0">
               <p className="truncate text-sm font-medium">
-                {isAuthenticated
-                  ? (currentUser?.displayName ?? 'Minha conta')
-                  : 'Visitante'}
+                {activeCity ? activeCity.name : 'Cidade pendente'}
               </p>
               <p className="truncate text-xs text-sidebar-foreground/70">
                 {activeCity
-                  ? `${activeCity.name} - ${activeCity.activeStoreCount} lojas`
-                  : 'Cidade pendente'}
+                  ? `${activeCity.activeStoreCount} lojas ativas`
+                  : 'Escolha no header'}
               </p>
             </div>
             <div className="flex gap-2">
@@ -335,20 +325,16 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
                   <MoonStarIcon className="size-4" />
                 )}
               </Button>
-              {isAuthenticated ? (
-                <Button
-                  className="flex-1"
-                  onClick={signOut}
-                  size="sm"
-                  variant="outline"
-                >
-                  Sair
-                </Button>
-              ) : (
-                <Button asChild className="flex-1" size="sm">
-                  <Link to="/entrar">Entrar</Link>
-                </Button>
-              )}
+              <Button
+                className="flex-1"
+                onClick={() => setIsLocationDialogOpen(true)}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                <LocateFixedIcon data-icon="inline-start" />
+                Local
+              </Button>
             </div>
           </div>
           <Button
@@ -371,7 +357,7 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
       </Sidebar>
 
       <SidebarInset>
-        <header className="sticky top-0 z-30 flex min-h-14 shrink-0 items-center justify-between border-b border-border/70 bg-background/92 px-4 backdrop-blur lg:px-6">
+        <header className="sticky top-0 z-30 flex min-h-16 shrink-0 items-center justify-between gap-3 border-b border-border/70 bg-background/94 px-4 backdrop-blur lg:px-6">
           <div className="flex min-w-0 items-center gap-3">
             <SidebarTrigger />
             <div className="min-w-0">
@@ -386,18 +372,72 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
               </p>
             </div>
           </div>
-          <Button asChild size="sm" variant="outline">
-            <Link to={isAuthenticated ? '/listas' : '/criar-conta'}>
-              {isAuthenticated ? (
-                <>
-                  <UserIcon data-icon="inline-start" />
-                  Minha conta
-                </>
-              ) : (
-                'Criar conta'
-              )}
-            </Link>
-          </Button>
+          <div className="flex min-w-0 items-center justify-end gap-2">
+            <Select
+              onValueChange={(value) => void setCityId(value)}
+              value={cityId ?? ''}
+            >
+              <SelectTrigger className="hidden h-9 w-[260px] bg-background md:inline-flex">
+                <MapPinIcon />
+                <SelectValue placeholder="Escolha sua cidade" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {cities.map((city) => (
+                    <SelectItem key={city.id} value={city.id}>
+                      {city.name} - {city.activeStoreCount} estabelecimentos
+                      ativos
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            <Button
+              aria-label="Configurar localização"
+              onClick={() => setIsLocationDialogOpen(true)}
+              size="icon-sm"
+              type="button"
+              variant="outline"
+            >
+              <LocateFixedIcon className="size-4" />
+            </Button>
+            <Button
+              aria-label="Notificacoes"
+              size="icon-sm"
+              type="button"
+              variant="outline"
+            >
+              <BellIcon className="size-4" />
+            </Button>
+            {isAuthenticated ? (
+              <>
+                <Button asChild size="sm" variant="outline">
+                  <Link to="/listas">
+                    <UserIcon data-icon="inline-start" />
+                    <span className="hidden sm:inline">
+                      {currentUser?.displayName ?? 'Minha conta'}
+                    </span>
+                  </Link>
+                </Button>
+                <Button
+                  className="hidden lg:inline-flex"
+                  onClick={signOut}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  Sair
+                </Button>
+              </>
+            ) : (
+              <Button asChild size="sm" variant="outline">
+                <Link to="/criar-conta">
+                  <ShoppingCartIcon data-icon="inline-start" />
+                  Criar conta
+                </Link>
+              </Button>
+            )}
+          </div>
         </header>
 
         <div className="flex flex-1 flex-col gap-8 bg-[radial-gradient(circle_at_top_left,rgba(15,118,110,0.08),transparent_26%),radial-gradient(circle_at_85%_15%,rgba(37,99,235,0.06),transparent_22%)] px-4 py-6 lg:px-6">

--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   CitiesPage,
+  LandingPage,
   ListsPage,
   OfferDetailPage,
   OffersPage,
@@ -20,11 +21,13 @@ import {
 
 const fetchRegionOffers = vi.fn();
 const fetchOfferDetail = vi.fn();
+const fetchPublicImpact = vi.fn();
 const requestCityInclusion = vi.fn();
 const submitReceipt = vi.fn();
 
 const setCityId = vi.fn();
 const pricelyMockState = vi.hoisted(() => ({
+  isAuthenticated: true,
   profileOverride: null as Record<string, unknown> | null,
 }));
 
@@ -33,13 +36,15 @@ vi.mock('@/app/pricely-context', () => ({
     accessToken: 'token',
     cityId: 'campinas-sp',
     setCityId,
-    currentUser: {
-      id: 'user-1',
-      email: 'cliente@pricely.local',
-      displayName: 'Cliente',
-      role: 'customer',
-    },
-    isAuthenticated: true,
+    currentUser: pricelyMockState.isAuthenticated
+      ? {
+          id: 'user-1',
+          email: 'cliente@pricely.local',
+          displayName: 'Cliente',
+          role: 'customer',
+        }
+      : null,
+    isAuthenticated: pricelyMockState.isAuthenticated,
     isBootstrapping: false,
     profile: {
       listsCreated: 1,
@@ -52,30 +57,32 @@ vi.mock('@/app/pricely-context', () => ({
       checkoutEnabled: false,
       ...pricelyMockState.profileOverride,
     },
-    lists: [
-      {
-        id: 'list-1',
-        name: 'Compra semanal',
-        cityId: 'sao-paulo-sp',
-        lastMode: 'global_multi',
-        updatedAt: '2026-05-10T10:00:00.000Z',
-        expectedSavings: 12.4,
-        latestOptimizationStatus: 'completed',
-        items: [
+    lists: pricelyMockState.isAuthenticated
+      ? [
           {
-            id: 'item-1',
-            name: 'Arroz tipo 1 5kg',
-            quantity: 1,
-            unitLabel: 'un',
-            purchaseStatus: 'pending',
-            status: 'resolved',
-            imageUrl: 'https://example.com/arroz.png',
-            brandPreferenceMode: 'any',
-            preferredBrandNames: [],
+            id: 'list-1',
+            name: 'Compra semanal',
+            cityId: 'sao-paulo-sp',
+            lastMode: 'global_multi',
+            updatedAt: '2026-05-10T10:00:00.000Z',
+            expectedSavings: 12.4,
+            latestOptimizationStatus: 'completed',
+            items: [
+              {
+                id: 'item-1',
+                name: 'Arroz tipo 1 5kg',
+                quantity: 1,
+                unitLabel: 'un',
+                purchaseStatus: 'pending',
+                status: 'resolved',
+                imageUrl: 'https://example.com/arroz.png',
+                brandPreferenceMode: 'any',
+                preferredBrandNames: [],
+              },
+            ],
           },
-        ],
-      },
-    ],
+        ]
+      : [],
     cities: [
       {
         id: 'campinas-sp',
@@ -122,6 +129,7 @@ vi.mock('@/app/api', async () => {
     ...actual,
     fetchRegionOffers: (...args: unknown[]) => fetchRegionOffers(...args),
     fetchOfferDetail: (...args: unknown[]) => fetchOfferDetail(...args),
+    fetchPublicImpact: (...args: unknown[]) => fetchPublicImpact(...args),
     requestCityInclusion: (...args: unknown[]) => requestCityInclusion(...args),
     submitReceipt: (...args: unknown[]) => submitReceipt(...args),
   };
@@ -131,15 +139,48 @@ describe('public pages', () => {
   beforeEach(() => {
     fetchRegionOffers.mockReset();
     fetchOfferDetail.mockReset();
+    fetchPublicImpact.mockReset();
+    fetchPublicImpact.mockResolvedValue({
+      totalEstimatedSavings: 7.69,
+      optimizedListsCount: 8,
+    });
     requestCityInclusion.mockReset();
     submitReceipt.mockReset();
     setCityId.mockReset();
+    pricelyMockState.isAuthenticated = true;
     pricelyMockState.profileOverride = null;
   });
 
   afterEach(() => {
     vi.clearAllMocks();
     cleanup();
+  });
+
+  it('uses action placeholders on logged-out home receipt and savings cards', async () => {
+    pricelyMockState.isAuthenticated = false;
+    fetchRegionOffers.mockResolvedValue({
+      region: {
+        id: 'campinas-sp',
+        slug: 'campinas-sp',
+        name: 'Campinas',
+        stateCode: 'SP',
+      },
+      activeEstablishmentCount: 0,
+      offerCoverageStatus: 'collecting_data',
+      offers: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <LandingPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Envie sua primeira nota fiscal')).toBeTruthy();
+    expect(screen.getByText('Entre para ver sua economia')).toBeTruthy();
+    expect(screen.getAllByText('Aguardando lista').length).toBeGreaterThan(0);
+    expect(screen.queryByText('R$ 7,69')).toBeNull();
+    await waitFor(() => expect(fetchPublicImpact).toHaveBeenCalledTimes(1));
   });
 
   it('renders zero-store and collecting-data messaging for supported cities', () => {

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -723,17 +723,82 @@ function RequireAuthentication({
   }
 
   if (!isAuthenticated) {
+    const isReceiptRoute = title.toLowerCase().includes('nota');
+
     return (
-      <Alert>
-        <LogInIcon />
-        <AlertTitle>{title}</AlertTitle>
-        <AlertDescription className="space-y-3">
-          <p>{description}</p>
-          <Button asChild size="sm">
-            <Link to="/entrar">Entrar agora</Link>
-          </Button>
-        </AlertDescription>
-      </Alert>
+      <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <Card className="border-border/70 bg-card/95 shadow-sm">
+          <CardHeader>
+            <div className="flex items-start gap-3">
+              <span className="flex size-11 shrink-0 items-center justify-center rounded-full bg-[var(--ds-location-soft)] text-[var(--ds-location)]">
+                <LogInIcon className="size-5" />
+              </span>
+              <div className="min-w-0">
+                <CardTitle className="font-heading text-2xl">
+                  {isReceiptRoute
+                    ? 'Entre para acompanhar suas notas fiscais'
+                    : 'Entre para salvar suas listas'}
+                </CardTitle>
+                <CardDescription className="mt-1 text-base">
+                  {description}
+                </CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            <div className="grid gap-3 sm:grid-cols-3">
+              {[
+                isReceiptRoute
+                  ? 'Envie sua primeira nota fiscal'
+                  : 'Crie sua primeira lista',
+                'Continue no celular',
+                'Preserve cidade e preferencias',
+              ].map((item) => (
+                <div
+                  className="rounded-lg border border-border/70 bg-background/80 p-3 text-sm"
+                  key={item}
+                >
+                  {item}
+                </div>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button asChild>
+                <Link to="/entrar">Entrar agora</Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link to="/criar-conta">Criar conta</Link>
+              </Button>
+              <Button asChild variant="ghost">
+                <Link to="/ofertas">Ver ofertas da cidade</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/70 bg-card/90 shadow-sm">
+          <CardHeader>
+            <CardTitle>
+              {isReceiptRoute
+                ? 'Depois do envio'
+                : 'Depois da primeira lista'}
+            </CardTitle>
+            <CardDescription>
+              Preview sem dados pessoais ate voce entrar.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 text-sm">
+            <div className="rounded-lg border border-dashed border-border/80 p-3">
+              {isReceiptRoute
+                ? 'Status da nota, validacao e historico aparecem aqui.'
+                : 'Itens, marcas preferidas e otimizacao aparecem aqui.'}
+            </div>
+            <Button asChild variant="secondary">
+              <Link to="/cidades">Escolher cidade</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </section>
     );
   }
 
@@ -955,13 +1020,14 @@ export function LandingPage() {
 
   const estimatedSavings = impact?.totalEstimatedSavings ?? 0;
   const optimizedListsCount = impact?.optimizedListsCount ?? 0;
+  const hasAccount = Boolean(currentUser);
   const primaryOffer = featuredOffers[0];
   const secondaryOffers = featuredOffers.slice(0, 3);
   const coveragePercent = city ? 100 : 0;
   const activeStoreLabel = city
     ? `${city.activeStoreCount} lojas ativas`
     : 'Cidade pendente';
-  const lastReceiptTotal = activeList
+  const lastReceiptTotal = hasAccount && activeList
     ? Math.max(42.9, activeList.items.length * 20.45)
     : 0;
 
@@ -1223,18 +1289,21 @@ export function LandingPage() {
                 title: 'Sem cidade selecionada',
                 text: 'Escolha uma cidade para ver ofertas',
                 action: 'Selecionar cidade',
+                to: '/cidades',
               },
               {
                 icon: LockIcon,
                 title: 'Permissão de localização negada',
                 text: 'Ative a permissão para ver lojas perto de você',
-                action: 'Abrir configurações',
+                action: 'Escolher cidade',
+                to: '/cidades',
               },
               {
                 icon: StoreIcon,
                 title: 'Nenhuma loja no raio',
                 text: 'Não encontramos lojas ativas a 5 km de você',
-                action: 'Aumentar raio',
+                action: 'Ver lojas',
+                to: '/cidades',
               },
               {
                 icon: Clock3Icon,
@@ -1253,8 +1322,8 @@ export function LandingPage() {
                   {state.text}
                 </div>
                 {state.action ? (
-                  <Button className="mt-3" size="sm" variant="outline">
-                    {state.action}
+                  <Button asChild className="mt-3" size="sm" variant="outline">
+                    <Link to={state.to ?? '/cidades'}>{state.action}</Link>
                   </Button>
                 ) : (
                   <div className="mt-4 grid gap-2">
@@ -1278,25 +1347,40 @@ export function LandingPage() {
                 </span>
                 <div>
                   <CardTitle>Nota fiscal</CardTitle>
-                  <CardDescription>Aguardando liberação manual</CardDescription>
+                  <CardDescription>
+                    {hasAccount
+                      ? 'Aguardando liberação manual'
+                      : 'Envie sua primeira nota fiscal'}
+                  </CardDescription>
                 </div>
               </div>
-              <StatusBadge tone="warning">Aguardando</StatusBadge>
+              <StatusBadge tone={hasAccount ? 'warning' : 'neutral'}>
+                {hasAccount ? 'Aguardando' : 'Primeira nota'}
+              </StatusBadge>
             </div>
           </CardHeader>
           <CardContent className="grid gap-4">
             <div>
-              <div className="font-medium">Enviada para validação</div>
+              <div className="font-medium">
+                {hasAccount
+                  ? 'Enviada para validação'
+                  : 'Acompanhe a validação depois do envio'}
+              </div>
               <div className="mt-1 text-sm text-muted-foreground">
-                Total: {formatCurrency(lastReceiptTotal)}
+                {hasAccount
+                  ? `Total: ${formatCurrency(lastReceiptTotal)}`
+                  : 'Entre ou crie conta para salvar a nota e receber status.'}
               </div>
             </div>
             <div className="rounded-lg border border-[var(--ds-warning-border)] bg-[var(--ds-warning-soft)] p-3 text-sm">
-              Nossa equipe vai revisar sua nota fiscal. Você será avisado quando
-              for liberada.
+              {hasAccount
+                ? 'Nossa equipe vai revisar sua nota fiscal. Você será avisado quando for liberada.'
+                : 'Saiba como funciona: a nota entra em validação e só depois libera histórico e status na conta.'}
             </div>
             <Button asChild variant="outline">
-              <Link to="/notas">Ver detalhes</Link>
+              <Link to={hasAccount ? '/notas' : '/entrar'}>
+                {hasAccount ? 'Ver detalhes' : 'Enviar primeira nota fiscal'}
+              </Link>
             </Button>
           </CardContent>
         </Card>
@@ -1311,38 +1395,54 @@ export function LandingPage() {
           </CardHeader>
           <CardContent className="grid gap-4">
             <div>
-              <div className="font-heading text-4xl font-semibold text-[var(--ds-savings)]">
-                {formatCurrency(estimatedSavings)}
-              </div>
+              {hasAccount ? (
+                <div className="font-heading text-4xl font-semibold text-[var(--ds-savings)]">
+                  {formatCurrency(estimatedSavings)}
+                </div>
+              ) : (
+                <div className="font-heading text-2xl font-semibold text-foreground">
+                  Entre para ver sua economia
+                </div>
+              )}
               <div className="text-sm text-muted-foreground">
-                Economia estimada
+                {hasAccount
+                  ? 'Economia estimada'
+                  : 'Seu resumo aparece depois da primeira lista otimizada.'}
               </div>
             </div>
             <div className="divide-y divide-border/70 text-sm">
               <div className="flex justify-between py-2">
                 <span className="text-muted-foreground">Itens otimizados</span>
                 <span>
-                  {completedItemCount} de {activeList?.items.length ?? 0}
+                  {hasAccount
+                    ? `${completedItemCount} de ${activeList?.items.length ?? 0}`
+                    : 'Aguardando lista'}
                 </span>
               </div>
               <div className="flex justify-between py-2">
                 <span className="text-muted-foreground">Melhor loja</span>
-                <span>{primaryOffer?.storeName ?? 'Aguardando lista'}</span>
+                <span>
+                  {hasAccount
+                    ? (primaryOffer?.storeName ?? 'Aguardando lista')
+                    : 'Aguardando cidade'}
+                </span>
               </div>
               <div className="flex justify-between py-2">
                 <span className="text-muted-foreground">
                   Preços verificados
                 </span>
-                <span>{city ? '100%' : '0%'}</span>
+                <span>{hasAccount && city ? '100%' : 'Aguardando lista'}</span>
               </div>
               <div className="flex justify-between py-2">
                 <span className="text-muted-foreground">Listas otimizadas</span>
-                <span>{optimizedListsCount}</span>
+                <span>
+                  {hasAccount ? optimizedListsCount : 'Aguardando lista'}
+                </span>
               </div>
             </div>
             <Button asChild variant="ghost">
               <Link to={currentUser ? '/listas' : '/entrar'}>
-                Ver detalhes da economia
+                {hasAccount ? 'Ver detalhes da economia' : 'Saiba como funciona'}
                 <ArrowRightIcon data-icon="inline-end" />
               </Link>
             </Button>
@@ -1473,18 +1573,23 @@ export function OffersPage() {
         </div>
       ) : null}
 
-      <div className="grid gap-4 lg:grid-cols-3">
+      <div className="grid auto-rows-fr gap-4 md:grid-cols-2 xl:grid-cols-3">
         {visibleOfferGroups.map((group) => (
-          <Card key={group.id} className="overflow-hidden">
-            <div className="aspect-[16/9] overflow-hidden">
+          <Card
+            key={group.id}
+            className="flex h-full min-h-[520px] flex-col overflow-hidden"
+          >
+            <div className="h-44 shrink-0 overflow-hidden">
               <img
                 alt={group.variantName}
                 className="h-full w-full object-cover"
                 src={resolveProductImage(group.imageUrl)}
               />
             </div>
-            <CardHeader>
-              <CardTitle>{group.variantName}</CardTitle>
+            <CardHeader className="shrink-0">
+              <CardTitle className="line-clamp-2 min-h-[2.5rem]">
+                {group.variantName}
+              </CardTitle>
               <CardDescription>
                 {formatVariantWithPackage(
                   group.productName,
@@ -1492,7 +1597,7 @@ export function OffersPage() {
                 )}
               </CardDescription>
             </CardHeader>
-            <CardContent className="grid gap-3">
+            <CardContent className="flex flex-1 flex-col gap-3">
               <div className="flex flex-wrap gap-2">
                 {freshnessBadge('fresh')}
                 {confidenceBadge(
@@ -1553,7 +1658,7 @@ export function OffersPage() {
                 </div>
               ) : null}
               {group.alternativeOffers.length > 0 ? (
-                <details className="rounded-lg border border-border/70 p-3 text-sm">
+                <details className="mt-auto rounded-lg border border-border/70 p-3 text-sm">
                   <summary className="cursor-pointer font-medium">
                     Ver outros estabelecimentos
                   </summary>
@@ -1581,9 +1686,11 @@ export function OffersPage() {
                     ))}
                   </div>
                 </details>
-              ) : null}
+              ) : (
+                <div className="mt-auto min-h-12" />
+              )}
             </CardContent>
-            <CardFooter className="justify-end">
+            <CardFooter className="mt-auto shrink-0 justify-end border-t border-border/70">
               <Button asChild size="sm" variant="outline">
                 <Link to={`/ofertas/${group.bestOffer.id}`}>
                   Detalhe

--- a/web/src/public/public-shell.spec.tsx
+++ b/web/src/public/public-shell.spec.tsx
@@ -205,12 +205,13 @@ describe('PublicLayout', () => {
     renderPublicLayout();
 
     expect(screen.getByText('Navegacao')).toBeTruthy();
-    expect(screen.getByRole('link', { name: /Minhas listas/i })).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Minha lista/i })).toBeTruthy();
     expect(document.body.textContent).toMatch(/Localiza/);
     expect(screen.getByText(/raio de 5 km/i)).toBeTruthy();
     expect(
       screen.getByRole('button', { name: /configurar localiza/i }),
     ).toBeTruthy();
+    expect(screen.getByRole('button', { name: /notificacoes/i })).toBeTruthy();
     expect(
       screen.queryByText('Sua compra continua de onde voce parou'),
     ).toBeNull();


### PR DESCRIPTION
## Summary
- align public sidebar/header with the approved home reference: menu in sidebar, city/location/notifications/account in header
- add logged-out home placeholders for receipt and savings cards instead of personal-looking values
- replace protected auth-required alert with an action-oriented screen for lists/receipts
- stabilize public offer-card grid height, media, body, and footer alignment
- update shell extraction tests and public page tests

## Validation
- `npm run lint` from `web/`
- `npm test -- public-shell public-pages -- --runInBand` from `web/`: 15 passed
- `npm run e2e -- --project=chromium` from `web/`: 10 passed, 1 skipped
- screenshots captured in `.tmp/smoke-screens-2026-06-18/post-refactor-final/`

Refs #376