### PR TITLE
Add web coverage for placeholders, tooltips, and hidden money

### DIFF
--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -584,7 +584,7 @@ sensitive monetary values across web surfaces.
 - [X] T231 [P] Replace passive admin placeholders with action-oriented states for empty receipt queues, healthy/empty job queues, no failed jobs, no low-trust offers, no user activity, and disabled job actions in `web/src/dashboard/`
 - [X] T232 [P] Add required tooltips for public icon buttons, status badges, trust/freshness/reward copy, receipt terms, location states, and sensitive monetary toggles in `web/src/public/` and `web/src/components/design-system/`
 - [X] T233 [P] Add required tooltips for admin icon buttons, status badges, destructive actions, technical IDs, billing-disabled copy, receipt moderation terms, and queue/job actions in `web/src/dashboard/`
-- [ ] T234 Add Playwright and unit coverage for action placeholders, tooltip presence, and hidden monetary values across public and admin web views in `web/src/` and `web/e2e/`
+- [X] T234 Add Playwright and unit coverage for action placeholders, tooltip presence, and hidden monetary values across public and admin web views in `web/src/` and `web/e2e/`
 
 ### Phase 30: Web Shell, Auth Prompts, and Offer Card Visual QA
 

--- a/web/e2e/mvp-smoke.spec.ts
+++ b/web/e2e/mvp-smoke.spec.ts
@@ -582,6 +582,12 @@ test('MVP shopper flow covers sign-in, city, list, optimization, checklist, and 
   await expect(
     page.getByRole('button', { name: /Premium indispon/i }),
   ).toBeDisabled();
+  await page
+    .getByRole('button', { name: /Ocultar valores monetários/i })
+    .first()
+    .click();
+  await page.goto('/');
+  await expect(page.getByText('R$ •••').first()).toBeVisible();
 
   await page.goto('/cidades');
   await expect(page.getByText('Cidades suportadas').first()).toBeVisible();
@@ -670,6 +676,8 @@ test('MVP receipt flow covers submission, admin audit release, and reward state'
   await expect(
     page.getByText('Aguardando liberação manual', { exact: true }),
   ).toBeVisible();
+  await page.getByText('Aguardando liberação manual', { exact: true }).hover();
+  await expect(page.getByText(/Status da fila após o envio/i)).toBeVisible();
   await expect(page.getByText(/Reward previsto/i)).toBeVisible();
   await expect(page.getByText('Admin libera no dashboard')).toBeVisible();
 
@@ -721,6 +729,8 @@ test('MVP admin flow covers route protection and queue detail', async ({
   await expect(
     page.getByText(/ID t.cnico: receipt .* receipt-1 .* job job-1/),
   ).toBeVisible();
+  await page.getByText('Em fila', { exact: true }).hover();
+  await expect(page.getByText(/Job aguardando worker/i)).toBeVisible();
   await page.goto('/dashboard/fila/job-1');
 
   await expect(

--- a/web/e2e/shell-layout.spec.ts
+++ b/web/e2e/shell-layout.spec.ts
@@ -252,6 +252,12 @@ test('public shell uses fixed sidebar navigation instead of topbar nav', async (
     page.getByRole('button', { name: /Configurar localização/i }),
   ).toBeVisible();
   await expect(page.getByRole('button', { name: /Notificacoes/i })).toBeVisible();
+  await page
+    .getByRole('button', { name: /Configurar localização/i })
+    .hover();
+  await expect(
+    page.getByText(/Configure cidade, CEP ou localização precisa/i),
+  ).toBeVisible();
 
   const extraction = await extractShell(page, 'public-home-sidebar');
   expect(extraction.header).not.toBeNull();
@@ -290,6 +296,13 @@ test('dashboard shell keeps sidebar, header, and footer fixed across admin pages
     page.getByText('Dashboard restrito a administradores'),
   ).toBeVisible();
   await expect(page.getByText('Admin Pricely')).toBeVisible();
+  await page
+    .getByRole('button', { name: /Ocultar valores monetários/i })
+    .first()
+    .hover();
+  await expect(
+    page.getByText(/Oculta valores monetários sensíveis em métricas/i),
+  ).toBeVisible();
 
   const extraction = await extractShell(page, 'admin-queue-sidebar');
   expect(extraction.header).not.toBeNull();

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -7,7 +7,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   AdminCatalogPage,
@@ -43,6 +43,9 @@ const deleteAdminProductVariant = vi.fn();
 const fetchAdminUsers = vi.fn();
 const setAdminUserPremium = vi.fn();
 const grantAdminUserTokens = vi.fn();
+const monetaryPrivacyMockState = vi.hoisted(() => ({
+  isMoneyVisible: true,
+}));
 
 vi.mock('@/app/pricely-context', () => ({
   usePricely: () => ({
@@ -59,7 +62,7 @@ vi.mock('@/app/pricely-context', () => ({
 
 vi.mock('@/app/monetary-privacy-context', () => ({
   useMonetaryPrivacy: () => ({
-    isMoneyVisible: true,
+    isMoneyVisible: monetaryPrivacyMockState.isMoneyVisible,
     setMoneyVisible: vi.fn(),
     toggleMoneyVisibility: vi.fn(),
   }),
@@ -257,6 +260,14 @@ function buildAdminOffer(overrides: Record<string, unknown> = {}) {
 }
 
 describe('Admin dashboard pages', () => {
+  beforeAll(() => {
+    globalThis.ResizeObserver ??= class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
   beforeEach(() => {
     fetchAdminMetrics.mockReset();
     fetchAdminQueueHealth.mockReset();
@@ -279,6 +290,7 @@ describe('Admin dashboard pages', () => {
     fetchAdminUsers.mockReset();
     setAdminUserPremium.mockReset();
     grantAdminUserTokens.mockReset();
+    monetaryPrivacyMockState.isMoneyVisible = true;
   });
 
   afterEach(() => {
@@ -882,6 +894,18 @@ describe('Admin dashboard pages', () => {
     ).toHaveLength(2);
     expect(screen.getByText('100 pontos + 1 credito pendente')).toBeTruthy();
     expect(screen.getByText('Elegível pendente')).toBeTruthy();
+    fireEvent.pointerMove(screen.getByText('Elegível pendente'), {
+      pointerType: 'mouse',
+    });
+    expect(
+      await screen.findAllByText(/Reward elegível, mas pendente/i),
+    ).not.toHaveLength(0);
+    fireEvent.pointerMove(screen.getAllByText('Aceita')[0], {
+      pointerType: 'mouse',
+    });
+    expect(
+      await screen.findAllByText(/Nota aceita para evidência/i),
+    ).not.toHaveLength(0);
     expect(screen.getByText('Auditar processamento')).toBeTruthy();
     expect(
       screen.getByText('Auditar processamento').closest('a')?.getAttribute('href'),
@@ -904,6 +928,19 @@ describe('Admin dashboard pages', () => {
     expect(screen.getByText('Preço caiu')).toBeTruthy();
     expect(screen.getAllByText('R$ 16,90').length).toBeGreaterThan(0);
     expect(screen.getByText(/anterior/)).toBeTruthy();
+  });
+
+  it('hides admin receipt money values when monetary privacy is disabled', async () => {
+    monetaryPrivacyMockState.isMoneyVisible = false;
+    fetchAdminReceiptProcessing.mockResolvedValue([buildReceiptAudit()]);
+
+    render(<AdminReceiptsPage />);
+
+    expect(await screen.findByText('Notas fiscais processadas')).toBeTruthy();
+    fireEvent.click(screen.getByText('Ver conteúdo e matcher'));
+
+    expect(await screen.findAllByText('R$ •••')).not.toHaveLength(0);
+    expect(screen.queryByText('R$ 15,90')).toBeNull();
   });
 
   it('links pending receipts to the dedicated receipt audit before processing exists', async () => {
@@ -1055,6 +1092,13 @@ describe('Admin dashboard pages', () => {
     expect(screen.getByText('Sao Paulo - SP')).toBeTruthy();
     expect(screen.getByText('2 creditos disponiveis')).toBeTruthy();
     expect(screen.getByText('Billing desativado')).toBeTruthy();
+    fireEvent.pointerMove(
+      screen.getByRole('button', { name: 'Entender billing desativado' }),
+      { pointerType: 'mouse' },
+    );
+    expect(
+      await screen.findAllByText(/Billing está desativado neste MVP/i),
+    ).not.toHaveLength(0);
 
     fireEvent.click(screen.getByText('Ativar premium'));
     await waitFor(() =>

--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -9,7 +9,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MonetaryPrivacyProvider } from '@/app/monetary-privacy-context';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -140,6 +140,14 @@ vi.mock('@/app/api', async () => {
 });
 
 describe('public pages', () => {
+  beforeAll(() => {
+    globalThis.ResizeObserver ??= class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
   beforeEach(() => {
     fetchRegionOffers.mockReset();
     fetchOfferDetail.mockReset();
@@ -189,10 +197,17 @@ describe('public pages', () => {
     expect(screen.getByText('Entre para ver sua economia')).toBeTruthy();
     expect(screen.getAllByText('Aguardando lista').length).toBeGreaterThan(0);
     expect(screen.queryByText('R$ 7,69')).toBeNull();
+    fireEvent.pointerMove(
+      screen.getAllByRole('button', { name: 'Saiba como funciona' })[0],
+      { pointerType: 'mouse' },
+    );
+    expect(
+      await screen.findAllByText(/Valores monetários podem ser ocultados/i),
+    ).not.toHaveLength(0);
     await waitFor(() => expect(fetchPublicImpact).toHaveBeenCalledTimes(1));
   });
 
-  it('renders zero-store and collecting-data messaging for supported cities', () => {
+  it('renders zero-store and collecting-data messaging for supported cities', async () => {
     renderPublicPage(<CitiesPage />);
 
     expect(screen.getByText('Cidades suportadas')).toBeTruthy();
@@ -206,6 +221,12 @@ describe('public pages', () => {
     ).toBeTruthy();
     expect(screen.getAllByText(/Em ativa/).length).toBeGreaterThan(0);
     expect(screen.getByText('Piloto')).toBeTruthy();
+    fireEvent.pointerMove(screen.getByText('Piloto'), {
+      pointerType: 'mouse',
+    });
+    expect(
+      await screen.findAllByText(/Cidade em piloto: parte dos dados/i),
+    ).not.toHaveLength(0);
     expect(screen.getByText(/As ofertas aparecem/)).toBeTruthy();
     expect(screen.getByText('Unidade Vila Mariana')).toBeTruthy();
     expect(screen.getByText('Unidade Pinheiros')).toBeTruthy();


### PR DESCRIPTION
## Summary
- add public page unit coverage for logged-out placeholders, tooltip presence, and city pilot tooltips
- add admin page unit coverage for receipt/status tooltips, billing-disabled tooltip, and hidden receipt money values
- extend Chromium smoke coverage for monetary privacy and shell/action tooltips
- mark T234 complete in the roadmap

## Validation
- npm test
- npm run build
- npm run lint
- npm run e2e -- --project=chromium

Issue: #390