### PR TITLE
Add public tooltip coverage

### DIFF
--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -582,7 +582,7 @@ sensitive monetary values across web surfaces.
 - [X] T229 [P] Apply monetary masking to admin overview, catalog/offers, receipt processing, user operations, list operations, and queue detail values in `web/src/dashboard/`
 - [X] T230 [P] Replace passive public placeholders with action-oriented states for no city, no receipt, no list, no savings, no paid total, no result, no evidence, and no store plan in `web/src/public/`
 - [X] T231 [P] Replace passive admin placeholders with action-oriented states for empty receipt queues, healthy/empty job queues, no failed jobs, no low-trust offers, no user activity, and disabled job actions in `web/src/dashboard/`
-- [ ] T232 [P] Add required tooltips for public icon buttons, status badges, trust/freshness/reward copy, receipt terms, location states, and sensitive monetary toggles in `web/src/public/` and `web/src/components/design-system/`
+- [X] T232 [P] Add required tooltips for public icon buttons, status badges, trust/freshness/reward copy, receipt terms, location states, and sensitive monetary toggles in `web/src/public/` and `web/src/components/design-system/`
 - [ ] T233 [P] Add required tooltips for admin icon buttons, status badges, destructive actions, technical IDs, billing-disabled copy, receipt moderation terms, and queue/job actions in `web/src/dashboard/`
 - [ ] T234 Add Playwright and unit coverage for action placeholders, tooltip presence, and hidden monetary values across public and admin web views in `web/src/` and `web/e2e/`
 

--- a/web/src/components/design-system/app-sidebar-shell.tsx
+++ b/web/src/components/design-system/app-sidebar-shell.tsx
@@ -58,6 +58,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '@/components/ui/sidebar';
+import { WithTooltip } from '@/components/design-system/with-tooltip';
 
 const publicNavItems = [
   { label: 'Inicio', to: '/', icon: HomeIcon },
@@ -314,38 +315,50 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
               </p>
             </div>
             <div className="flex gap-2">
-              <Button
-                aria-label={
+              <WithTooltip
+                label={
                   isMoneyVisible
-                    ? 'Ocultar valores monetários'
-                    : 'Mostrar valores monetários'
+                    ? 'Oculta valores monetários sensíveis em cards, listas e otimizações.'
+                    : 'Mostra novamente valores monetários em cards, listas e otimizações.'
                 }
-                onClick={toggleMoneyVisibility}
-                size="icon-sm"
-                type="button"
-                variant="outline"
               >
-                {isMoneyVisible ? (
-                  <EyeIcon className="size-4" />
-                ) : (
-                  <EyeOffIcon className="size-4" />
-                )}
-              </Button>
-              <Button
-                aria-label={
-                  theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'
-                }
-                onClick={toggleTheme}
-                size="icon-sm"
-                type="button"
-                variant="outline"
-              >
-                {theme === 'dark' ? (
-                  <SunMediumIcon className="size-4" />
-                ) : (
-                  <MoonStarIcon className="size-4" />
-                )}
-              </Button>
+                <Button
+                  aria-label={
+                    isMoneyVisible
+                      ? 'Ocultar valores monetários'
+                      : 'Mostrar valores monetários'
+                  }
+                  onClick={toggleMoneyVisibility}
+                  size="icon-sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {isMoneyVisible ? (
+                    <EyeIcon className="size-4" />
+                  ) : (
+                    <EyeOffIcon className="size-4" />
+                  )}
+                </Button>
+              </WithTooltip>
+              <WithTooltip label="Alterna entre tema claro e escuro.">
+                <Button
+                  aria-label={
+                    theme === 'dark'
+                      ? 'Ativar modo claro'
+                      : 'Ativar modo escuro'
+                  }
+                  onClick={toggleTheme}
+                  size="icon-sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {theme === 'dark' ? (
+                    <SunMediumIcon className="size-4" />
+                  ) : (
+                    <MoonStarIcon className="size-4" />
+                  )}
+                </Button>
+              </WithTooltip>
               <Button
                 className="flex-1"
                 onClick={() => setIsLocationDialogOpen(true)}
@@ -358,40 +371,50 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
               </Button>
             </div>
           </div>
