### PR TITLE
Add offer categories and scalable sorting

### DIFF
--- a/backend/src/common/contracts/regions.contract.ts
+++ b/backend/src/common/contracts/regions.contract.ts
@@ -51,6 +51,7 @@ export interface RegionalOffersContract {
     catalogProductId: string;
     productVariantId: string;
     productName: string;
+    category: string;
     variantName?: string;
     imageUrl?: string | null;
     displayName: string;
@@ -73,6 +74,7 @@ export interface RegionalOffersContract {
     catalogProductId: string;
     productVariantId: string;
     productName: string;
+    category: string;
     variantName?: string;
     imageUrl?: string | null;
     packageLabel: string;

--- a/backend/src/pricing/application/public-pricing.service.ts
+++ b/backend/src/pricing/application/public-pricing.service.ts
@@ -257,6 +257,7 @@ export class PublicPricingService {
       confidenceLevel: 'high' | 'medium' | 'low';
       catalogProduct: {
         name: string;
+        category: string;
         imageUrl: string | null;
       };
       productVariant: {
@@ -284,6 +285,7 @@ export class PublicPricingService {
       catalogProductId: offer.catalogProductId,
       productVariantId: offer.productVariantId,
       productName: offer.catalogProduct.name,
+      category: offer.catalogProduct.category,
       variantName: offer.productVariant.displayName,
       imageUrl: offer.productVariant.imageUrl ?? undefined,
       displayName: offer.displayName,
@@ -353,6 +355,7 @@ export class PublicPricingService {
           catalogProductId: bestOffer.catalogProductId,
           productVariantId: bestOffer.productVariantId,
           productName: bestOffer.productName,
+          category: bestOffer.category,
           variantName: bestOffer.variantName,
           imageUrl: bestOffer.imageUrl,
           packageLabel: bestOffer.packageLabel,

--- a/backend/test/contract/grocery-optimizer-api.contract.spec.ts
+++ b/backend/test/contract/grocery-optimizer-api.contract.spec.ts
@@ -181,8 +181,10 @@ describe('Grocery optimizer API contract', () => {
         expect(regionalOffersResponse.body.groupedOffers[0]).toEqual(
           expect.objectContaining({
             productName: expect.any(String),
+            category: expect.any(String),
             bestOffer: expect.objectContaining({
               id: expect.any(String),
+              category: expect.any(String),
               priceAmount: expect.any(Number),
               storeName: expect.any(String),
             }),

--- a/backend/test/unit/pricing/public-pricing.service.spec.ts
+++ b/backend/test/unit/pricing/public-pricing.service.spec.ts
@@ -37,6 +37,7 @@ describe('PublicPricingService', () => {
               confidenceLevel: 'high',
               catalogProduct: {
                 name: 'Cafe torrado',
+                category: 'mercearia',
                 imageUrl: null,
               },
               productVariant: {
@@ -124,6 +125,7 @@ describe('PublicPricingService', () => {
         expect.objectContaining({
           id: 'offer-1',
           productName: 'Cafe torrado',
+          category: 'mercearia',
           variantName: 'Cafe 500g',
           imageUrl: 'https://example.com/cafe.png',
           storeName: 'Mercado Centro',
@@ -137,6 +139,7 @@ describe('PublicPricingService', () => {
           id: 'variant-1',
           productVariantId: 'variant-1',
           productName: 'Cafe torrado',
+          category: 'mercearia',
           variantName: 'Cafe 500g',
           establishmentCount: 1,
           cheapestPriceAmount: 15.9,
@@ -144,6 +147,7 @@ describe('PublicPricingService', () => {
           highestPriceAmount: 15.9,
           bestOffer: expect.objectContaining({
             id: 'offer-1',
+            category: 'mercearia',
             storeName: 'Mercado Centro',
           }),
           alternativeOffers: [],

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -599,6 +599,7 @@ sensitive monetary values across web surfaces.
 - [X] T243 Replace misleading public city-selection CTAs with header-selection guidance or explicit cities-and-stores browsing copy in `web/src/public/`
 - [X] T244 Make public city-selection CTAs open a real shared city selector instead of routing to `/cidades` in `web/src/public/`
 - [X] T245 Compact public offer cards and add scalable offer search/filter controls in `web/src/public/`
+- [X] T246 Preserve offer categories in regional pricing responses and add scalable public offer sorting in `backend/src/pricing/` and `web/src/public/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.

--- a/web/e2e/responsive-qa.spec.ts
+++ b/web/e2e/responsive-qa.spec.ts
@@ -381,6 +381,7 @@ for (const viewport of [
 
       await page.goto('/ofertas');
       await expect(page.getByText('Buscar e filtrar ofertas')).toBeVisible();
+      await expect(page.getByText('Ordenar por')).toBeVisible();
       await expect(page.getByText('Cafe Pilao 500g').first()).toBeVisible();
       await expectNoHorizontalOverflow(page);
 

--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -533,6 +533,19 @@ describe('public pages', () => {
     expect(screen.getByText(/1\s+de\s+2 produtos agrupados/)).toBeTruthy();
     expect(screen.queryByText('Arroz Camil tipo 1 5kg')).toBeNull();
     expect(screen.getByText('Acucar Uniao 1kg')).toBeTruthy();
+
+    fireEvent.change(
+      screen.getByPlaceholderText('Nome, produto, mercado, bairro...'),
+      {
+        target: { value: '' },
+      },
+    );
+
+    expect(
+      screen
+        .getAllByRole('img')
+        .map((image) => image.getAttribute('alt')),
+    ).toEqual(['Acucar Uniao 1kg', 'Arroz Camil tipo 1 5kg']);
   });
 
   it('deduplicates regional offers by variant when the API only returns flat offers', async () => {

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -132,6 +132,12 @@ type OptimizationResultTab =
   | 'stores'
   | 'savings';
 type OptimizationItemFilter = 'all' | 'selected' | 'review';
+type OfferSort =
+  | 'name'
+  | 'lowest-price'
+  | 'highest-savings'
+  | 'highest-confidence'
+  | 'most-recent';
 
 function normalizeSearchText(value: string | null | undefined) {
   return (value ?? '')
@@ -2103,6 +2109,7 @@ export function OffersPage() {
   const [categoryFilter, setCategoryFilter] = useState('all');
   const [confidenceFilter, setConfidenceFilter] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const [offerSort, setOfferSort] = useState<OfferSort>('name');
   const [isCitySelectionOpen, setIsCitySelectionOpen] = useState(false);
 
   useEffect(() => {
@@ -2172,46 +2179,87 @@ export function OffersPage() {
             Boolean(group),
           );
   const normalizedSearchQuery = normalizeSearchText(searchQuery);
-  const visibleOfferGroups = storeScopedOfferGroups.filter((group) => {
-    const groupCategory = group.category ?? group.bestOffer.category ?? '';
-    const comparableOffers = getComparableOffers(group);
+  const visibleOfferGroups = storeScopedOfferGroups
+    .filter((group) => {
+      const groupCategory = group.category ?? group.bestOffer.category ?? '';
+      const comparableOffers = getComparableOffers(group);
 
-    if (categoryFilter !== 'all' && groupCategory !== categoryFilter) {
-      return false;
-    }
+      if (categoryFilter !== 'all' && groupCategory !== categoryFilter) {
+        return false;
+      }
 
-    if (
-      confidenceFilter !== 'all' &&
-      group.bestOffer.confidenceLevel !== confidenceFilter
-    ) {
-      return false;
-    }
+      if (
+        confidenceFilter !== 'all' &&
+        group.bestOffer.confidenceLevel !== confidenceFilter
+      ) {
+        return false;
+      }
 
-    if (!normalizedSearchQuery) {
-      return true;
-    }
+      if (!normalizedSearchQuery) {
+        return true;
+      }
 
-    const searchableText = normalizeSearchText(
-      [
-        group.productName,
-        group.variantName,
-        group.packageLabel,
-        groupCategory,
-        group.bestOffer.displayName,
-        ...comparableOffers.flatMap((offer) => [
-          offer.productName,
-          offer.variantName,
-          offer.displayName,
-          offer.packageLabel,
-          offer.storeName,
-          offer.neighborhood,
-          offer.sourceLabel,
-        ]),
-      ].join(' '),
-    );
+      const searchableText = normalizeSearchText(
+        [
+          group.productName,
+          group.variantName,
+          group.packageLabel,
+          groupCategory,
+          group.bestOffer.displayName,
+          ...comparableOffers.flatMap((offer) => [
+            offer.productName,
+            offer.variantName,
+            offer.displayName,
+            offer.packageLabel,
+            offer.storeName,
+            offer.neighborhood,
+            offer.sourceLabel,
+          ]),
+        ].join(' '),
+      );
 
-    return searchableText.includes(normalizedSearchQuery);
-  });
+      return searchableText.includes(normalizedSearchQuery);
+    })
+    .sort((left, right) => {
+      if (offerSort === 'lowest-price') {
+        return left.cheapestPriceAmount - right.cheapestPriceAmount;
+      }
+
+      if (offerSort === 'highest-savings') {
+        const leftSavings = Math.max(
+          left.savingsVsSecondCheapest ?? 0,
+          left.bestOffer.savingsVsRegionalAverage ?? 0,
+          left.bestOffer.savingsVsComparison ?? 0,
+        );
+        const rightSavings = Math.max(
+          right.savingsVsSecondCheapest ?? 0,
+          right.bestOffer.savingsVsRegionalAverage ?? 0,
+          right.bestOffer.savingsVsComparison ?? 0,
+        );
+
+        return rightSavings - leftSavings;
+      }
+
+      if (offerSort === 'highest-confidence') {
+        const confidenceRank = { high: 3, medium: 2, low: 1 };
+        return (
+          confidenceRank[right.bestOffer.confidenceLevel] -
+          confidenceRank[left.bestOffer.confidenceLevel]
+        );
+      }
+
+      if (offerSort === 'most-recent') {
+        return (
+          new Date(right.bestOffer.observedAt).getTime() -
+          new Date(left.bestOffer.observedAt).getTime()
+        );
+      }
+
+      return (left.variantName ?? left.productName).localeCompare(
+        right.variantName ?? right.productName,
+        'pt-BR',
+      );
+    });
 
   const clearOfferFilters = () => {
     setSearchQuery('');
@@ -2267,8 +2315,8 @@ export function OffersPage() {
               </Button>
             ) : null}
           </div>
-          <div className="grid gap-3 lg:grid-cols-[minmax(220px,1fr)_repeat(3,minmax(160px,220px))]">
-            <label className="grid gap-1 text-sm">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
+            <label className="grid gap-1 text-sm xl:col-span-2">
               <span className="font-medium">Pesquisar</span>
               <div className="relative">
                 <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
@@ -2341,6 +2389,32 @@ export function OffersPage() {
                     <SelectItem value="high">Alta</SelectItem>
                     <SelectItem value="medium">Média</SelectItem>
                     <SelectItem value="low">Baixa</SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </label>
+            <label className="grid gap-1 text-sm">
+              <span className="font-medium">Ordenar por</span>
+              <Select
+                onValueChange={(value) => setOfferSort(value as OfferSort)}
+                value={offerSort}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Nome" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectItem value="name">Nome (A-Z)</SelectItem>
+                    <SelectItem value="lowest-price">Menor preço</SelectItem>
+                    <SelectItem value="highest-savings">
+                      Maior economia
+                    </SelectItem>
+                    <SelectItem value="highest-confidence">
+                      Maior confiança
+                    </SelectItem>
+                    <SelectItem value="most-recent">
+                      Atualizado recentemente
+                    </SelectItem>
                   </SelectGroup>
                 </SelectContent>
               </Select>


### PR DESCRIPTION
## Summary
- Preserve catalog product category in regional offer and grouped-offer API responses
- Enable the existing category filter with real backend data
- Add sorting by name, lowest price, highest savings, confidence, and freshness
- Keep the filter toolbar responsive with a wider search field

## Validation
- backend lint, build, and 130 tests
- web lint, build, and 55 tests
- Chromium responsive and full MVP E2E
- Smoke: category filtering, savings sorting, desktop and mobile without overflow
- Screenshots: .tmp/smoke-screens-412-offer-sort-category-2026-06-24/

Issue: #412