### PR TITLE
Clarify public city browsing CTAs

### DIFF
--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -596,6 +596,7 @@ sensitive monetary values across web surfaces.
 - [X] T240 Align public login/register, protected auth-required, and brand mark surfaces with `docs/design-system/reference-screens/web-public/web_login_and_register.png`, `docs/design-system/reference-screens/web-public/web_protected_auth_required.png`, and shared public web brand references in `web/src/public/` and `web/src/components/design-system/`
 - [X] T241 Polish public brand asset, sidebar help footer, receipt education modal, home location status cards, and protected auth-required sizing in `web/src/public/` and `web/src/components/design-system/`
 - [X] T242 Resize shared brand cart asset alignment and add visual receipt-flow roadmap modules to public explanatory modals in `web/src/public/` and `web/src/components/design-system/`
+- [X] T243 Replace misleading public city-selection CTAs with header-selection guidance or explicit cities-and-stores browsing copy in `web/src/public/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -817,7 +817,7 @@ function RequireAuthentication({
               disponiveis.
             </span>
             <Button asChild className="w-fit" size="sm" variant="outline">
-              <Link to="/cidades">Escolher cidade</Link>
+              <Link to="/cidades">Ver cidades e lojas</Link>
             </Button>
           </AlertDescription>
         </Alert>
@@ -923,7 +923,7 @@ function RequireAuthentication({
               <Button asChild className="w-full justify-center gap-2" variant="outline">
                 <Link to="/cidades">
                   <MapPinIcon data-icon="inline-start" />
-                  Escolher cidade
+                  Ver cidades e lojas
                 </Link>
               </Button>
               <div className="mt-6 grid gap-1 text-sm">
@@ -1637,10 +1637,9 @@ export function LandingPage() {
           ) : (
             <ActionPlaceholder
               icon={<MapPinIcon className="size-5" />}
-              title="Escolha uma cidade para ver ofertas reais"
-              description="A vitrine depende da cidade selecionada. Depois mostramos produto, loja, preço observado e confiança da informação."
-              primaryAction={<Link to="/cidades">Selecionar cidade</Link>}
-              secondaryAction={<Link to="/listas/nova">Criar lista</Link>}
+              title="Escolha uma cidade no header para ver ofertas reais"
+              description="A vitrine depende da cidade selecionada no header. Depois mostramos produto, loja, preço observado e confiança da informação."
+              secondaryAction={<Link to="/cidades">Ver cidades e lojas</Link>}
             />
           )}
         </section>
@@ -1667,7 +1666,7 @@ export function LandingPage() {
                 icon: StoreIcon,
                 title: 'Nenhuma loja no raio',
                 text: 'Não encontramos lojas ativas a 5 km de você',
-                action: 'Ver lojas',
+                action: 'Ver cidades e lojas',
                 to: '/cidades',
               },
               {
@@ -2064,10 +2063,9 @@ export function OffersPage() {
       {!cityId ? (
         <ActionPlaceholder
           icon={<MapPinIcon className="size-5" />}
-          title="Escolha uma cidade primeiro"
-          description="A cidade define quais lojas e preços entram na vitrine pública. Depois você poderá filtrar estabelecimentos e abrir o detalhe de cada oferta."
-          primaryAction={<Link to="/cidades">Selecionar cidade</Link>}
-          secondaryAction={<Link to="/listas/nova">Criar lista</Link>}
+          title="Escolha uma cidade no header primeiro"
+          description="A cidade selecionada no header define quais lojas e preços entram na vitrine pública. Você também pode consultar as cidades e lojas suportadas."
+          secondaryAction={<Link to="/cidades">Ver cidades e lojas</Link>}
         />
       ) : null}
 
@@ -2248,9 +2246,9 @@ export function OffersPage() {
           description={
             city?.status === 'pilot'
               ? 'Esta cidade ainda precisa de notas fiscais e validações para liberar ofertas confiáveis.'
-              : 'Troque o filtro de estabelecimento ou escolha outra cidade para comparar preços.'
+              : 'Troque o filtro de estabelecimento ou consulte as cidades e lojas suportadas para comparar preços.'
           }
-          primaryAction={<Link to="/cidades">Escolher outra cidade</Link>}
+          primaryAction={<Link to="/cidades">Ver cidades e lojas</Link>}
           secondaryAction={<Link to="/notas">Enviar nota fiscal</Link>}
         />
       ) : null}


### PR DESCRIPTION
﻿## Summary
- Replace misleading city-selection CTA copy with explicit cities-and-stores browsing copy.
- Make no-city offer states point users to the header selector instead of implying /cidades performs selection.
- Mark T243 in the SpecKit task list.

## Validation
- npm --prefix web run lint
- npm --prefix web run test
- npm --prefix web run build
- npm --prefix web run e2e -- --project=chromium
- Smoke screenshots: .tmp/smoke-screens-406-city-cta-2026-06-19/
