### PR TITLE
Fix smoke-found sidebar footer and placeholder visuals

### DIFF
--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -592,6 +592,7 @@ sensitive monetary values across web surfaces.
 - [X] T236 [P] Add ChatGPT/Stitch-ready prompts for login, registration, and protected auth-required screens in `docs/design-system/screen-prompts/web-public/`
 - [X] T237 [P] Fix public offer-card grid alignment, card height stability, action footer placement, and responsive spacing across logged-out/logged-in desktop and mobile states in `web/src/public/` and `web/e2e/`
 - [X] T238 Extend smoke screenshot extraction to validate logged-out/logged-in shell state, protected auth-required state, offer-card alignment, and home placeholder copy against generated artifacts in `.tmp/smoke-screens-*` and `web/e2e/`
+- [X] T239 Fix smoke-found sidebar footer contrast and public placeholder card wrapping in `web/src/components/design-system/`, `web/src/dashboard/`, and `web/src/public/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.

--- a/web/src/components/design-system/app-sidebar-shell.tsx
+++ b/web/src/components/design-system/app-sidebar-shell.tsx
@@ -332,6 +332,7 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
                   size="icon-sm"
                   type="button"
                   variant="outline"
+                  className="border-sidebar-border bg-sidebar-accent/20 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                 >
                   {isMoneyVisible ? (
                     <EyeIcon className="size-4" />
@@ -351,6 +352,7 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
                   size="icon-sm"
                   type="button"
                   variant="outline"
+                  className="border-sidebar-border bg-sidebar-accent/20 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                 >
                   {theme === 'dark' ? (
                     <SunMediumIcon className="size-4" />
@@ -360,7 +362,7 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
                 </Button>
               </WithTooltip>
               <Button
-                className="flex-1"
+                className="flex-1 border-sidebar-border bg-sidebar-accent/20 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                 onClick={() => setIsLocationDialogOpen(true)}
                 size="sm"
                 type="button"
@@ -384,11 +386,11 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
                   ? 'Ocultar valores monetários'
                   : 'Mostrar valores monetários'
               }
-              className="hidden group-data-[collapsible=icon]:inline-flex"
               onClick={toggleMoneyVisibility}
               size="icon-sm"
               type="button"
               variant="outline"
+              className="hidden border-sidebar-border bg-sidebar-accent/20 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:inline-flex"
             >
               {isMoneyVisible ? (
                 <EyeIcon className="size-4" />
@@ -402,7 +404,7 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
               aria-label={
                 theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'
               }
-              className="hidden group-data-[collapsible=icon]:inline-flex"
+              className="hidden border-sidebar-border bg-sidebar-accent/20 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:inline-flex"
               onClick={toggleTheme}
               size="icon-sm"
               type="button"

--- a/web/src/dashboard/admin-shell.tsx
+++ b/web/src/dashboard/admin-shell.tsx
@@ -187,6 +187,7 @@ export function AdminLayout() {
                   size="icon-sm"
                   type="button"
                   variant="outline"
+                  className="border-sidebar-border bg-sidebar-accent/20 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                 >
                   {isMoneyVisible ? (
                     <EyeIcon className="size-4" />
@@ -206,6 +207,7 @@ export function AdminLayout() {
                   size="icon-sm"
                   type="button"
                   variant="outline"
+                  className="border-sidebar-border bg-sidebar-accent/20 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                 >
                   {theme === 'dark' ? (
                     <SunMediumIcon className="size-4" />
@@ -214,7 +216,12 @@ export function AdminLayout() {
                   )}
                 </Button>
               </WithTooltip>
-              <Button asChild className="flex-1" size="sm" variant="outline">
+              <Button
+                asChild
+                className="flex-1 border-sidebar-border bg-sidebar-accent/20 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                size="sm"
+                variant="outline"
+              >
                 <Link to="/">Publico</Link>
               </Button>
             </div>
@@ -232,7 +239,7 @@ export function AdminLayout() {
                   ? 'Ocultar valores monetários'
                   : 'Mostrar valores monetários'
               }
-              className="hidden group-data-[collapsible=icon]:inline-flex"
+              className="hidden border-sidebar-border bg-sidebar-accent/20 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:inline-flex"
               onClick={toggleMoneyVisibility}
               size="icon-sm"
               type="button"
@@ -250,7 +257,7 @@ export function AdminLayout() {
               aria-label={
                 theme === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro'
               }
-              className="hidden group-data-[collapsible=icon]:inline-flex"
+              className="hidden border-sidebar-border bg-sidebar-accent/20 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:inline-flex"
               onClick={toggleTheme}
               size="icon-sm"
               type="button"

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -1354,7 +1354,7 @@ export function LandingPage() {
           <h2 className="font-heading text-lg font-semibold">
             Outros estados importantes
           </h2>
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <div className="grid gap-3 sm:grid-cols-[repeat(auto-fit,minmax(220px,1fr))]">
             {[
               {
                 icon: MapPinIcon,
@@ -1385,7 +1385,7 @@ export function LandingPage() {
               },
             ].map((state) => (
               <ActionPlaceholder
-                className="bg-card/70"
+                className="min-w-0 bg-card/70"
                 key={state.title}
                 icon={<state.icon className="size-5" />}
                 title={state.title}


### PR DESCRIPTION
## Summary
- fix low-contrast public/admin sidebar footer controls found during deep Chromium smoke
- make public home placeholder cards use stable minimum widths so text/actions do not clip
- register completed T239 in the roadmap

## Validation
- npm run build
- npm run lint
- npm test
- npm run e2e -- --project=chromium

Issue: #392