### PR TITLE
Resize brand cart and add receipt roadmap modals

### DIFF
--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -595,6 +595,7 @@ sensitive monetary values across web surfaces.
 - [X] T239 Fix smoke-found sidebar footer contrast and public placeholder card wrapping in `web/src/components/design-system/`, `web/src/dashboard/`, and `web/src/public/`
 - [X] T240 Align public login/register, protected auth-required, and brand mark surfaces with `docs/design-system/reference-screens/web-public/web_login_and_register.png`, `docs/design-system/reference-screens/web-public/web_protected_auth_required.png`, and shared public web brand references in `web/src/public/` and `web/src/components/design-system/`
 - [X] T241 Polish public brand asset, sidebar help footer, receipt education modal, home location status cards, and protected auth-required sizing in `web/src/public/` and `web/src/components/design-system/`
+- [X] T242 Resize shared brand cart asset alignment and add visual receipt-flow roadmap modules to public explanatory modals in `web/src/public/` and `web/src/components/design-system/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.

--- a/web/src/components/design-system/app-sidebar-shell.tsx
+++ b/web/src/components/design-system/app-sidebar-shell.tsx
@@ -86,7 +86,11 @@ function SidebarLogo() {
         className="hidden size-9 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground group-data-[collapsible=icon]:flex"
         to="/"
       >
-        <img alt="" className="size-6 object-contain" src={pricelyIcon} />
+        <img
+          alt=""
+          className="size-7 scale-[2.05] object-contain"
+          src={pricelyIcon}
+        />
       </Link>
     </div>
   );
@@ -602,6 +606,44 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
               fiscais e privacidade monetária.
             </DialogDescription>
           </DialogHeader>
+          <div className="grid gap-3 rounded-xl border border-[var(--ds-info-border)] bg-[var(--ds-info-soft)] p-4">
+            <div className="flex items-center gap-3">
+              <span className="flex size-12 shrink-0 items-center justify-center rounded-lg border border-[var(--ds-info-border)] bg-background">
+                <img
+                  alt=""
+                  className="size-8 scale-[2.05] object-contain"
+                  src={pricelyIcon}
+                />
+              </span>
+              <div>
+                <div className="font-medium">Roadmap da nota fiscal</div>
+                <p className="text-sm text-muted-foreground">
+                  A nota enviada vira evidência validada antes de liberar
+                  histórico e melhorar ofertas.
+                </p>
+              </div>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-4">
+              {[
+                'Enviar',
+                'Revisar',
+                'Liberar',
+                'Recomendar',
+              ].map((label, index) => (
+                <div className="grid gap-1" key={label}>
+                  <div className="flex items-center gap-2">
+                    <span className="flex size-6 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+                      {index + 1}
+                    </span>
+                    {index < 3 ? (
+                      <span className="hidden h-px flex-1 bg-border sm:block" />
+                    ) : null}
+                  </div>
+                  <div className="text-xs font-medium">{label}</div>
+                </div>
+              ))}
+            </div>
+          </div>
           <div className="grid gap-3 text-sm">
             {[
               {

--- a/web/src/components/design-system/pricely-brand-mark.tsx
+++ b/web/src/components/design-system/pricely-brand-mark.tsx
@@ -27,8 +27,8 @@ function PricelyBrandMark({
       <img
         alt=""
         className={cn(
-          'size-9 object-contain',
-          compact && 'size-7',
+          'mt-0.5 size-10 scale-[2.15] object-contain',
+          compact && 'size-8 scale-[2.1]',
         )}
         src={pricelyIcon}
       />
@@ -39,7 +39,7 @@ function PricelyBrandMark({
     return (
       <div
         aria-label="Pricely"
-        className={cn('inline-flex items-center gap-2', className)}
+        className={cn('inline-flex items-center gap-2.5', className)}
       >
         {content}
       </div>
@@ -49,7 +49,7 @@ function PricelyBrandMark({
   return (
     <Link
       aria-label="Pricely"
-      className={cn('inline-flex items-center gap-2 rounded-md', className)}
+      className={cn('inline-flex items-center gap-2.5 rounded-md', className)}
       to={to}
     >
       {content}

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -40,6 +40,7 @@ import {
 } from '@/app/format';
 import { resolveProductImage } from '@/app/media';
 import { getCityById, optimizationModes } from '@/app/mock-data';
+import pricelyIcon from '@/assets/pricely-icon.png';
 import {
   type CatalogProductSearchResponse,
   type OfferDetailApiResponse,
@@ -1858,6 +1859,49 @@ export function LandingPage() {
               você e para a qualidade das ofertas da plataforma.
             </DialogDescription>
           </DialogHeader>
+          <div className="grid gap-4 rounded-xl border border-[var(--ds-info-border)] bg-[var(--ds-info-soft)] p-4 sm:grid-cols-[auto_1fr] sm:items-center">
+            <div className="relative flex size-24 items-center justify-center rounded-xl border border-[var(--ds-info-border)] bg-background">
+              <img
+                alt=""
+                className="size-14 scale-[2.05] object-contain"
+                src={pricelyIcon}
+              />
+              <ReceiptTextIcon className="absolute -right-2 -top-2 size-9 rounded-full border border-[var(--ds-warning-border)] bg-[var(--ds-warning-soft)] p-2 text-orange-700 dark:text-orange-200" />
+              <BadgeCheckIcon className="absolute -bottom-2 -left-2 size-9 rounded-full border border-[var(--ds-savings-border)] bg-[var(--ds-savings-soft)] p-2 text-[var(--ds-savings)]" />
+            </div>
+            <div>
+              <div className="text-sm font-medium text-foreground">
+                Roadmap da nota fiscal
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Enviar a nota cria evidência, valida preços e melhora as
+                próximas recomendações de compra.
+              </p>
+            </div>
+          </div>
+          <div className="grid gap-2 rounded-xl border border-border/70 bg-card p-3 sm:grid-cols-4">
+            {[
+              { label: 'Enviar', detail: 'nota da compra' },
+              { label: 'Validar', detail: 'preços reais' },
+              { label: 'Liberar', detail: 'histórico' },
+              { label: 'Melhorar', detail: 'ofertas' },
+            ].map((step, index) => (
+              <div className="relative grid gap-1" key={step.label}>
+                <div className="flex items-center gap-2">
+                  <span className="flex size-7 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+                    {index + 1}
+                  </span>
+                  {index < 3 ? (
+                    <span className="hidden h-px flex-1 bg-border sm:block" />
+                  ) : null}
+                </div>
+                <div className="text-sm font-medium">{step.label}</div>
+                <div className="text-xs text-muted-foreground">
+                  {step.detail}
+                </div>
+              </div>
+            ))}
+          </div>
           <div className="grid gap-3">
             {[
               {


### PR DESCRIPTION
﻿## Summary
- Resize and align the shared Pricely cart asset so it is visually balanced with the wordmark.
- Scale the compact/collapsed cart instances that reuse the same padded PNG asset.
- Add visual receipt-flow roadmap modules to the receipt explanation modal and the sidebar help modal.
- Mark T242 in the SpecKit task list.

## Validation
- npm --prefix web run lint
- npm --prefix web run test
- npm --prefix web run build
- npm --prefix web run e2e -- --project=chromium
- Smoke screenshots: .tmp/smoke-screens-404-brand-roadmaps-2026-06-19/
