### PR TITLE
Make city selection CTAs open a real selector

### DIFF
--- a/docs/design-system/screen-prompts/web-public/06-protected-auth-required.md
+++ b/docs/design-system/screen-prompts/web-public/06-protected-auth-required.md
@@ -32,7 +32,10 @@ Required content:
 - Secondary CTA: "Criar conta".
 - Tertiary text/button to continue public browsing:
   - "Ver ofertas da cidade"
-  - "Escolher cidade"
+  - "Selecionar cidade" opens the shared city selector; do not link this CTA
+    to `/cidades`.
+  - "Ver cidades e lojas" may link to `/cidades` only when the intent is to
+    browse supported coverage.
 - Action-oriented placeholders:
   - If no lists: "Crie sua primeira lista para comparar precos por loja."
   - If no receipts: "Envie sua primeira nota fiscal para acompanhar a validacao."
@@ -63,4 +66,3 @@ Map likely components to:
 - web/src/components/design-system/
 - web/src/components/ui/*
 ```
-

--- a/docs/product/web-action-placeholder-tooltip-privacy-plan.md
+++ b/docs/product/web-action-placeholder-tooltip-privacy-plan.md
@@ -22,7 +22,9 @@ Issue: #372
 ### Public Web
 
 - Home contextual states in `web/src/public/public-pages.tsx`
-  - No city selected: offer "Selecionar cidade" and explain city-scoped pricing.
+  - No city selected: offer "Selecionar cidade" through the shared selector
+    dialog/header select and explain city-scoped pricing. Use "Ver cidades e
+    lojas" for `/cidades`, because that route is only coverage browsing.
   - Location denied: show "Saiba como ativar" and keep manual city/CEP fallback.
   - No stores in radius: offer "Ampliar raio" once radius editing exists; until then
     route to city/global mode guidance.

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -597,6 +597,7 @@ sensitive monetary values across web surfaces.
 - [X] T241 Polish public brand asset, sidebar help footer, receipt education modal, home location status cards, and protected auth-required sizing in `web/src/public/` and `web/src/components/design-system/`
 - [X] T242 Resize shared brand cart asset alignment and add visual receipt-flow roadmap modules to public explanatory modals in `web/src/public/` and `web/src/components/design-system/`
 - [X] T243 Replace misleading public city-selection CTAs with header-selection guidance or explicit cities-and-stores browsing copy in `web/src/public/`
+- [X] T244 Make public city-selection CTAs open a real shared city selector instead of routing to `/cidades` in `web/src/public/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -100,6 +100,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 
 type EditableListItem = {
@@ -124,6 +132,62 @@ type OptimizationResultTab =
   | 'stores'
   | 'savings';
 type OptimizationItemFilter = 'all' | 'selected' | 'review';
+
+function CitySelectionDialog({
+  cityId,
+  cities,
+  onOpenChange,
+  onSelectCity,
+  open,
+}: {
+  cityId: string | null;
+  cities: SupportedCity[];
+  onOpenChange: (open: boolean) => void;
+  onSelectCity: (cityId: string) => unknown;
+  open: boolean;
+}) {
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="bg-background">
+        <DialogHeader>
+          <DialogTitle>Selecionar cidade</DialogTitle>
+          <DialogDescription>
+            Escolha a cidade aqui para atualizar ofertas, listas e lojas no
+            header. A tela de cidades continua sendo apenas o catálogo de
+            cobertura.
+          </DialogDescription>
+        </DialogHeader>
+        <Select
+          onValueChange={(value) => {
+            void onSelectCity(value);
+            onOpenChange(false);
+          }}
+          value={cityId ?? ''}
+        >
+          <SelectTrigger>
+            <MapPinIcon />
+            <SelectValue placeholder="Selecione uma cidade disponível" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {cities.map((city) => (
+                <SelectItem key={city.id} value={city.id}>
+                  {city.name} - {city.activeStoreCount} estabelecimentos
+                  ativos
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+        <DialogFooter>
+          <Button asChild variant="outline">
+            <Link to="/cidades">Ver cidades e lojas</Link>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 function getCatalogProductPreviewImage(product: CatalogProductSearchResponse) {
   return (
@@ -788,7 +852,9 @@ function RequireAuthentication({
   title: string;
   description: string;
 }) {
-  const { isAuthenticated, isBootstrapping } = usePricely();
+  const { cityId, cities, isAuthenticated, isBootstrapping, setCityId } =
+    usePricely();
+  const [isCitySelectionOpen, setIsCitySelectionOpen] = useState(false);
 
   if (isBootstrapping) {
     return (
@@ -816,8 +882,14 @@ function RequireAuthentication({
               Voce pode escolher sua cidade para ver ofertas e lojas
               disponiveis.
             </span>
-            <Button asChild className="w-fit" size="sm" variant="outline">
-              <Link to="/cidades">Ver cidades e lojas</Link>
+            <Button
+              className="w-fit"
+              onClick={() => setIsCitySelectionOpen(true)}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              Selecionar cidade
             </Button>
           </AlertDescription>
         </Alert>
@@ -920,11 +992,14 @@ function RequireAuthentication({
                   Ver ofertas da cidade
                 </Link>
               </Button>
-              <Button asChild className="w-full justify-center gap-2" variant="outline">
-                <Link to="/cidades">
-                  <MapPinIcon data-icon="inline-start" />
-                  Ver cidades e lojas
-                </Link>
+              <Button
+                className="w-full justify-center gap-2"
+                onClick={() => setIsCitySelectionOpen(true)}
+                type="button"
+                variant="outline"
+              >
+                <MapPinIcon data-icon="inline-start" />
+                Selecionar cidade
               </Button>
               <div className="mt-6 grid gap-1 text-sm">
                 <div className="flex items-center gap-2 font-medium text-primary">
@@ -1006,6 +1081,13 @@ function RequireAuthentication({
             dinheiro. Junte-se a eles!
           </AlertDescription>
         </Alert>
+        <CitySelectionDialog
+          cityId={cityId}
+          cities={cities}
+          onOpenChange={setIsCitySelectionOpen}
+          onSelectCity={setCityId}
+          open={isCitySelectionOpen}
+        />
       </section>
     );
   }
@@ -1277,7 +1359,7 @@ function AuthCard({
 }
 
 export function LandingPage() {
-  const { cityId, cities, currentUser, lists } = usePricely();
+  const { cityId, cities, currentUser, lists, setCityId } = usePricely();
   const city = cityId
     ? (cities.find((entry) => entry.id === cityId) ?? getCityById(cityId))
     : null;
@@ -1308,6 +1390,7 @@ export function LandingPage() {
   >([]);
   const [isReceiptInfoOpen, setIsReceiptInfoOpen] = useState(false);
   const [isLocationHelpOpen, setIsLocationHelpOpen] = useState(false);
+  const [isCitySelectionOpen, setIsCitySelectionOpen] = useState(false);
 
   useEffect(() => {
     let disposed = false;
@@ -1639,6 +1722,14 @@ export function LandingPage() {
               icon={<MapPinIcon className="size-5" />}
               title="Escolha uma cidade no header para ver ofertas reais"
               description="A vitrine depende da cidade selecionada no header. Depois mostramos produto, loja, preço observado e confiança da informação."
+              primaryAction={
+                <button
+                  onClick={() => setIsCitySelectionOpen(true)}
+                  type="button"
+                >
+                  Selecionar cidade
+                </button>
+              }
               secondaryAction={<Link to="/cidades">Ver cidades e lojas</Link>}
             />
           )}
@@ -1981,12 +2072,19 @@ export function LandingPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      <CitySelectionDialog
+        cityId={cityId}
+        cities={cities}
+        onOpenChange={setIsCitySelectionOpen}
+        onSelectCity={setCityId}
+        open={isCitySelectionOpen}
+      />
     </div>
   );
 }
 
 export function OffersPage() {
-  const { cityId, cities } = usePricely();
+  const { cityId, cities, setCityId } = usePricely();
   const city = cityId
     ? (cities.find((entry) => entry.id === cityId) ?? getCityById(cityId))
     : null;
@@ -1994,6 +2092,7 @@ export function OffersPage() {
     NonNullable<RegionOffersApiResponse['groupedOffers']>
   >([]);
   const [storeFilter, setStoreFilter] = useState('all');
+  const [isCitySelectionOpen, setIsCitySelectionOpen] = useState(false);
 
   useEffect(() => {
     let disposed = false;
@@ -2065,6 +2164,11 @@ export function OffersPage() {
           icon={<MapPinIcon className="size-5" />}
           title="Escolha uma cidade no header primeiro"
           description="A cidade selecionada no header define quais lojas e preços entram na vitrine pública. Você também pode consultar as cidades e lojas suportadas."
+          primaryAction={
+            <button onClick={() => setIsCitySelectionOpen(true)} type="button">
+              Selecionar cidade
+            </button>
+          }
           secondaryAction={<Link to="/cidades">Ver cidades e lojas</Link>}
         />
       ) : null}
@@ -2252,6 +2356,13 @@ export function OffersPage() {
           secondaryAction={<Link to="/notas">Enviar nota fiscal</Link>}
         />
       ) : null}
+      <CitySelectionDialog
+        cityId={cityId}
+        cities={cities}
+        onOpenChange={setIsCitySelectionOpen}
+        onSelectCity={setCityId}
+        open={isCitySelectionOpen}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add a shared public city-selection dialog for CTAs that previously routed to /cidades
- Keep /cidades as coverage browsing via explicit 'Ver cidades e lojas' copy
- Update design/spec docs so future screens do not treat /cidades as city selection

## Validation
- npm --prefix web run lint
- npm --prefix web run test
- npm --prefix web run build
- npm --prefix web run e2e -- --project=chromium
- Smoke screenshots: .tmp/smoke-screens-408-real-city-selector-2026-06-19/

Issue: #408