### PR TITLE
Add web monetary privacy primitives

### DIFF
--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -576,8 +576,8 @@ where compact controls or operational terms need clarification, and let users/ad
 sensitive monetary values across web surfaces.
 
 - [X] T225 Map web action placeholders, tooltip needs, and monetary privacy surfaces in `docs/product/web-action-placeholder-tooltip-privacy-plan.md`
-- [ ] T226 [P] Add design-system primitives for action-oriented empty states, contextual help tooltips, and masked monetary values in `web/src/components/design-system/`
-- [ ] T227 [P] Add web context support for persistent hide/show monetary visibility with sidebar/account controls and tests in `web/src/app/`, `web/src/components/design-system/`, and `web/src/public/`
+- [X] T226 [P] Add design-system primitives for action-oriented empty states, contextual help tooltips, and masked monetary values in `web/src/components/design-system/`
+- [X] T227 [P] Add web context support for persistent hide/show monetary visibility with sidebar/account controls and tests in `web/src/app/`, `web/src/components/design-system/`, and `web/src/public/`
 - [ ] T228 [P] Apply monetary masking to public home, offers, offer detail, profile/list summary, checklist, receipt submission, and optimization result values in `web/src/public/`
 - [ ] T229 [P] Apply monetary masking to admin overview, catalog/offers, receipt processing, user operations, list operations, and queue detail values in `web/src/dashboard/`
 - [ ] T230 [P] Replace passive public placeholders with action-oriented states for no city, no receipt, no list, no savings, no paid total, no result, no evidence, and no store plan in `web/src/public/`

--- a/web/src/app/monetary-privacy-context.tsx
+++ b/web/src/app/monetary-privacy-context.tsx
@@ -1,0 +1,64 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from 'react';
+
+type MonetaryPrivacyContextValue = {
+  isMoneyVisible: boolean;
+  setMoneyVisible: (visible: boolean) => void;
+  toggleMoneyVisibility: () => void;
+};
+
+const STORAGE_KEY = 'pricely-money-visible-v1';
+
+const MonetaryPrivacyContext =
+  createContext<MonetaryPrivacyContextValue | null>(null);
+
+export function MonetaryPrivacyProvider({ children }: PropsWithChildren) {
+  const [isMoneyVisible, setIsMoneyVisible] = useState(() => {
+    if (typeof window === 'undefined') {
+      return true;
+    }
+
+    return window.localStorage.getItem(STORAGE_KEY) !== 'hidden';
+  });
+
+  useEffect(() => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      isMoneyVisible ? 'visible' : 'hidden',
+    );
+  }, [isMoneyVisible]);
+
+  const value = useMemo<MonetaryPrivacyContextValue>(
+    () => ({
+      isMoneyVisible,
+      setMoneyVisible: setIsMoneyVisible,
+      toggleMoneyVisibility: () =>
+        setIsMoneyVisible((currentValue) => !currentValue),
+    }),
+    [isMoneyVisible],
+  );
+
+  return (
+    <MonetaryPrivacyContext.Provider value={value}>
+      {children}
+    </MonetaryPrivacyContext.Provider>
+  );
+}
+
+export function useMonetaryPrivacy() {
+  const context = useContext(MonetaryPrivacyContext);
+
+  if (!context) {
+    throw new Error(
+      'useMonetaryPrivacy must be used inside MonetaryPrivacyProvider',
+    );
+  }
+
+  return context;
+}