-          <Button
-            aria-label={
+          <WithTooltip
+            label={
               isMoneyVisible
-                ? 'Ocultar valores monetários'
-                : 'Mostrar valores monetários'
+                ? 'Oculta valores monetários sensíveis em cards, listas e otimizações.'
+                : 'Mostra novamente valores monetários em cards, listas e otimizações.'
             }
-            className="hidden group-data-[collapsible=icon]:inline-flex"
-            onClick={toggleMoneyVisibility}
-            size="icon-sm"
-            type="button"
-            variant="outline"
           >
-            {isMoneyVisible ? (
-              <EyeIcon className="size-4" />
-            ) : (
-              <EyeOffIcon className="size-4" />
-            )}
-          </Button>
-          <Button
-            aria-label={
-              theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'
-            }
-            className="hidden group-data-[collapsible=icon]:inline-flex"
-            onClick={toggleTheme}
-            size="icon-sm"
-            type="button"
-            variant="outline"
-          >
-            {theme === 'dark' ? (
-              <SunMediumIcon className="size-4" />
-            ) : (
-              <MoonStarIcon className="size-4" />
-            )}
-          </Button>
+            <Button
+              aria-label={
+                isMoneyVisible
+                  ? 'Ocultar valores monetários'
+                  : 'Mostrar valores monetários'
+              }
+              className="hidden group-data-[collapsible=icon]:inline-flex"
+              onClick={toggleMoneyVisibility}
+              size="icon-sm"
+              type="button"
+              variant="outline"
+            >
+              {isMoneyVisible ? (
+                <EyeIcon className="size-4" />
+              ) : (
+                <EyeOffIcon className="size-4" />
+              )}
+            </Button>
+          </WithTooltip>
+          <WithTooltip label="Alterna entre tema claro e escuro.">
+            <Button
+              aria-label={
+                theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'
+              }
+              className="hidden group-data-[collapsible=icon]:inline-flex"
+              onClick={toggleTheme}
+              size="icon-sm"
+              type="button"
+              variant="outline"
+            >
+              {theme === 'dark' ? (
+                <SunMediumIcon className="size-4" />
+              ) : (
+                <MoonStarIcon className="size-4" />
+              )}
+            </Button>
+          </WithTooltip>
         </SidebarFooter>
       </Sidebar>
 
@@ -431,23 +454,27 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
                 </SelectGroup>
               </SelectContent>
             </Select>
-            <Button
-              aria-label="Configurar localização"
-              onClick={() => setIsLocationDialogOpen(true)}
-              size="icon-sm"
-              type="button"
-              variant="outline"
-            >
-              <LocateFixedIcon className="size-4" />
-            </Button>
-            <Button
-              aria-label="Notificacoes"
-              size="icon-sm"
-              type="button"
-              variant="outline"
-            >
-              <BellIcon className="size-4" />
-            </Button>
+            <WithTooltip label="Configure cidade, CEP ou localização precisa para calcular cobertura local.">
+              <Button
+                aria-label="Configurar localização"
+                onClick={() => setIsLocationDialogOpen(true)}
+                size="icon-sm"
+                type="button"
+                variant="outline"
+              >
+                <LocateFixedIcon className="size-4" />
+              </Button>
+            </WithTooltip>
+            <WithTooltip label="Notificações de preço, cobertura e revisão aparecerão aqui quando habilitadas.">
+              <Button
+                aria-label="Notificacoes"
+                size="icon-sm"
+                type="button"
+                variant="outline"
+              >
+                <BellIcon className="size-4" />
+              </Button>
+            </WithTooltip>
             {isAuthenticated ? (
               <>
                 <Button asChild size="sm" variant="outline">

--- a/web/src/components/design-system/design-system.spec.tsx
+++ b/web/src/components/design-system/design-system.spec.tsx
@@ -18,6 +18,7 @@ import {
   StatusBadge,
   StickyActionBar,
   TechnicalDisclosure,
+  WithTooltip,
 } from './index';
 
 afterEach(() => {
@@ -35,7 +36,13 @@ function renderDesignSystem(ui: React.ReactNode) {
 
 describe('design-system component foundation', () => {
   it('renders semantic status badges with accessible text', () => {
-    renderDesignSystem(<StatusBadge family="trust" status="high" />);
+    renderDesignSystem(
+      <StatusBadge
+        family="trust"
+        status="high"
+        tooltip="Confiança combina origem, frescor e quantidade de evidências."
+      />,
+    );
 
     expect(screen.getByText('Confiança alta')).toBeTruthy();
   });
@@ -113,6 +120,9 @@ describe('design-system component foundation', () => {
         />
         <InfoTooltip label="Valores podem ser ocultados." />
         <MaskedMoney value="R$ 42,90" />
+        <WithTooltip label="Ação contextual">
+          <button type="button">Acao com tooltip</button>
+        </WithTooltip>
       </>,
     );
 

--- a/web/src/components/design-system/evidence-module.tsx
+++ b/web/src/components/design-system/evidence-module.tsx
@@ -59,9 +59,17 @@ function EvidenceModule({
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="font-medium">{title}</div>
         <div className="flex flex-wrap items-center gap-1.5">
-          <StatusBadge family="trust" status={trustLevel} />
+          <StatusBadge
+            family="trust"
+            status={trustLevel}
+            tooltip="Confiança combina origem, frescor e quantidade de evidências para este preço."
+          />
           {trustScore !== undefined ? (
-            <StatusBadge icon={GaugeIcon} tone="neutral">
+            <StatusBadge
+              icon={GaugeIcon}
+              tone="neutral"
+              tooltip="Score interno de confiança usado para destacar preços que precisam de revisão."
+            >
               <span className="tabular-nums">{trustScore}/100</span>
             </StatusBadge>
           ) : null}
@@ -85,14 +93,22 @@ function EvidenceModule({
         <StatusBadge
           icon={ReceiptTextIcon}
           tone={evidenceCount ? 'savings' : 'neutral'}
+          tooltip="Origem informada para explicar se o preço veio de nota fiscal aceita, seed operacional ou outra fonte."
         >
           {sourceLabel ?? 'Origem operacional'}
         </StatusBadge>
-        <StatusBadge tone={evidenceCount ? 'savings' : 'neutral'}>
+        <StatusBadge
+          tone={evidenceCount ? 'savings' : 'neutral'}
+          tooltip="Quantidade de notas fiscais aceitas que sustentam este preço observado."
+        >
           {evidenceLabel}
         </StatusBadge>
         {freshnessLabel ? (
-          <StatusBadge family="freshness" status="aging">
+          <StatusBadge
+            family="freshness"
+            status="aging"
+            tooltip="Frescor indica quando a última evidência de preço foi validada."
+          >
             {freshnessLabel}
           </StatusBadge>
         ) : null}

--- a/web/src/components/design-system/index.ts
+++ b/web/src/components/design-system/index.ts
@@ -23,3 +23,5 @@ export { StickyActionBar } from './sticky-action-bar';
 export type { StickyActionBarProps } from './sticky-action-bar';
 export { TechnicalDisclosure } from './technical-disclosure';
 export type { TechnicalDisclosureProps } from './technical-disclosure';
+export { WithTooltip } from './with-tooltip';
+export type { WithTooltipProps } from './with-tooltip';

--- a/web/src/components/design-system/info-tooltip.tsx
+++ b/web/src/components/design-system/info-tooltip.tsx
@@ -2,11 +2,8 @@ import * as React from 'react';
 import { InfoIcon } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+import type { TooltipContent } from '@/components/ui/tooltip';
+import { WithTooltip } from '@/components/design-system/with-tooltip';
 import { cn } from '@/lib/utils';
 
 type InfoTooltipProps = {
@@ -23,23 +20,19 @@ function InfoTooltip({
   triggerLabel = 'Saiba como funciona',
 }: InfoTooltipProps) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          aria-label={triggerLabel}
-          className={cn('size-7 text-muted-foreground', className)}
-          size="icon-sm"
-          type="button"
-          variant="ghost"
-        >
-          <InfoIcon className="size-4" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side={side}>{label}</TooltipContent>
-    </Tooltip>
+    <WithTooltip label={label} side={side}>
+      <Button
+        aria-label={triggerLabel}
+        className={cn('size-7 text-muted-foreground', className)}
+        size="icon-sm"
+        type="button"
+        variant="ghost"
+      >
+        <InfoIcon className="size-4" />
+      </Button>
+    </WithTooltip>
   );
 }
 
 export { InfoTooltip };
 export type { InfoTooltipProps };
-

--- a/web/src/components/design-system/status-badge.tsx
+++ b/web/src/components/design-system/status-badge.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
+import { WithTooltip } from '@/components/design-system/with-tooltip';
 import { cn } from '@/lib/utils';
 
 const statusBadgeVariants = cva(
@@ -107,6 +108,8 @@ type StatusBadgeProps = React.ComponentProps<typeof Badge> &
     status?: string;
     icon?: React.ElementType | null;
     label?: string;
+    tooltip?: React.ReactNode;
+    tooltipSide?: React.ComponentProps<typeof WithTooltip>['side'];
   };
 
 function getStatusPreset(family?: StatusFamily, status?: string) {
@@ -129,6 +132,8 @@ function StatusBadge({
   icon,
   label,
   tone,
+  tooltip,
+  tooltipSide,
   children,
   ...props
 }: StatusBadgeProps) {
@@ -137,7 +142,7 @@ function StatusBadge({
   const badgeTone = tone ?? preset?.tone ?? 'neutral';
   const content = children ?? label ?? preset?.label ?? status;
 
-  return (
+  const badge = (
     <Badge
       data-slot="status-badge"
       variant="outline"
@@ -147,6 +152,16 @@ function StatusBadge({
       {Icon ? <Icon aria-hidden="true" /> : null}
       {content}
     </Badge>
+  );
+
+  if (!tooltip) {
+    return badge;
+  }
+
+  return (
+    <WithTooltip label={tooltip} side={tooltipSide}>
+      {badge}
+    </WithTooltip>
   );
 }
 

--- a/web/src/components/design-system/with-tooltip.tsx
+++ b/web/src/components/design-system/with-tooltip.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+type WithTooltipProps = {
+  children: React.ReactElement;
+  label: React.ReactNode;
+  side?: React.ComponentProps<typeof TooltipContent>['side'];
+};
+
+function WithTooltip({ children, label, side = 'top' }: WithTooltipProps) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side}>{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export { WithTooltip };
+export type { WithTooltipProps };

--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -314,7 +314,7 @@ describe('public pages', () => {
         ],
       }),
     );
-    expect(screen.getByText('Nota recebida')).toBeTruthy();
+    expect(await screen.findByText('Nota recebida')).toBeTruthy();
     expect(
       screen.getAllByText(/aguardando liberação manual/).length,
     ).toBeGreaterThan(0);

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -71,6 +71,7 @@ import {
   PriceRow,
   StatusBadge,
   StickyActionBar,
+  WithTooltip,
 } from '@/components/design-system';
 import {
   Card,
@@ -259,32 +260,62 @@ function toOptimizationError(error: unknown) {
 function freshnessBadge(level: FreshnessLevel) {
   if (level === 'fresh') {
     return (
-      <StatusBadge family="freshness" status="fresh">
+      <StatusBadge
+        family="freshness"
+        status="fresh"
+        tooltip="Preço validado hoje ou dentro da janela mais recente da cidade."
+      >
         Atualizado hoje
       </StatusBadge>
     );
   }
   if (level === 'aging') {
-    return <StatusBadge family="freshness" status="aging" />;
+    return (
+      <StatusBadge
+        family="freshness"
+        status="aging"
+        tooltip="Há evidência de preço, mas a cobertura ainda é parcial ou menos recente."
+      />
+    );
   }
 
-  return <StatusBadge family="freshness" status="stale" />;
+  return (
+    <StatusBadge
+      family="freshness"
+      status="stale"
+      tooltip="Preço antigo: use como referência e confirme antes de comprar."
+    />
+  );
 }
 
 function confidenceBadge(level: ConfidenceLevel) {
   if (level === 'alta') {
     return (
-      <StatusBadge family="trust" status="high">
+      <StatusBadge
+        family="trust"
+        status="high"
+        tooltip="Alta confiança: preço sustentado por evidências recentes e consistentes."
+      >
         Confiança alta
       </StatusBadge>
     );
   }
   if (level === 'media') {
-    return <StatusBadge family="trust" status="medium" />;
+    return (
+      <StatusBadge
+        family="trust"
+        status="medium"
+        tooltip="Confiança média: preço útil para comparação, mas ainda pede confirmação."
+      />
+    );
   }
 
   return (
-    <StatusBadge family="trust" status="low">
+    <StatusBadge
+      family="trust"
+      status="low"
+      tooltip="Confiança baixa: revise loja, variante e data antes de tomar decisão."
+    >
       Revisar
     </StatusBadge>
   );
@@ -466,21 +497,33 @@ function PriceDisplay({
 function cityStatusBadge(city: SupportedCity) {
   if (city.status === 'supported') {
     return (
-      <StatusBadge family="city" status="active">
+      <StatusBadge
+        family="city"
+        status="active"
+        tooltip="Cidade disponível para ofertas, listas e otimização com cobertura local."
+      >
         Disponível
       </StatusBadge>
     );
   }
   if (city.status === 'pilot') {
     return (
-      <StatusBadge family="city" status="activating">
+      <StatusBadge
+        family="city"
+        status="activating"
+        tooltip="Cidade em piloto: parte dos dados ainda está sendo calibrada."
+      >
         Piloto
       </StatusBadge>
     );
   }
 
   return (
-    <StatusBadge family="city" status="hidden">
+    <StatusBadge
+      family="city"
+      status="hidden"
+      tooltip="Ainda sem cobertura pública; você pode registrar interesse para priorização."
+    >
       Em breve
     </StatusBadge>
   );
@@ -2441,6 +2484,7 @@ export function ReceiptSubmissionPage() {
                             ? 'warning'
                             : undefined
                         }
+                        tooltip="Status da fila após o envio: a nota pode aguardar liberação manual, processamento ou nova tentativa."
                       >
                         {submission.processingStatus ===
                         'waiting_manual_release'
@@ -2469,6 +2513,7 @@ export function ReceiptSubmissionPage() {
                             ? 'rejected'
                             : submission.rewardEligibilityStatus
                         }
+                        tooltip="Reward depende da qualidade da nota, validação da evidência e regras antifraude."
                       >
                         {submission.rewardEligibilityStatus === 'granted'
                           ? 'Validado e concedido'
@@ -2516,7 +2561,13 @@ export function ReceiptSubmissionPage() {
 
         <Card className="border-[var(--ds-savings-border)] bg-[var(--ds-savings-soft)]/70 shadow-sm">
           <CardHeader>
-            <CardTitle>Como o reward funciona</CardTitle>
+            <div className="flex items-center gap-2">
+              <CardTitle>Como o reward funciona</CardTitle>
+              <InfoTooltip
+                label="O reward só é concedido depois que a nota passa por liberação, processamento e validação de confiança."
+                triggerLabel="Entender regras do reward"
+              />
+            </div>
             <CardDescription>
               Envio recebido, reward em processamento, nota validada e reward
               concedido depois da liberação/admin e processamento da fila.
@@ -3693,24 +3744,30 @@ export function ListEditorPage() {
               <span className="text-sm font-medium text-primary">
                 {items.length} {items.length === 1 ? 'item' : 'itens'}
               </span>
-              <Button
-                aria-label="Compartilhar lista"
-                size="icon"
-                type="button"
-                variant="outline"
-              >
-                <ArrowRightIcon className="size-4 rotate-[-35deg]" />
-              </Button>
-              <Button
-                aria-label="Remover itens"
-                disabled={items.length === 0}
-                onClick={() => setItems([])}
-                size="icon"
-                type="button"
-                variant="outline"
-              >
-                <ClipboardListIcon className="size-4" />
-              </Button>
+              <WithTooltip label="Compartilhar lista quando o link público estiver disponível.">
+                <Button
+                  aria-label="Compartilhar lista"
+                  size="icon"
+                  type="button"
+                  variant="outline"
+                >
+                  <ArrowRightIcon className="size-4 rotate-[-35deg]" />
+                </Button>
+              </WithTooltip>
+              <WithTooltip label="Remove todos os itens desta lista antes de salvar.">
+                <span className="inline-flex">
+                  <Button
+                    aria-label="Remover itens"
+                    disabled={items.length === 0}
+                    onClick={() => setItems([])}
+                    size="icon"
+                    type="button"
+                    variant="outline"
+                  >
+                    <ClipboardListIcon className="size-4" />
+                  </Button>
+                </span>
+              </WithTooltip>
             </div>
           </div>
 
@@ -4321,13 +4378,15 @@ export function OptimizationPage() {
                     </span>
                   </div>
                   <div className="flex items-center gap-3">
-                    <Button
-                      aria-label="Notificações"
-                      size="icon"
-                      variant="ghost"
-                    >
-                      <BellIcon className="size-4" />
-                    </Button>
+                    <WithTooltip label="Alertas sobre preço, cobertura e revisão desta otimização aparecerão aqui.">
+                      <Button
+                        aria-label="Notificações"
+                        size="icon"
+                        variant="ghost"
+                      >
+                        <BellIcon className="size-4" />
+                      </Button>
+                    </WithTooltip>
                     <div className="hidden items-center gap-3 sm:flex">
                       <div className="grid size-9 place-items-center rounded-full bg-[var(--ds-warning-soft)] text-sm font-semibold text-[var(--ds-warning)]">
                         M
@@ -4397,6 +4456,10 @@ export function OptimizationPage() {
                     <RefreshCwIcon className="size-4" />
                     Recalcular
                   </Button>
+                  <InfoTooltip
+                    label="Recalcula a lista com preços, cobertura e regras atuais da cidade selecionada."
+                    triggerLabel="Como funciona o recálculo"
+                  />
                   <Button asChild>
                     <Link to={`/listas/${list.id}/checklist`}>
                       <ListChecksIcon className="size-4" />


### PR DESCRIPTION
## Summary
- add a reusable design-system WithTooltip primitive and route InfoTooltip/StatusBadge through it
- add public tooltip copy for trust, freshness, city, receipt, reward, location, notification, and monetary privacy states
- mark T232 complete in the grocery optimizer task list

## Validation
- npm run build
- npm run lint
- npm test
- npm run e2e -- --project=chromium

Issue: #386