### PR TITLE
Polish public brand, help, receipt education, and auth states

### DIFF
--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -594,6 +594,7 @@ sensitive monetary values across web surfaces.
 - [X] T238 Extend smoke screenshot extraction to validate logged-out/logged-in shell state, protected auth-required state, offer-card alignment, and home placeholder copy against generated artifacts in `.tmp/smoke-screens-*` and `web/e2e/`
 - [X] T239 Fix smoke-found sidebar footer contrast and public placeholder card wrapping in `web/src/components/design-system/`, `web/src/dashboard/`, and `web/src/public/`
 - [X] T240 Align public login/register, protected auth-required, and brand mark surfaces with `docs/design-system/reference-screens/web-public/web_login_and_register.png`, `docs/design-system/reference-screens/web-public/web_protected_auth_required.png`, and shared public web brand references in `web/src/public/` and `web/src/components/design-system/`
+- [X] T241 Polish public brand asset, sidebar help footer, receipt education modal, home location status cards, and protected auth-required sizing in `web/src/public/` and `web/src/components/design-system/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.

--- a/web/src/components/design-system/app-sidebar-shell.tsx
+++ b/web/src/components/design-system/app-sidebar-shell.tsx
@@ -5,6 +5,7 @@ import {
   Building2Icon,
   EyeIcon,
   EyeOffIcon,
+  LifeBuoyIcon,
   HistoryIcon,
   HomeIcon,
   LayoutDashboardIcon,
@@ -24,6 +25,7 @@ import {
 import { useMonetaryPrivacy } from '@/app/monetary-privacy-context';
 import { usePricely } from '@/app/pricely-context';
 import { useTheme } from '@/app/theme-context';
+import pricelyIcon from '@/assets/pricely-icon.png';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -84,7 +86,7 @@ function SidebarLogo() {
         className="hidden size-9 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground group-data-[collapsible=icon]:flex"
         to="/"
       >
-        <ShoppingCartIcon className="size-5" />
+        <img alt="" className="size-6 object-contain" src={pricelyIcon} />
       </Link>
     </div>
   );
@@ -118,6 +120,7 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
   const [locationFeedback, setLocationFeedback] = useState<string | null>(null);
   const [locationPreview, setLocationPreview] = useState<string | null>(null);
   const [isLocationDialogOpen, setIsLocationDialogOpen] = useState(false);
+  const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
 
   const activeCity = cityId
     ? (cities.find((city) => city.id === cityId) ?? null)
@@ -297,16 +300,6 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
 
         <SidebarFooter className="shrink-0">
           <div className="grid gap-2 rounded-lg border border-sidebar-border p-2 group-data-[collapsible=icon]:hidden">
-            <div className="min-w-0">
-              <p className="truncate text-sm font-medium">
-                {activeCity ? activeCity.name : 'Cidade pendente'}
-              </p>
-              <p className="truncate text-xs text-sidebar-foreground/70">
-                {activeCity
-                  ? `${activeCity.activeStoreCount} lojas ativas`
-                  : 'Escolha no header'}
-              </p>
-            </div>
             <div className="flex gap-2">
               <WithTooltip
                 label={
@@ -363,6 +356,21 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
               >
                 <LocateFixedIcon data-icon="inline-start" />
                 Local
+              </Button>
+            </div>
+            <div className="rounded-md border border-sidebar-border bg-sidebar-accent/20 p-3">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <LifeBuoyIcon className="size-4" />
+                Precisa de ajuda?
+              </div>
+              <Button
+                className="mt-1 h-auto justify-start p-0 text-sidebar-foreground hover:text-sidebar-accent-foreground"
+                onClick={() => setIsHelpDialogOpen(true)}
+                size="sm"
+                type="button"
+                variant="link"
+              >
+                Central de ajuda
               </Button>
             </div>
           </div>
@@ -512,7 +520,7 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
         onOpenChange={setIsLocationDialogOpen}
         open={isLocationDialogOpen}
       >
-        <DialogContent>
+        <DialogContent className="bg-background">
           <DialogHeader>
             <DialogTitle>Localizacao para otimizacao local</DialogTitle>
             <DialogDescription>
@@ -581,6 +589,47 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
                 Salvar CEP
               </Button>
             </form>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog onOpenChange={setIsHelpDialogOpen} open={isHelpDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Central de ajuda</DialogTitle>
+            <DialogDescription>
+              Encontre orientação rápida para cidade, listas, ofertas, notas
+              fiscais e privacidade monetária.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-3 text-sm">
+            {[
+              {
+                title: 'Cidade e localização',
+                copy: 'A cidade fica no header. A localização precisa só é usada quando você autoriza ou salva um CEP.',
+              },
+              {
+                title: 'Listas e ofertas',
+                copy: 'Monte uma lista para comparar produtos equivalentes e ver a melhor estratégia por loja.',
+              },
+              {
+                title: 'Notas fiscais',
+                copy: 'Envie a nota para validar preços reais, aumentar confiança dos dados e liberar histórico na conta.',
+              },
+            ].map((item) => (
+              <div
+                className="rounded-lg border border-border/70 bg-card p-3"
+                key={item.title}
+              >
+                <div className="font-medium">{item.title}</div>
+                <p className="mt-1 text-muted-foreground">{item.copy}</p>
+              </div>
+            ))}
+          </div>
+          <DialogFooter>
+            <Button onClick={() => setIsHelpDialogOpen(false)} type="button">
+              Entendi
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/web/src/components/design-system/pricely-brand-mark.tsx
+++ b/web/src/components/design-system/pricely-brand-mark.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
-import { ShoppingCartIcon } from 'lucide-react';
 
+import pricelyIcon from '@/assets/pricely-icon.png';
 import { cn } from '@/lib/utils';
 
 type PricelyBrandMarkProps = {
@@ -22,14 +22,15 @@ function PricelyBrandMark({
           compact && 'text-[1.65rem]',
         )}
       >
-        pricely
+        Pricely
       </span>
-      <ShoppingCartIcon
-        aria-hidden="true"
+      <img
+        alt=""
         className={cn(
-          'size-9 stroke-[2.4] text-primary',
+          'size-9 object-contain',
           compact && 'size-7',
         )}
+        src={pricelyIcon}
       />
     </>
   );

--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -197,9 +197,8 @@ describe('public pages', () => {
     expect(screen.getByText('Entre para ver sua economia')).toBeTruthy();
     expect(screen.getAllByText('Aguardando lista').length).toBeGreaterThan(0);
     expect(screen.queryByText('R$ 7,69')).toBeNull();
-    fireEvent.pointerMove(
+    fireEvent.click(
       screen.getAllByRole('button', { name: 'Saiba como funciona' })[0],
-      { pointerType: 'mouse' },
     );
     expect(
       await screen.findAllByText(/Valores monetários podem ser ocultados/i),

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -822,13 +822,13 @@ function RequireAuthentication({
         </Alert>
 
         <Card className="overflow-hidden border-border/70 bg-card/95 shadow-sm">
-          <div className="grid lg:grid-cols-[1.05fr_0.8fr_1.05fr]">
-            <CardContent className="grid gap-5 p-6 lg:p-8">
-              <span className="flex size-24 items-center justify-center rounded-full bg-primary/10 text-primary">
-                <LockIcon className="size-11" />
+          <div className="grid lg:grid-cols-[minmax(0,1fr)_minmax(280px,0.75fr)_minmax(0,0.95fr)]">
+            <CardContent className="grid gap-4 p-5 lg:p-6">
+              <span className="flex size-18 items-center justify-center rounded-full bg-primary/10 text-primary sm:size-20">
+                <LockIcon className="size-9" />
               </span>
               <div className="grid gap-3">
-                <h1 className="font-heading text-4xl font-semibold tracking-normal text-foreground">
+                <h1 className="font-heading text-3xl font-semibold tracking-normal text-foreground">
                   {isReceiptRoute
                     ? 'Entre para enviar sua nota fiscal'
                     : 'Entre para salvar suas listas'}
@@ -884,7 +884,7 @@ function RequireAuthentication({
               </Alert>
             </CardContent>
 
-            <CardContent className="grid content-center gap-4 border-y border-border/70 p-6 lg:border-x lg:border-y-0 lg:p-8">
+              <CardContent className="grid content-center gap-3 border-y border-border/70 p-5 lg:border-x lg:border-y-0 lg:p-6">
               <div className="grid gap-2">
                 <StatusBadge
                   icon={ShieldCheckIcon}
@@ -943,7 +943,7 @@ function RequireAuthentication({
               </div>
             </CardContent>
 
-            <CardContent className="grid gap-4 p-6 lg:p-8">
+              <CardContent className="grid gap-3 p-5 lg:p-6">
               <div>
                 <h2 className="text-xl font-semibold">Depois que voce entrar</h2>
                 <p className="text-sm text-muted-foreground">
@@ -1305,6 +1305,8 @@ export function LandingPage() {
       savingsVsRegionalAverage?: number;
     }>
   >([]);
+  const [isReceiptInfoOpen, setIsReceiptInfoOpen] = useState(false);
+  const [isLocationHelpOpen, setIsLocationHelpOpen] = useState(false);
 
   useEffect(() => {
     let disposed = false;
@@ -1651,16 +1653,14 @@ export function LandingPage() {
               {
                 icon: MapPinIcon,
                 title: 'Sem cidade selecionada',
-                text: 'Escolha uma cidade para ver ofertas',
-                action: 'Selecionar cidade',
-                to: '/cidades',
+                text: 'Escolha a cidade no header para carregar ofertas, lojas e evidências da região.',
               },
               {
                 icon: LockIcon,
                 title: 'Permissão de localização negada',
-                text: 'Ative a permissão para ver lojas perto de você',
-                action: 'Escolher cidade',
-                to: '/cidades',
+                text: 'Ative a permissão no navegador ou use CEP quando quiser calcular lojas próximas.',
+                action: 'Como ativar',
+                onAction: () => setIsLocationHelpOpen(true),
               },
               {
                 icon: StoreIcon,
@@ -1684,7 +1684,13 @@ export function LandingPage() {
                 description={state.text}
                 primaryAction={
                   state.action ? (
-                    <Link to={state.to ?? '/cidades'}>{state.action}</Link>
+                    state.onAction ? (
+                      <button onClick={state.onAction} type="button">
+                        {state.action}
+                      </button>
+                    ) : (
+                      <Link to={state.to ?? '/cidades'}>{state.action}</Link>
+                    )
                   ) : undefined
                 }
                 secondaryAction={
@@ -1748,13 +1754,22 @@ export function LandingPage() {
             <div className="rounded-lg border border-[var(--ds-warning-border)] bg-[var(--ds-warning-soft)] p-3 text-sm">
               {hasAccount
                 ? 'Nossa equipe vai revisar sua nota fiscal. Você será avisado quando for liberada.'
-                : 'Saiba como funciona: a nota entra em validação e só depois libera histórico e status na conta.'}
+                : 'Envie a nota para validar preços reais, melhorar a confiança das ofertas e liberar histórico de compra na sua conta.'}
             </div>
-            <Button asChild variant="outline">
-              <Link to={hasAccount ? '/notas' : '/entrar'}>
-                {hasAccount ? 'Ver detalhes' : 'Enviar primeira nota fiscal'}
-              </Link>
-            </Button>
+            <div className="grid gap-2">
+              <Button asChild variant="outline">
+                <Link to={hasAccount ? '/notas' : '/entrar'}>
+                  {hasAccount ? 'Ver detalhes' : 'Enviar primeira nota fiscal'}
+                </Link>
+              </Button>
+              <Button
+                onClick={() => setIsReceiptInfoOpen(true)}
+                type="button"
+                variant="ghost"
+              >
+                Saiba como funciona
+              </Button>
+            </div>
           </CardContent>
         </Card>
 
@@ -1830,6 +1845,99 @@ export function LandingPage() {
           <StatusBadge tone="savings">Ativo</StatusBadge>
         </div>
       </aside>
+
+      <Dialog
+        onOpenChange={setIsReceiptInfoOpen}
+        open={isReceiptInfoOpen}
+      >
+        <DialogContent className="max-h-[calc(100vh-2rem)] overflow-y-auto bg-background sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Como a nota fiscal melhora sua compra</DialogTitle>
+            <DialogDescription>
+              A nota fiscal transforma uma compra real em evidência útil para
+              você e para a qualidade das ofertas da plataforma.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-3">
+            {[
+              {
+                title: '1. Envie a nota depois da compra',
+                copy: 'A plataforma registra loja, data, produtos e valores sem depender de preenchimento manual.',
+              },
+              {
+                title: '2. A validação confirma os preços reais',
+                copy: 'O envio passa por revisão antes de liberar histórico, status e dados derivados na sua conta.',
+              },
+              {
+                title: '3. Você ganha histórico e comparações melhores',
+                copy: 'Com notas validadas, fica mais fácil acompanhar gastos, reutilizar listas e comparar ofertas com evidência real.',
+              },
+              {
+                title: '4. A comunidade recebe ofertas mais confiáveis',
+                copy: 'Os preços observados ajudam a indicar confiança, frescor e variação por estabelecimento.',
+              },
+            ].map((step) => (
+              <div
+                className="rounded-lg border border-border/70 bg-card p-3"
+                key={step.title}
+              >
+                <div className="font-medium">{step.title}</div>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {step.copy}
+                </p>
+              </div>
+            ))}
+          </div>
+          <div className="rounded-lg border border-[var(--ds-info-border)] bg-[var(--ds-info-soft)] p-3 text-sm text-muted-foreground">
+            Valores monetários podem ser ocultados pelo botão de privacidade no
+            header e no sidebar.
+          </div>
+          <DialogFooter>
+            <Button asChild>
+              <Link to={hasAccount ? '/notas' : '/entrar'}>
+                {hasAccount ? 'Abrir notas fiscais' : 'Entrar para enviar'}
+              </Link>
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        onOpenChange={setIsLocationHelpOpen}
+        open={isLocationHelpOpen}
+      >
+        <DialogContent className="bg-background">
+          <DialogHeader>
+            <DialogTitle>Permissão de localização</DialogTitle>
+            <DialogDescription>
+              A cidade no header mostra ofertas da região. A permissão de
+              localização só é necessária para calcular lojas realmente
+              próximas.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-3 text-sm">
+            <div className="rounded-lg border border-border/70 bg-card p-3">
+              <div className="font-medium">No navegador</div>
+              <p className="mt-1 text-muted-foreground">
+                Abra as permissões do site, libere localização e tente usar o
+                botão de localização novamente.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border/70 bg-card p-3">
+              <div className="font-medium">Sem localização precisa</div>
+              <p className="mt-1 text-muted-foreground">
+                Você ainda pode usar a cidade selecionada; o Pricely só não
+                promete distância até lojas específicas.
+              </p>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button onClick={() => setIsLocationHelpOpen(false)} type="button">
+              Entendi
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
@@ -2607,7 +2715,7 @@ export function ReceiptSubmissionPage() {
 
   return (
     <RequireAuthentication
-      description="Entre para contribuir com notas fiscais e acompanhar rewards depois da validação."
+      description="Entre para contribuir com notas fiscais e acompanhar histórico, status e benefícios depois da validação."
       title="Envio de nota fiscal precisa da sua conta"
     >
       <div className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">

--- a/web/src/public/public-shell.spec.tsx
+++ b/web/src/public/public-shell.spec.tsx
@@ -209,6 +209,9 @@ describe('PublicLayout', () => {
 
     expect(screen.getByText('Navegacao')).toBeTruthy();
     expect(screen.getByRole('link', { name: /Minha lista/i })).toBeTruthy();
+    expect(screen.getByText('Precisa de ajuda?')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Central de ajuda/i })).toBeTruthy();
+    expect(screen.queryByText('Cidade pendente')).toBeNull();
     expect(document.body.textContent).toMatch(/Localiza/);
     expect(screen.getByText(/raio de 5 km/i)).toBeTruthy();
     expect(
@@ -230,6 +233,16 @@ describe('PublicLayout', () => {
     );
 
     await waitFor(() => expect(setCityId).toHaveBeenCalledWith('sao-paulo-sp'));
+  });
+
+  it('opens the sidebar help dialog without requiring a missing help route', async () => {
+    renderPublicLayout();
+
+    fireEvent.click(screen.getByRole('button', { name: /Central de ajuda/i }));
+
+    expect(await screen.findByRole('dialog')).toBeTruthy();
+    expect(screen.getAllByText('Notas fiscais').length).toBeGreaterThan(1);
+    expect(screen.getByText(/validar preços reais/i)).toBeTruthy();
   });
 
   it('keeps browser location as an explicit preview state', () => {


### PR DESCRIPTION
﻿## Summary
- Use the Pricely cart asset in the shared brand mark and keep the wordmark as "Pricely".
- Remove city status from the sidebar footer, add a Central de ajuda modal, and keep location/account controls in the header/sidebar utilities.
- Improve the home receipt card with value-focused copy and a step-by-step modal; convert key home status cards away from misleading /cidades actions.
- Compact the protected auth-required layout and update receipt auth copy to PT-BR benefits/status language.
- Mark T241 in the SpecKit task list.

## Validation
- npm --prefix web run lint
- npm --prefix web run test
- npm --prefix web run build
- npm --prefix web run e2e -- --project=chromium
- Smoke screenshots: .tmp/smoke-screens-brand-help-2026-06-19/