--- a/web/src/components/design-system/action-placeholder.tsx
+++ b/web/src/components/design-system/action-placeholder.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+type ActionPlaceholderProps = React.ComponentProps<typeof Card> & {
+  icon?: React.ReactNode;
+  title: React.ReactNode;
+  description: React.ReactNode;
+  primaryAction?: React.ReactNode;
+  secondaryAction?: React.ReactNode;
+};
+
+function ActionPlaceholder({
+  className,
+  description,
+  icon,
+  primaryAction,
+  secondaryAction,
+  title,
+  ...props
+}: ActionPlaceholderProps) {
+  return (
+    <Card
+      className={cn('border-dashed border-border/80 bg-card/80', className)}
+      {...props}
+    >
+      <CardHeader>
+        <div className="flex items-start gap-3">
+          {icon ? (
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--ds-location-soft)] text-[var(--ds-location)]">
+              {icon}
+            </span>
+          ) : null}
+          <div className="min-w-0">
+            <CardTitle>{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      {primaryAction || secondaryAction ? (
+        <CardContent className="flex flex-wrap gap-2 pt-0">
+          {primaryAction ? (
+            <Button asChild size="sm">
+              {primaryAction}
+            </Button>
+          ) : null}
+          {secondaryAction ? (
+            <Button asChild size="sm" variant="outline">
+              {secondaryAction}
+            </Button>
+          ) : null}
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}
+
+export { ActionPlaceholder };
+export type { ActionPlaceholderProps };
+

--- a/web/src/components/design-system/app-sidebar-shell.tsx
+++ b/web/src/components/design-system/app-sidebar-shell.tsx
@@ -3,6 +3,8 @@ import { Link, NavLink } from 'react-router-dom';
 import {
   BellIcon,
   Building2Icon,
+  EyeIcon,
+  EyeOffIcon,
   HistoryIcon,
   HomeIcon,
   LayoutDashboardIcon,
@@ -19,6 +21,7 @@ import {
   UserIcon,
 } from 'lucide-react';
 
+import { useMonetaryPrivacy } from '@/app/monetary-privacy-context';
 import { usePricely } from '@/app/pricely-context';
 import { useTheme } from '@/app/theme-context';
 import pricelyIcon from '@/assets/pricely-icon.png';
@@ -107,6 +110,7 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
     setCityId,
     signOut,
   } = usePricely();
+  const { isMoneyVisible, toggleMoneyVisibility } = useMonetaryPrivacy();
   const { theme, toggleTheme } = useTheme();
   const [locationPermissionState, setLocationPermissionState] = useState<
     | 'manual'
@@ -312,6 +316,23 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
             <div className="flex gap-2">
               <Button
                 aria-label={
+                  isMoneyVisible
+                    ? 'Ocultar valores monetários'
+                    : 'Mostrar valores monetários'
+                }
+                onClick={toggleMoneyVisibility}
+                size="icon-sm"
+                type="button"
+                variant="outline"
+              >
+                {isMoneyVisible ? (
+                  <EyeIcon className="size-4" />
+                ) : (
+                  <EyeOffIcon className="size-4" />
+                )}
+              </Button>
+              <Button
+                aria-label={
                   theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'
                 }
                 onClick={toggleTheme}
@@ -337,6 +358,24 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
               </Button>
             </div>
           </div>
+          <Button
+            aria-label={
+              isMoneyVisible
+                ? 'Ocultar valores monetários'
+                : 'Mostrar valores monetários'
+            }
+            className="hidden group-data-[collapsible=icon]:inline-flex"
+            onClick={toggleMoneyVisibility}
+            size="icon-sm"
+            type="button"
+            variant="outline"
+          >
+            {isMoneyVisible ? (
+              <EyeIcon className="size-4" />
+            ) : (
+              <EyeOffIcon className="size-4" />
+            )}
+          </Button>
           <Button
             aria-label={
               theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'

--- a/web/src/components/design-system/design-system.spec.tsx
+++ b/web/src/components/design-system/design-system.spec.tsx
@@ -1,11 +1,18 @@
 // @vitest-environment jsdom
 
+import type React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { MonetaryPrivacyProvider } from '@/app/monetary-privacy-context';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
 import {
+  ActionPlaceholder,
   AdminActionQueueItem,
   EvidenceModule,
+  InfoTooltip,
+  MaskedMoney,
   NextActionStrip,
   PriceRow,
   StatusBadge,
@@ -13,17 +20,28 @@ import {
   TechnicalDisclosure,
 } from './index';
 
-afterEach(cleanup);
+afterEach(() => {
+  window.localStorage.clear();
+  cleanup();
+});
+
+function renderDesignSystem(ui: React.ReactNode) {
+  return render(
+    <TooltipProvider>
+      <MonetaryPrivacyProvider>{ui}</MonetaryPrivacyProvider>
+    </TooltipProvider>,
+  );
+}
 
 describe('design-system component foundation', () => {
   it('renders semantic status badges with accessible text', () => {
-    render(<StatusBadge family="trust" status="high" />);
+    renderDesignSystem(<StatusBadge family="trust" status="high" />);
 
     expect(screen.getByText('Confiança alta')).toBeTruthy();
   });
 
   it('renders an evidence module with trust score and receipt evidence', () => {
-    render(
+    renderDesignSystem(
       <EvidenceModule
         selectedVariant="Camil Arroz tipo 1 1kg"
         requestedRule="Qualquer variante"
@@ -45,7 +63,7 @@ describe('design-system component foundation', () => {
   });
 
   it('renders a reusable price row', () => {
-    render(
+    renderDesignSystem(
       <PriceRow
         title="Arroz tipo 1"
         subtitle="Mercado Centro"
@@ -59,7 +77,7 @@ describe('design-system component foundation', () => {
   });
 
   it('renders workflow and admin primitives', () => {
-    render(
+    renderDesignSystem(
       <>
         <NextActionStrip
           eyebrow="Próximo passo"
@@ -82,5 +100,27 @@ describe('design-system component foundation', () => {
     expect(screen.getByText('Ação fixa')).toBeTruthy();
     expect(screen.getByText('Nota aguardando liberacao')).toBeTruthy();
     expect(screen.getByText('receipt-1')).toBeTruthy();
+  });
+
+  it('renders action placeholders, info tooltip triggers, and masked money', () => {
+    window.localStorage.setItem('pricely-money-visible-v1', 'hidden');
+
+    renderDesignSystem(
+      <>
+        <ActionPlaceholder
+          title="Envie sua primeira nota fiscal"
+          description="Acompanhe a validação depois do envio."
+        />
+        <InfoTooltip label="Valores podem ser ocultados." />
+        <MaskedMoney value="R$ 42,90" />
+      </>,
+    );
+
+    expect(screen.getByText('Envie sua primeira nota fiscal')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: /saiba como funciona/i }),
+    ).toBeTruthy();
+    expect(screen.getByText('R$ •••')).toBeTruthy();
+    expect(screen.queryByText('R$ 42,90')).toBeNull();
   });
 });

--- a/web/src/components/design-system/index.ts
+++ b/web/src/components/design-system/index.ts
@@ -1,7 +1,13 @@
+export { ActionPlaceholder } from './action-placeholder';
+export type { ActionPlaceholderProps } from './action-placeholder';
 export { AdminActionQueueItem } from './admin-action-queue-item';
 export type { AdminActionQueueItemProps } from './admin-action-queue-item';
 export { EvidenceModule } from './evidence-module';
 export type { EvidenceModuleProps } from './evidence-module';
+export { InfoTooltip } from './info-tooltip';
+export type { InfoTooltipProps } from './info-tooltip';
+export { MaskedMoney } from './masked-money';
+export type { MaskedMoneyProps } from './masked-money';
 export { NextActionStrip } from './next-action-strip';
 export type { NextActionStripProps } from './next-action-strip';
 export { PriceRow } from './price-row';

--- a/web/src/components/design-system/info-tooltip.tsx
+++ b/web/src/components/design-system/info-tooltip.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { InfoIcon } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+type InfoTooltipProps = {
+  label: React.ReactNode;
+  side?: React.ComponentProps<typeof TooltipContent>['side'];
+  className?: string;
+  triggerLabel?: string;
+};
+
+function InfoTooltip({
+  className,
+  label,
+  side = 'top',
+  triggerLabel = 'Saiba como funciona',
+}: InfoTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          aria-label={triggerLabel}
+          className={cn('size-7 text-muted-foreground', className)}
+          size="icon-sm"
+          type="button"
+          variant="ghost"
+        >
+          <InfoIcon className="size-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side={side}>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export { InfoTooltip };
+export type { InfoTooltipProps };
+

--- a/web/src/components/design-system/masked-money.tsx
+++ b/web/src/components/design-system/masked-money.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+
+import { useMonetaryPrivacy } from '@/app/monetary-privacy-context';
+import { cn } from '@/lib/utils';
+
+type MaskedMoneyProps = React.ComponentProps<'span'> & {
+  value: React.ReactNode;
+  mask?: string;
+};
+
+function MaskedMoney({
+  className,
+  mask = 'R$ •••',
+  value,
+  ...props
+}: MaskedMoneyProps) {
+  const { isMoneyVisible } = useMonetaryPrivacy();
+
+  return (
+    <span
+      className={cn('tabular-nums', className)}
+      data-money-visible={isMoneyVisible ? 'true' : 'false'}
+      {...props}
+    >
+      {isMoneyVisible ? value : mask}
+    </span>
+  );
+}
+
+export { MaskedMoney };
+export type { MaskedMoneyProps };
+

--- a/web/src/dashboard/admin-shell.tsx
+++ b/web/src/dashboard/admin-shell.tsx
@@ -1,6 +1,8 @@
 import { Link, NavLink, Outlet } from 'react-router-dom';
 import {
   DatabaseZapIcon,
+  EyeIcon,
+  EyeOffIcon,
   LayoutDashboardIcon,
   ListChecksIcon,
   MapPinnedIcon,
@@ -14,6 +16,7 @@ import {
   WorkflowIcon,
 } from 'lucide-react';
 
+import { useMonetaryPrivacy } from '@/app/monetary-privacy-context';
 import { usePricely } from '@/app/pricely-context';
 import { useTheme } from '@/app/theme-context';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -86,6 +89,7 @@ const adminNav = [
 
 export function AdminLayout() {
   const { currentUser, isAuthenticated } = usePricely();
+  const { isMoneyVisible, toggleMoneyVisibility } = useMonetaryPrivacy();
   const { theme, toggleTheme } = useTheme();
 
   if (!isAuthenticated || currentUser?.role !== 'admin') {
@@ -168,6 +172,23 @@ export function AdminLayout() {
             <div className="flex gap-2">
               <Button
                 aria-label={
+                  isMoneyVisible
+                    ? 'Ocultar valores monetários'
+                    : 'Mostrar valores monetários'
+                }
+                onClick={toggleMoneyVisibility}
+                size="icon-sm"
+                type="button"
+                variant="outline"
+              >
+                {isMoneyVisible ? (
+                  <EyeIcon className="size-4" />
+                ) : (
+                  <EyeOffIcon className="size-4" />
+                )}
+              </Button>
+              <Button
+                aria-label={
                   theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'
                 }
                 onClick={toggleTheme}
@@ -186,6 +207,24 @@ export function AdminLayout() {
               </Button>
             </div>
           </div>
+          <Button
+            aria-label={
+              isMoneyVisible
+                ? 'Ocultar valores monetários'
+                : 'Mostrar valores monetários'
+            }
+            className="hidden group-data-[collapsible=icon]:inline-flex"
+            onClick={toggleMoneyVisibility}
+            size="icon-sm"
+            type="button"
+            variant="outline"
+          >
+            {isMoneyVisible ? (
+              <EyeIcon className="size-4" />
+            ) : (
+              <EyeOffIcon className="size-4" />
+            )}
+          </Button>
           <Button
             aria-label={
               theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -57,6 +57,14 @@ vi.mock('@/app/pricely-context', () => ({
   }),
 }));
 
+vi.mock('@/app/monetary-privacy-context', () => ({
+  useMonetaryPrivacy: () => ({
+    isMoneyVisible: true,
+    setMoneyVisible: vi.fn(),
+    toggleMoneyVisibility: vi.fn(),
+  }),
+}));
+
 vi.mock('@/app/api', () => ({
   fetchAdminMetrics: (...args: unknown[]) => fetchAdminMetrics(...args),
   fetchAdminQueueHealth: (...args: unknown[]) => fetchAdminQueueHealth(...args),
@@ -884,7 +892,8 @@ describe('Admin dashboard pages', () => {
     fireEvent.click(screen.getByText('Ver conteúdo e matcher'));
     expect(await screen.findByText('CAFE PILAO 500G')).toBeTruthy();
     expect(screen.getByText('Payload extraído')).toBeTruthy();
-    expect(screen.getByText('1 itens · R$ 15,90')).toBeTruthy();
+    expect(screen.getAllByText(/1 itens/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('R$ 15,90').length).toBeGreaterThan(0);
     expect(
       screen.getByText(/35260500000000000100550010000000011000000011/),
     ).toBeTruthy();
@@ -892,7 +901,8 @@ describe('Admin dashboard pages', () => {
     expect(screen.getByText('Oferta criada')).toBeTruthy();
     expect(screen.getByText('Ver oferta criada')).toBeTruthy();
     expect(screen.getByText('Preço caiu')).toBeTruthy();
-    expect(screen.getByText(/R\$ 16,90 anterior/)).toBeTruthy();
+    expect(screen.getAllByText('R$ 16,90').length).toBeGreaterThan(0);
+    expect(screen.getByText(/anterior/)).toBeTruthy();
   });
 
   it('links pending receipts to the dedicated receipt audit before processing exists', async () => {

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -68,6 +68,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import {
   AdminActionQueueItem,
+  MaskedMoney,
   StatusBadge,
   TechnicalDisclosure,
 } from '@/components/design-system';
@@ -1544,13 +1545,19 @@ export function AdminPricesPage() {
                                   {offer.promotionalPriceAmount &&
                                   offer.basePriceAmount ? (
                                     <span className="text-xs text-muted-foreground line-through">
-                                      {formatCurrency(
-                                        Number(offer.basePriceAmount),
-                                      )}
+                                      <MaskedMoney
+                                        value={formatCurrency(
+                                          Number(offer.basePriceAmount),
+                                        )}
+                                      />
                                     </span>
                                   ) : null}
                                   <span>
-                                    {formatCurrency(Number(offer.priceAmount))}
+                                    <MaskedMoney
+                                      value={formatCurrency(
+                                        Number(offer.priceAmount),
+                                      )}
+                                    />
                                   </span>
                                 </div>
                               </TableCell>
@@ -2646,7 +2653,9 @@ export function AdminCatalogPage() {
                             </div>
                           </div>
                           <div className="text-right font-semibold">
-                            {formatCurrency(Number(offer.priceAmount))}
+                            <MaskedMoney
+                              value={formatCurrency(Number(offer.priceAmount))}
+                            />
                           </div>
                         </div>
                         <div className="flex flex-wrap gap-2">
@@ -3456,7 +3465,9 @@ export function AdminListsPage() {
                   Economia global estimada
                 </div>
                 <div className="text-2xl font-semibold">
-                  {formatCurrency(metrics.globalEstimatedSavings)}
+                  <MaskedMoney
+                    value={formatCurrency(metrics.globalEstimatedSavings)}
+                  />
                 </div>
               </div>
               <div className="rounded-lg border border-border/70 p-4">
@@ -3545,13 +3556,17 @@ export function AdminListsPage() {
                 </div>
                 <div className="mt-2 text-sm text-muted-foreground">
                   Custo{' '}
-                  {formatCurrency(
-                    selectedAudit.latestOptimization.totalEstimatedCost,
-                  )}{' '}
+                  <MaskedMoney
+                    value={formatCurrency(
+                      selectedAudit.latestOptimization.totalEstimatedCost,
+                    )}
+                  />{' '}
                   · economia{' '}
-                  {formatCurrency(
-                    selectedAudit.latestOptimization.estimatedSavings,
-                  )}
+                  <MaskedMoney
+                    value={formatCurrency(
+                      selectedAudit.latestOptimization.estimatedSavings,
+                    )}
+                  />
                 </div>
               </div>
             ) : null}
@@ -3978,9 +3993,11 @@ export function AdminReceiptsPage() {
                         </div>
                         <div className="mt-1 font-medium">
                           {receipt.extractedPayload.lineItemCount} itens ·{' '}
-                          {formatCurrency(
-                            receipt.extractedPayload.totalLineAmount,
-                          )}
+                          <MaskedMoney
+                            value={formatCurrency(
+                              receipt.extractedPayload.totalLineAmount,
+                            )}
+                          />
                         </div>
                       </div>
                       <div>
@@ -4070,16 +4087,23 @@ export function AdminReceiptsPage() {
                               Preço lido
                             </div>
                             <div className="mt-1 font-medium">
-                              {formatCurrency(item.unitPrice)}
+                              <MaskedMoney
+                                value={formatCurrency(item.unitPrice)}
+                              />
                             </div>
                             <div className="text-xs text-muted-foreground">
-                              total {formatCurrency(item.lineTotal)}
+                              total{' '}
+                              <MaskedMoney
+                                value={formatCurrency(item.lineTotal)}
+                              />
                             </div>
                             {item.originalUnitPrice &&
                             item.originalUnitPrice !== item.unitPrice ? (
                               <div className="text-xs text-muted-foreground">
                                 original{' '}
-                                {formatCurrency(item.originalUnitPrice)}
+                                <MaskedMoney
+                                  value={formatCurrency(item.originalUnitPrice)}
+                                />
                               </div>
                             ) : null}
                           </div>
@@ -4147,7 +4171,11 @@ export function AdminReceiptsPage() {
                                       {offer.neighborhood}
                                     </TableCell>
                                     <TableCell>
-                                      {formatCurrency(offer.priceAmount)}
+                                      <MaskedMoney
+                                        value={formatCurrency(
+                                          offer.priceAmount,
+                                        )}
+                                      />
                                     </TableCell>
                                     <TableCell>
                                       <div className="grid gap-1">
@@ -4166,15 +4194,26 @@ export function AdminReceiptsPage() {
                                           )}
                                         </StatusBadge>
                                         <span className="text-xs text-muted-foreground">
-                                          {offer.comparison.previousPriceAmount
-                                            ? `${formatCurrency(
-                                                offer.comparison
-                                                  .previousPriceAmount,
-                                              )} anterior · ${formatCurrency(
-                                                offer.comparison.deltaAmount ??
-                                                  0,
-                                              )}`
-                                            : 'Sem oferta anterior comparável'}
+                                          {offer.comparison
+                                            .previousPriceAmount ? (
+                                            <>
+                                              <MaskedMoney
+                                                value={formatCurrency(
+                                                  offer.comparison
+                                                    .previousPriceAmount,
+                                                )}
+                                              />{' '}
+                                              anterior ·{' '}
+                                              <MaskedMoney
+                                                value={formatCurrency(
+                                                  offer.comparison
+                                                    .deltaAmount ?? 0,
+                                                )}
+                                              />
+                                            </>
+                                          ) : (
+                                            'Sem oferta anterior comparável'
+                                          )}
                                         </span>
                                       </div>
                                     </TableCell>
@@ -4523,7 +4562,11 @@ export function AdminReceiptAuditPage() {
               </div>
               <div className="mt-1 font-medium">
                 {receipt.extractedPayload.lineItemCount} itens ·{' '}
-                {formatCurrency(receipt.extractedPayload.totalLineAmount)}
+                <MaskedMoney
+                  value={formatCurrency(
+                    receipt.extractedPayload.totalLineAmount,
+                  )}
+                />
               </div>
             </div>
             <div>
@@ -4602,10 +4645,10 @@ export function AdminReceiptAuditPage() {
                       Preço lido
                     </div>
                     <div className="mt-1 font-medium">
-                      {formatCurrency(item.unitPrice)}
+                      <MaskedMoney value={formatCurrency(item.unitPrice)} />
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      total {formatCurrency(item.lineTotal)}
+                      total <MaskedMoney value={formatCurrency(item.lineTotal)} />
                     </div>
                   </div>
                   <div className="rounded-md border border-border/70 p-3">
@@ -5060,7 +5103,11 @@ export function AdminQueueDetailPage() {
                           <TableCell>{item.rawProductName}</TableCell>
                           <TableCell>{item.normalizedName}</TableCell>
                           <TableCell>{item.quantity}</TableCell>
-                          <TableCell>{formatCurrency(item.unitPrice)}</TableCell>
+                          <TableCell>
+                            <MaskedMoney
+                              value={formatCurrency(item.unitPrice)}
+                            />
+                          </TableCell>
                           <TableCell>
                             {Math.round(item.matchConfidence * 100)}%
                           </TableCell>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 
+import { MonetaryPrivacyProvider } from './app/monetary-privacy-context';
 import { PricelyProvider } from './app/pricely-context';
 import { ThemeProvider } from './app/theme-context';
 import { TooltipProvider } from './components/ui/tooltip';
@@ -12,9 +13,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ThemeProvider>
       <TooltipProvider>
-        <PricelyProvider>
-          <RouterProvider router={appRouter} />
-        </PricelyProvider>
+        <MonetaryPrivacyProvider>
+          <PricelyProvider>
+            <RouterProvider router={appRouter} />
+          </PricelyProvider>
+        </MonetaryPrivacyProvider>
       </TooltipProvider>
     </ThemeProvider>
   </React.StrictMode>,

--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import type React from 'react';
 import {
   cleanup,
   fireEvent,
@@ -9,6 +10,9 @@ import {
 } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MonetaryPrivacyProvider } from '@/app/monetary-privacy-context';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 import {
   CitiesPage,
@@ -156,6 +160,15 @@ describe('public pages', () => {
     cleanup();
   });
 
+  const renderPublicPage = (ui: React.ReactNode) =>
+    render(
+      <TooltipProvider>
+        <MonetaryPrivacyProvider>
+          <MemoryRouter>{ui}</MemoryRouter>
+        </MonetaryPrivacyProvider>
+      </TooltipProvider>,
+    );
+
   it('uses action placeholders on logged-out home receipt and savings cards', async () => {
     pricelyMockState.isAuthenticated = false;
     fetchRegionOffers.mockResolvedValue({
@@ -170,11 +183,7 @@ describe('public pages', () => {
       offers: [],
     });
 
-    render(
-      <MemoryRouter>
-        <LandingPage />
-      </MemoryRouter>,
-    );
+    renderPublicPage(<LandingPage />);
 
     expect(screen.getByText('Envie sua primeira nota fiscal')).toBeTruthy();
     expect(screen.getByText('Entre para ver sua economia')).toBeTruthy();
@@ -184,11 +193,7 @@ describe('public pages', () => {
   });
 
   it('renders zero-store and collecting-data messaging for supported cities', () => {
-    render(
-      <MemoryRouter>
-        <CitiesPage />
-      </MemoryRouter>,
-    );
+    renderPublicPage(<CitiesPage />);
 
     expect(screen.getByText('Cidades suportadas')).toBeTruthy();
     expect(
@@ -215,11 +220,7 @@ describe('public pages', () => {
       createdAt: '2026-05-10T10:00:00.000Z',
     });
 
-    render(
-      <MemoryRouter>
-        <CitiesPage />
-      </MemoryRouter>,
-    );
+    renderPublicPage(<CitiesPage />);
 
     fireEvent.change(screen.getByLabelText('Cidade'), {
       target: { value: 'Santos' },
@@ -244,11 +245,7 @@ describe('public pages', () => {
   });
 
   it('renders the shopper next action lane on lists', () => {
-    render(
-      <MemoryRouter>
-        <ListsPage />
-      </MemoryRouter>,
-    );
+    renderPublicPage(<ListsPage />);
 
     expect(screen.getByText('Use o checklist no mercado')).toBeTruthy();
     expect(screen.getByText('Lista')).toBeTruthy();
@@ -266,11 +263,7 @@ describe('public pages', () => {
       checkoutEnabled: false,
     };
 
-    render(
-      <MemoryRouter>
-        <ListsPage />
-      </MemoryRouter>,
-    );
+    renderPublicPage(<ListsPage />);
 
     expect(screen.getAllByText('Premium ativo').length).toBeGreaterThan(0);
     expect(screen.getByText('Benefícios Premium')).toBeTruthy();
@@ -292,11 +285,7 @@ describe('public pages', () => {
         'Nota recebida: reward em processamento ate a liberacao e validacao.',
     });
 
-    render(
-      <MemoryRouter>
-        <ReceiptSubmissionPage />
-      </MemoryRouter>,
-    );
+    renderPublicPage(<ReceiptSubmissionPage />);
 
     fireEvent.change(screen.getByLabelText('Estabelecimento'), {
       target: { value: 'Mercado Centro' },
@@ -346,11 +335,7 @@ describe('public pages', () => {
         'Nota validada: voce ganhou 100 pontos e 1 credito de otimizacao.',
     });
 
-    render(
-      <MemoryRouter>
-        <ReceiptSubmissionPage />
-      </MemoryRouter>,
-    );
+    renderPublicPage(<ReceiptSubmissionPage />);
 
     fireEvent.change(screen.getByLabelText('Estabelecimento'), {
       target: { value: 'Mercado Validado' },
@@ -383,11 +368,7 @@ describe('public pages', () => {
       offers: [],
     });
 
-    render(
-      <MemoryRouter>
-        <OffersPage />
-      </MemoryRouter>,
-    );
+    renderPublicPage(<OffersPage />);
 
     expect(await screen.findByText('Ofertas por cidade')).toBeTruthy();
     expect(
@@ -471,11 +452,7 @@ describe('public pages', () => {
       ],
     });
 
-    render(
-      <MemoryRouter>
-        <OffersPage />
-      </MemoryRouter>,
-    );
+    renderPublicPage(<OffersPage />);
 
     expect(await screen.findByText('Arroz Camil tipo 1 5kg')).toBeTruthy();
     expect(screen.getByText('Arroz tipo 1 5kg')).toBeTruthy();
@@ -483,12 +460,9 @@ describe('public pages', () => {
     expect(
       screen.getByText(/Menor preço em Unidade Vila Mariana/),
     ).toBeTruthy();
-    expect(
-      screen.getByText(/R\$ 1,00 abaixo do próximo menor preço/),
-    ).toBeTruthy();
-    expect(
-      screen.getByText(/Média da variante na cidade: R\$ 22,40/),
-    ).toBeTruthy();
+    expect(screen.getAllByText('R$ 1,00').length).toBeGreaterThan(0);
+    expect(screen.getByText(/abaixo/)).toBeTruthy();
+    expect(screen.getByText('R$ 22,40')).toBeTruthy();
     expect(screen.getByText('Ver outros estabelecimentos')).toBeTruthy();
   });
 
@@ -548,11 +522,7 @@ describe('public pages', () => {
       ],
     });
 
-    render(
-      <MemoryRouter>
-        <OffersPage />
-      </MemoryRouter>,
-    );
+    renderPublicPage(<OffersPage />);
 
     expect(
       await screen.findByText('Feijao Carioca Camil 1kg'),
@@ -619,11 +589,15 @@ describe('public pages', () => {
     });
 
     render(
-      <MemoryRouter initialEntries={['/ofertas/offer-1']}>
-        <Routes>
-          <Route path="/ofertas/:offerId" element={<OfferDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
+      <TooltipProvider>
+        <MonetaryPrivacyProvider>
+          <MemoryRouter initialEntries={['/ofertas/offer-1']}>
+            <Routes>
+              <Route path="/ofertas/:offerId" element={<OfferDetailPage />} />
+            </Routes>
+          </MemoryRouter>
+        </MonetaryPrivacyProvider>
+      </TooltipProvider>,
     );
 
     await waitFor(() => expect(screen.getByText('Cafe torrado')).toBeTruthy());

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -64,6 +64,8 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import {
   EvidenceModule,
+  InfoTooltip,
+  MaskedMoney,
   PriceRow,
   StatusBadge,
   StickyActionBar,
@@ -441,7 +443,7 @@ function PriceDisplay({
     <div className="grid gap-1">
       {hasPromotion ? (
         <div className="text-sm text-muted-foreground line-through">
-          {formatCurrency(basePriceAmount)}
+          <MaskedMoney value={formatCurrency(basePriceAmount)} />
         </div>
       ) : null}
       <div
@@ -449,7 +451,7 @@ function PriceDisplay({
           size === 'lg' ? 'text-4xl font-semibold' : 'text-2xl font-semibold'
         }
       >
-        {formatCurrency(priceAmount)}
+        <MaskedMoney value={formatCurrency(priceAmount)} />
       </div>
     </div>
   );
@@ -1050,13 +1052,17 @@ export function LandingPage() {
                   : 'Escolha uma cidade para começar'}
             </h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              {activeList
-                ? `Sua lista está pronta para otimização. Última economia estimada: ${formatCurrency(
-                    estimatedSavings,
-                  )}.`
-                : city
-                  ? 'Monte uma lista com produtos comparáveis antes de ir ao mercado.'
-                  : 'A cidade define ofertas, lojas e evidências usadas na comparação.'}
+              {activeList ? (
+                <>
+                  Sua lista está pronta para otimização. Última economia
+                  estimada:{' '}
+                  <MaskedMoney value={formatCurrency(estimatedSavings)} />.
+                </>
+              ) : city ? (
+                'Monte uma lista com produtos comparáveis antes de ir ao mercado.'
+              ) : (
+                'A cidade define ofertas, lojas e evidências usadas na comparação.'
+              )}
             </p>
           </div>
           <div className="grid gap-2 sm:justify-items-end">
@@ -1244,7 +1250,7 @@ export function LandingPage() {
                     <div className="flex items-end justify-between gap-3">
                       <div>
                         <div className="font-heading text-2xl font-semibold text-[var(--ds-location)]">
-                          {formatCurrency(offer.price)}
+                          <MaskedMoney value={formatCurrency(offer.price)} />
                         </div>
                         <div className="text-xs text-muted-foreground">
                           Preço otimizado
@@ -1253,7 +1259,11 @@ export function LandingPage() {
                       <div className="rounded-md bg-[var(--ds-savings-soft)] px-3 py-2 text-right text-sm text-[var(--ds-savings)]">
                         <div>Economize</div>
                         <div className="font-semibold">
-                          {formatCurrency(offer.savingsVsRegionalAverage ?? 0)}
+                          <MaskedMoney
+                            value={formatCurrency(
+                              offer.savingsVsRegionalAverage ?? 0,
+                            )}
+                          />
                         </div>
                       </div>
                     </div>
@@ -1367,9 +1377,14 @@ export function LandingPage() {
                   : 'Acompanhe a validação depois do envio'}
               </div>
               <div className="mt-1 text-sm text-muted-foreground">
-                {hasAccount
-                  ? `Total: ${formatCurrency(lastReceiptTotal)}`
-                  : 'Entre ou crie conta para salvar a nota e receber status.'}
+                {hasAccount ? (
+                  <>
+                    Total:{' '}
+                    <MaskedMoney value={formatCurrency(lastReceiptTotal)} />
+                  </>
+                ) : (
+                  'Entre ou crie conta para salvar a nota e receber status.'
+                )}
               </div>
             </div>
             <div className="rounded-lg border border-[var(--ds-warning-border)] bg-[var(--ds-warning-soft)] p-3 text-sm">
@@ -1389,7 +1404,7 @@ export function LandingPage() {
           <CardHeader>
             <div className="flex items-center justify-between gap-3">
               <CardTitle>Resumo de economia</CardTitle>
-              <InfoIcon className="size-4 text-muted-foreground" />
+              <InfoTooltip label="Valores monetários podem ser ocultados pelo botão de privacidade no header." />
             </div>
             <CardDescription>Esta semana</CardDescription>
           </CardHeader>
@@ -1397,7 +1412,7 @@ export function LandingPage() {
             <div>
               {hasAccount ? (
                 <div className="font-heading text-4xl font-semibold text-[var(--ds-savings)]">
-                  {formatCurrency(estimatedSavings)}
+                  <MaskedMoney value={formatCurrency(estimatedSavings)} />
                 </div>
               ) : (
                 <div className="font-heading text-2xl font-semibold text-foreground">
@@ -1626,9 +1641,14 @@ export function OffersPage() {
               {(group.savingsVsSecondCheapest ?? 0) > 0 &&
               group.secondCheapestPriceAmount ? (
                 <div className="text-sm font-medium text-[var(--ds-savings)]">
-                  {formatCurrency(group.savingsVsSecondCheapest ?? 0)} abaixo do
-                  próximo menor preço (
-                  {formatCurrency(group.secondCheapestPriceAmount)}).
+                  <MaskedMoney
+                    value={formatCurrency(group.savingsVsSecondCheapest ?? 0)}
+                  />{' '}
+                  abaixo do próximo menor preço (
+                  <MaskedMoney
+                    value={formatCurrency(group.secondCheapestPriceAmount)}
+                  />
+                  ).
                 </div>
               ) : group.establishmentCount > 1 ? (
                 <div className="text-sm text-muted-foreground">
@@ -1638,14 +1658,16 @@ export function OffersPage() {
               {group.averagePriceAmount > 0 ? (
                 <div className="text-sm text-muted-foreground">
                   Média da variante na cidade:{' '}
-                  {formatCurrency(group.averagePriceAmount)}
+                  <MaskedMoney value={formatCurrency(group.averagePriceAmount)} />
                   {group.averagePriceAmount > group.cheapestPriceAmount ? (
                     <>
                       {' '}
                       ·{' '}
-                      {formatCurrency(
-                        group.averagePriceAmount - group.cheapestPriceAmount,
-                      )}{' '}
+                      <MaskedMoney
+                        value={formatCurrency(
+                          group.averagePriceAmount - group.cheapestPriceAmount,
+                        )}
+                      />{' '}
                       acima do menor preço
                     </>
                   ) : null}
@@ -1673,13 +1695,17 @@ export function OffersPage() {
                         </span>
                         <div className="text-right">
                           <div className="font-medium">
-                            {formatCurrency(offer.priceAmount)}
+                            <MaskedMoney
+                              value={formatCurrency(offer.priceAmount)}
+                            />
                           </div>
                           <div className="text-xs text-muted-foreground">
                             +
-                            {formatCurrency(
-                              offer.priceAmount - group.cheapestPriceAmount,
-                            )}
+                            <MaskedMoney
+                              value={formatCurrency(
+                                offer.priceAmount - group.cheapestPriceAmount,
+                              )}
+                            />
                           </div>
                         </div>
                       </div>

--- a/web/src/public/public-shell.spec.tsx
+++ b/web/src/public/public-shell.spec.tsx
@@ -16,6 +16,7 @@ import {
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { MonetaryPrivacyProvider } from '@/app/monetary-privacy-context';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 import { PublicLayout } from './public-shell';
@@ -174,7 +175,9 @@ function renderPublicLayout() {
   return render(
     <MemoryRouter>
       <TooltipProvider>
-        <PublicLayout />
+        <MonetaryPrivacyProvider>
+          <PublicLayout />
+        </MonetaryPrivacyProvider>
       </TooltipProvider>
     </MemoryRouter>,
   );

--- a/web/src/public/security.spec.tsx
+++ b/web/src/public/security.spec.tsx
@@ -4,6 +4,9 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { MonetaryPrivacyProvider } from '@/app/monetary-privacy-context';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
 import { OfferDetailPage } from './public-pages';
 
 const fetchOfferDetail = vi.fn();
@@ -69,11 +72,15 @@ describe('public web security rendering', () => {
     });
 
     const { container } = render(
-      <MemoryRouter initialEntries={['/ofertas/offer-xss']}>
-        <Routes>
-          <Route path="/ofertas/:offerId" element={<OfferDetailPage />} />
-        </Routes>
-      </MemoryRouter>,
+      <TooltipProvider>
+        <MonetaryPrivacyProvider>
+          <MemoryRouter initialEntries={['/ofertas/offer-xss']}>
+            <Routes>
+              <Route path="/ofertas/:offerId" element={<OfferDetailPage />} />
+            </Routes>
+          </MemoryRouter>
+        </MonetaryPrivacyProvider>
+      </TooltipProvider>,
     );
 
     await waitFor(() =>

--- a/web/src/routes/app-router.spec.tsx
+++ b/web/src/routes/app-router.spec.tsx
@@ -5,6 +5,7 @@ import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ThemeProvider } from '@/app/theme-context';
+import { MonetaryPrivacyProvider } from '@/app/monetary-privacy-context';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 import { dashboardRoute } from './dashboard';
@@ -125,7 +126,9 @@ function renderRoute(initialEntry: string) {
   return render(
     <TooltipProvider>
       <ThemeProvider>
-        <RouterProvider router={router} />
+        <MonetaryPrivacyProvider>
+          <RouterProvider router={router} />
+        </MonetaryPrivacyProvider>
       </ThemeProvider>
     </TooltipProvider>,
   );


### PR DESCRIPTION
## Summary\n- Add ActionPlaceholder, InfoTooltip, and MaskedMoney design-system primitives.\n- Add persistent monetary privacy context and sidebar controls in public/admin shells.\n- Mask key public/admin monetary surfaces and update provider-aware tests.\n- Mark T226-T227 complete in the roadmap tasks.\n\nIssue: #378\n\n## Validation\n- npm run build\n- npm run lint\n- npm test -- design-system public-shell public-pages dashboard-pages app-router\n- npm run e2e -- --project=chromium