### PR TITLE
Avoid share token deploy warning

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -380,7 +380,7 @@ model ShoppingList {
   name                 String
   preferredRegionId    String?               @db.Uuid
   status               ShoppingListStatus    @default(draft)
-  shareToken           String?               @unique
+  shareToken           String?
   sharedAt             DateTime?
   shareRevokedAt       DateTime?
   completedAt          DateTime?


### PR DESCRIPTION
## Summary
- Removes the database-level unique constraint from shareToken to avoid Prisma db push --accept-data-loss requirement during homolog deploy
- Keeps shareToken indexed through the existing shareToken/sharedAt index and preserves the public share API contract

## Validation
- npm --prefix backend run db:generate
- npm --prefix backend run build
- npm --prefix backend run lint
- npm --prefix backend run test -- --runTestsByPath test/unit/lists/shopping-lists.service.spec.ts test/contract/grocery-optimizer-api.contract.spec.ts

Issue: #398