### PR TITLE
Paginate offers and persist catalog filters

### DIFF
--- a/backend/src/common/contracts/regions.contract.ts
+++ b/backend/src/common/contracts/regions.contract.ts
@@ -88,4 +88,16 @@ export interface RegionalOffersContract {
     averagePriceAmount: number;
     highestPriceAmount: number;
   }>;
+  pagination: {
+    page: number;
+    pageSize: number;
+    totalItems: number;
+    totalPages: number;
+    hasPreviousPage: boolean;
+    hasNextPage: boolean;
+  };
+  filters: {
+    stores: string[];
+    categories: string[];
+  };
 }

--- a/backend/src/pricing/api/public-pricing.controller.ts
+++ b/backend/src/pricing/api/public-pricing.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 
 import { PublicPricingService } from '../application/public-pricing.service';
 
@@ -7,8 +7,25 @@ export class PublicPricingController {
   constructor(private readonly publicPricingService: PublicPricingService) {}
 
   @Get('regions/:regionSlug/offers')
-  async listRegionOffers(@Param('regionSlug') regionSlug: string) {
-    return this.publicPricingService.listRegionOffers(regionSlug);
+  async listRegionOffers(
+    @Param('regionSlug') regionSlug: string,
+    @Query('q') query?: string,
+    @Query('store') store?: string,
+    @Query('category') category?: string,
+    @Query('confidence') confidence?: string,
+    @Query('sort') sort?: string,
+    @Query('page') page?: string,
+    @Query('pageSize') pageSize?: string,
+  ) {
+    return this.publicPricingService.listRegionOffers(regionSlug, {
+      query,
+      store,
+      category,
+      confidence,
+      sort,
+      page,
+      pageSize,
+    });
   }
 
   @Get('offers/:offerId')

--- a/backend/src/pricing/application/public-pricing.service.ts
+++ b/backend/src/pricing/application/public-pricing.service.ts
@@ -2,13 +2,30 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 
 import { PrismaService } from '../../persistence/prisma.service';
 
+type PublicOfferSort =
+  | 'name'
+  | 'lowest-price'
+  | 'highest-savings'
+  | 'highest-confidence'
+  | 'most-recent';
+
+type PublicOfferQuery = {
+  query?: string;
+  store?: string;
+  category?: string;
+  confidence?: string;
+  sort?: string;
+  page?: string;
+  pageSize?: string;
+};
+
 @Injectable()
 export class PublicPricingService {
   private readonly logger = new Logger(PublicPricingService.name);
 
   constructor(private readonly prisma: PrismaService) {}
 
-  async listRegionOffers(regionSlug: string) {
+  async listRegionOffers(regionSlug: string, query: PublicOfferQuery = {}) {
     const region = await this.prisma.region.findUnique({
       where: {
         slug: regionSlug,
@@ -19,17 +36,100 @@ export class PublicPricingService {
       throw new NotFoundException(`Region ${regionSlug} was not found`);
     }
 
+    const normalizedQuery = query.query?.trim();
+    const normalizedStore = query.store?.trim();
+    const normalizedCategory = query.category?.trim();
+    const confidence =
+      query.confidence === 'high' ||
+      query.confidence === 'medium' ||
+      query.confidence === 'low'
+        ? query.confidence
+        : undefined;
+    const page = this.parsePositiveInteger(query.page, 1);
+    const pageSize = Math.min(
+      this.parsePositiveInteger(query.pageSize, 24),
+      48,
+    );
+    const sort = this.parseOfferSort(query.sort);
+
     const offers = await this.prisma.productOffer.findMany({
       where: {
         isActive: true,
         availabilityStatus: 'available',
+        ...(confidence ? { confidenceLevel: confidence } : {}),
         establishment: {
           isActive: true,
           regionId: region.id,
+          ...(normalizedStore
+            ? {
+                unitName: {
+                  equals: normalizedStore,
+                  mode: 'insensitive' as const,
+                },
+              }
+            : {}),
         },
         catalogProduct: {
           isActive: true,
+          ...(normalizedCategory
+            ? {
+                category: {
+                  equals: normalizedCategory,
+                  mode: 'insensitive' as const,
+                },
+              }
+            : {}),
         },
+        ...(normalizedQuery
+          ? {
+              OR: [
+                {
+                  displayName: {
+                    contains: normalizedQuery,
+                    mode: 'insensitive' as const,
+                  },
+                },
+                {
+                  packageLabel: {
+                    contains: normalizedQuery,
+                    mode: 'insensitive' as const,
+                  },
+                },
+                {
+                  catalogProduct: {
+                    name: {
+                      contains: normalizedQuery,
+                      mode: 'insensitive' as const,
+                    },
+                  },
+                },
+                {
+                  productVariant: {
+                    displayName: {
+                      contains: normalizedQuery,
+                      mode: 'insensitive' as const,
+                    },
+                  },
+                },
+                {
+                  establishment: {
+                    unitName: {
+                      contains: normalizedQuery,
+                      mode: 'insensitive' as const,
+                    },
+                  },
+                },
+                {
+                  establishment: {
+                    neighborhood: {
+                      contains: normalizedQuery,
+                      mode: 'insensitive' as const,
+                    },
+                  },
+                },
+              ],
+            }
+          : {}),
       },
       include: {
         catalogProduct: true,
@@ -46,6 +146,20 @@ export class PublicPricingService {
       ),
     );
 
+    const groupedOffers = this.sortRegionalOfferGroups(
+      this.groupRegionalOffers(projectedOffers),
+      sort,
+    );
+    const totalItems = groupedOffers.length;
+    const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+    const currentPage = Math.min(page, totalPages);
+    const paginatedGroups = groupedOffers.slice(
+      (currentPage - 1) * pageSize,
+      currentPage * pageSize,
+    );
+    const visibleOfferIds = new Set(
+      paginatedGroups.flatMap((group) => group.offers.map((offer) => offer.id)),
+    );
     const response = {
       region: {
         id: region.id,
@@ -60,8 +174,28 @@ export class PublicPricingService {
         },
       }),
       offerCoverageStatus: offers.length > 0 ? 'live' : 'collecting_data',
-      offers: projectedOffers,
-      groupedOffers: this.groupRegionalOffers(projectedOffers),
+      offers: projectedOffers.filter((offer) => visibleOfferIds.has(offer.id)),
+      groupedOffers: paginatedGroups,
+      pagination: {
+        page: currentPage,
+        pageSize,
+        totalItems,
+        totalPages,
+        hasPreviousPage: currentPage > 1,
+        hasNextPage: currentPage < totalPages,
+      },
+      filters: {
+        stores: [
+          ...new Set(
+            projectedOffers.map((offer) => offer.storeName).filter(Boolean),
+          ),
+        ].sort((left, right) => left.localeCompare(right)),
+        categories: [
+          ...new Set(
+            projectedOffers.map((offer) => offer.category).filter(Boolean),
+          ),
+        ].sort((left, right) => left.localeCompare(right)),
+      },
     };
 
     this.logger.log(
@@ -216,6 +350,24 @@ export class PublicPricingService {
         this.calculateComparison(entries),
       ]),
     );
+  }
+
+  private parsePositiveInteger(value: string | undefined, fallback: number) {
+    const parsed = Number.parseInt(value ?? '', 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+
+  private parseOfferSort(value: string | undefined): PublicOfferSort {
+    if (
+      value === 'lowest-price' ||
+      value === 'highest-savings' ||
+      value === 'highest-confidence' ||
+      value === 'most-recent'
+    ) {
+      return value;
+    }
+
+    return 'name';
   }
 
   private calculateComparison(
@@ -383,5 +535,50 @@ export class PublicPricingService {
 
         return left.cheapestPriceAmount - right.cheapestPriceAmount;
       });
+  }
+
+  private sortRegionalOfferGroups(
+    groups: ReturnType<PublicPricingService['groupRegionalOffers']>,
+    sort: PublicOfferSort,
+  ) {
+    return [...groups].sort((left, right) => {
+      if (sort === 'lowest-price') {
+        return left.cheapestPriceAmount - right.cheapestPriceAmount;
+      }
+
+      if (sort === 'highest-savings') {
+        const leftSavings = Math.max(
+          left.savingsVsSecondCheapest,
+          left.bestOffer.savingsVsRegionalAverage,
+          left.bestOffer.savingsVsComparison,
+        );
+        const rightSavings = Math.max(
+          right.savingsVsSecondCheapest,
+          right.bestOffer.savingsVsRegionalAverage,
+          right.bestOffer.savingsVsComparison,
+        );
+        return rightSavings - leftSavings;
+      }
+
+      if (sort === 'highest-confidence') {
+        const confidenceRank = { high: 3, medium: 2, low: 1 };
+        return (
+          confidenceRank[right.bestOffer.confidenceLevel] -
+          confidenceRank[left.bestOffer.confidenceLevel]
+        );
+      }
+
+      if (sort === 'most-recent') {
+        return (
+          new Date(right.bestOffer.observedAt).getTime() -
+          new Date(left.bestOffer.observedAt).getTime()
+        );
+      }
+
+      return (left.variantName ?? left.productName).localeCompare(
+        right.variantName ?? right.productName,
+        'pt-BR',
+      );
+    });
   }
 }

--- a/backend/test/contract/grocery-optimizer-api.contract.spec.ts
+++ b/backend/test/contract/grocery-optimizer-api.contract.spec.ts
@@ -174,6 +174,16 @@ describe('Grocery optimizer API contract', () => {
           offerCoverageStatus: expect.stringMatching(/live|collecting_data/),
           offers: expect.any(Array),
           groupedOffers: expect.any(Array),
+          pagination: expect.objectContaining({
+            page: expect.any(Number),
+            pageSize: expect.any(Number),
+            totalItems: expect.any(Number),
+            totalPages: expect.any(Number),
+          }),
+          filters: expect.objectContaining({
+            stores: expect.any(Array),
+            categories: expect.any(Array),
+          }),
         }),
       );
 

--- a/backend/test/unit/pricing/public-pricing.service.spec.ts
+++ b/backend/test/unit/pricing/public-pricing.service.spec.ts
@@ -159,6 +159,18 @@ describe('PublicPricingService', () => {
           ],
         }),
       ],
+      pagination: {
+        page: 1,
+        pageSize: 24,
+        totalItems: 1,
+        totalPages: 1,
+        hasPreviousPage: false,
+        hasNextPage: false,
+      },
+      filters: {
+        stores: ['Mercado Centro'],
+        categories: ['mercearia'],
+      },
     });
 
     await expect(service.getOfferDetail('offer-1')).resolves.toEqual(
@@ -299,6 +311,105 @@ describe('PublicPricingService', () => {
       expect.objectContaining({
         where: expect.objectContaining({
           productVariantId: 'variant-camil',
+        }),
+      }),
+    );
+  });
+
+  it('filters, sorts, and paginates regional offer groups', async () => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    const makeOffer = (
+      id: string,
+      variantName: string,
+      priceAmount: number,
+      category: string,
+    ) => ({
+      id,
+      catalogProductId: `product-${id}`,
+      productVariantId: `variant-${id}`,
+      displayName: variantName,
+      packageLabel: '1 un',
+      priceAmount,
+      basePriceAmount: priceAmount,
+      promotionalPriceAmount: null,
+      sourceType: 'admin',
+      sourceReference: 'Teste',
+      observedAt: new Date('2026-06-24T10:00:00Z'),
+      confidenceLevel: 'high' as const,
+      catalogProduct: {
+        name: variantName,
+        category,
+        imageUrl: null,
+      },
+      productVariant: {
+        displayName: variantName,
+        imageUrl: null,
+      },
+      establishment: {
+        unitName: 'Mercado Centro',
+        neighborhood: 'Centro',
+      },
+    });
+    const findMany = jest.fn().mockResolvedValue([
+      makeOffer('cafe', 'Cafe 500g', 16.9, 'mercearia'),
+      makeOffer('acucar', 'Acucar 1kg', 4.19, 'mercearia'),
+      makeOffer('arroz', 'Arroz 5kg', 20.9, 'mercearia'),
+    ]);
+    const prisma = {
+      region: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'region-1',
+          slug: 'sao-paulo-sp',
+          name: 'Sao Paulo',
+          stateCode: 'SP',
+          implantationStatus: 'active',
+        }),
+      },
+      establishment: {
+        count: jest.fn().mockResolvedValue(1),
+      },
+      productOffer: {
+        findMany,
+      },
+    };
+    const service = new PublicPricingService(prisma as never);
+
+    const result = await service.listRegionOffers('sao-paulo-sp', {
+      query: 'a',
+      store: 'Mercado Centro',
+      category: 'mercearia',
+      confidence: 'high',
+      sort: 'lowest-price',
+      page: '2',
+      pageSize: '1',
+    });
+
+    expect(result.pagination).toEqual({
+      page: 2,
+      pageSize: 1,
+      totalItems: 3,
+      totalPages: 3,
+      hasPreviousPage: true,
+      hasNextPage: true,
+    });
+    expect(result.groupedOffers).toHaveLength(1);
+    expect(result.groupedOffers[0].variantName).toBe('Cafe 500g');
+    expect(result.offers).toHaveLength(1);
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          confidenceLevel: 'high',
+          OR: expect.any(Array),
+          catalogProduct: expect.objectContaining({
+            category: expect.objectContaining({
+              equals: 'mercearia',
+            }),
+          }),
+          establishment: expect.objectContaining({
+            unitName: expect.objectContaining({
+              equals: 'Mercado Centro',
+            }),
+          }),
         }),
       }),
     );

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -600,6 +600,7 @@ sensitive monetary values across web surfaces.
 - [X] T244 Make public city-selection CTAs open a real shared city selector instead of routing to `/cidades` in `web/src/public/`
 - [X] T245 Compact public offer cards and add scalable offer search/filter controls in `web/src/public/`
 - [X] T246 Preserve offer categories in regional pricing responses and add scalable public offer sorting in `backend/src/pricing/` and `web/src/public/`
+- [X] T247 Add server-side public offer querying and pagination with URL-persisted web catalog state in `backend/src/pricing/` and `web/src/public/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.

--- a/web/e2e/responsive-qa.spec.ts
+++ b/web/e2e/responsive-qa.spec.ts
@@ -42,6 +42,7 @@ const offer = {
   catalogProductId: 'catalog-1',
   productVariantId: 'variant-1',
   productName: 'Cafe torrado',
+  category: 'mercearia',
   variantName: 'Cafe Pilao 500g',
   displayName: 'Cafe Pilao 500g',
   imageUrl: '/uploads/cafe.png',
@@ -129,17 +130,31 @@ async function mockResponsiveApi(
     }
 
     if (path === '/regions/sao-paulo-sp/offers') {
+      const currentPage = Number(url.searchParams.get('page') ?? '1');
       return json({
         region,
         activeEstablishmentCount: 2,
         offerCoverageStatus: 'live',
         offers: [offer],
+        pagination: {
+          page: currentPage,
+          pageSize: 24,
+          totalItems: 50,
+          totalPages: 3,
+          hasPreviousPage: currentPage > 1,
+          hasNextPage: currentPage < 3,
+        },
+        filters: {
+          stores: ['Mercado Centro'],
+          categories: ['mercearia'],
+        },
         groupedOffers: [
           {
             id: 'variant-1',
             catalogProductId: 'catalog-1',
             productVariantId: 'variant-1',
             productName: 'Cafe torrado',
+            category: 'mercearia',
             variantName: 'Cafe Pilao 500g',
             imageUrl: '/uploads/cafe.png',
             packageLabel: '500 g',
@@ -383,6 +398,18 @@ for (const viewport of [
       await expect(page.getByText('Buscar e filtrar ofertas')).toBeVisible();
       await expect(page.getByText('Ordenar por')).toBeVisible();
       await expect(page.getByText('Cafe Pilao 500g').first()).toBeVisible();
+      await expectNoHorizontalOverflow(page);
+      await page
+        .getByPlaceholder('Nome, produto, mercado, bairro...')
+        .fill('cafe');
+      await expect(page).toHaveURL(/q=cafe/);
+      await page
+        .getByPlaceholder('Nome, produto, mercado, bairro...')
+        .fill('');
+      await expect(page).not.toHaveURL(/q=/);
+      await page.getByRole('button', { name: 'Próxima' }).click();
+      await expect(page).toHaveURL(/page=2/);
+      await expect(page.getByText('Página 2 de 3')).toBeVisible();
       await expectNoHorizontalOverflow(page);
 
       await page.goto('/listas');

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -161,6 +161,18 @@ type RegionOffersApiResponse = {
   offerCoverageStatus: 'live' | 'collecting_data';
   offers: RegionalOfferApiResponse[];
   groupedOffers?: RegionalOfferGroupApiResponse[];
+  pagination?: {
+    page: number;
+    pageSize: number;
+    totalItems: number;
+    totalPages: number;
+    hasPreviousPage: boolean;
+    hasNextPage: boolean;
+  };
+  filters?: {
+    stores: string[];
+    categories: string[];
+  };
 };
 
 type RegionalOfferApiResponse = {
@@ -897,8 +909,30 @@ export async function submitReceipt(
   );
 }
 
-export async function fetchRegionOffers(regionSlug: string) {
-  return apiFetch<RegionOffersApiResponse>(`/regions/${regionSlug}/offers`);
+export async function fetchRegionOffers(
+  regionSlug: string,
+  query?: {
+    q?: string;
+    store?: string;
+    category?: string;
+    confidence?: string;
+    sort?: string;
+    page?: number;
+    pageSize?: number;
+  },
+) {
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value !== undefined && value !== '' && value !== 'all') {
+      searchParams.set(key, String(value));
+    }
+  }
+
+  const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : '';
+  return apiFetch<RegionOffersApiResponse>(
+    `/regions/${regionSlug}/offers${suffix}`,
+  );
 }
 
 export async function fetchOfferDetail(offerId: string) {

--- a/web/src/public/public-pages.spec.tsx
+++ b/web/src/public/public-pages.spec.tsx
@@ -414,6 +414,18 @@ describe('public pages', () => {
       activeEstablishmentCount: 2,
       offerCoverageStatus: 'live',
       offers: [],
+      pagination: {
+        page: 1,
+        pageSize: 24,
+        totalItems: 2,
+        totalPages: 1,
+        hasPreviousPage: false,
+        hasNextPage: false,
+      },
+      filters: {
+        stores: ['Unidade Pinheiros', 'Unidade Vila Mariana'],
+        categories: ['Mercearia'],
+      },
       groupedOffers: [
         {
           id: 'variant-1',
@@ -513,7 +525,9 @@ describe('public pages', () => {
     expect(await screen.findByText('Arroz Camil tipo 1 5kg')).toBeTruthy();
     expect(screen.getByText('Acucar Uniao 1kg')).toBeTruthy();
     expect(screen.getByText('Arroz tipo 1 5kg')).toBeTruthy();
-    expect(screen.getByText(/2\s+de\s+2 produtos agrupados/)).toBeTruthy();
+    expect(
+      screen.getByText(/2 produtos nesta página de 2 produtos encontrados/),
+    ).toBeTruthy();
     expect(screen.getByText('2 mercados')).toBeTruthy();
     expect(
       screen.getAllByText(/Menor preço em Unidade Vila Mariana/).length,
@@ -530,9 +544,16 @@ describe('public pages', () => {
       },
     );
 
-    expect(screen.getByText(/1\s+de\s+2 produtos agrupados/)).toBeTruthy();
-    expect(screen.queryByText('Arroz Camil tipo 1 5kg')).toBeNull();
-    expect(screen.getByText('Acucar Uniao 1kg')).toBeTruthy();
+    await waitFor(() =>
+      expect(fetchRegionOffers).toHaveBeenLastCalledWith(
+        'campinas-sp',
+        expect.objectContaining({
+          q: 'acucar',
+          page: 1,
+          pageSize: 24,
+        }),
+      ),
+    );
 
     fireEvent.change(
       screen.getByPlaceholderText('Nome, produto, mercado, bairro...'),
@@ -540,12 +561,12 @@ describe('public pages', () => {
         target: { value: '' },
       },
     );
-
-    expect(
-      screen
-        .getAllByRole('img')
-        .map((image) => image.getAttribute('alt')),
-    ).toEqual(['Acucar Uniao 1kg', 'Arroz Camil tipo 1 5kg']);
+    await waitFor(() =>
+      expect(fetchRegionOffers).toHaveBeenLastCalledWith(
+        'campinas-sp',
+        expect.objectContaining({ q: '' }),
+      ),
+    );
   });
 
   it('deduplicates regional offers by variant when the API only returns flat offers', async () => {

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -1,11 +1,17 @@
 ﻿import { useEffect, useState, type FormEvent } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from 'react-router-dom';
 import {
   AlertCircleIcon,
   ArrowRightIcon,
   BadgeCheckIcon,
   BellIcon,
   ChevronDownIcon,
+  ChevronLeftIcon,
   ChevronRightIcon,
   CheckCircle2Icon,
   ClipboardListIcon,
@@ -132,20 +138,6 @@ type OptimizationResultTab =
   | 'stores'
   | 'savings';
 type OptimizationItemFilter = 'all' | 'selected' | 'review';
-type OfferSort =
-  | 'name'
-  | 'lowest-price'
-  | 'highest-savings'
-  | 'highest-confidence'
-  | 'most-recent';
-
-function normalizeSearchText(value: string | null | undefined) {
-  return (value ?? '')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .trim();
-}
 
 function CitySelectionDialog({
   cityId,
@@ -746,50 +738,6 @@ function getComparableOffers(group: PublicOfferGroup) {
   return group.offers.length > 0
     ? group.offers
     : [group.bestOffer, ...group.alternativeOffers];
-}
-
-function buildOfferGroupFromOffers(
-  group: PublicOfferGroup,
-  offers: PublicOfferGroup['offers'],
-): PublicOfferGroup | null {
-  if (offers.length === 0) {
-    return null;
-  }
-
-  const sorted = [...offers].sort((left, right) => {
-    if (left.priceAmount !== right.priceAmount) {
-      return left.priceAmount - right.priceAmount;
-    }
-
-    return (
-      new Date(right.observedAt).getTime() - new Date(left.observedAt).getTime()
-    );
-  });
-  const prices = sorted.map((offer) => offer.priceAmount);
-  const cheapestPriceAmount = sorted[0].priceAmount;
-  const secondCheapestPriceAmount = sorted[1]?.priceAmount;
-  const averagePriceAmount = Number(
-    (prices.reduce((sum, price) => sum + price, 0) / prices.length).toFixed(2),
-  );
-
-  return {
-    ...group,
-    bestOffer: sorted[0],
-    alternativeOffers: sorted.slice(1),
-    offers: sorted,
-    establishmentCount: sorted.length,
-    cheapestPriceAmount,
-    secondCheapestPriceAmount,
-    savingsVsSecondCheapest: Number(
-      Math.max(
-        0,
-        (secondCheapestPriceAmount ?? cheapestPriceAmount) -
-          cheapestPriceAmount,
-      ).toFixed(2),
-    ),
-    averagePriceAmount,
-    highestPriceAmount: Math.max(...prices),
-  };
 }
 
 function groupFlatRegionalOffers(
@@ -2099,18 +2047,35 @@ export function LandingPage() {
 
 export function OffersPage() {
   const { cityId, cities, setCityId } = usePricely();
+  const [searchParams, setSearchParams] = useSearchParams();
   const city = cityId
     ? (cities.find((entry) => entry.id === cityId) ?? getCityById(cityId))
     : null;
   const [offerGroups, setOfferGroups] = useState<
     NonNullable<RegionOffersApiResponse['groupedOffers']>
   >([]);
-  const [storeFilter, setStoreFilter] = useState('all');
-  const [categoryFilter, setCategoryFilter] = useState('all');
-  const [confidenceFilter, setConfidenceFilter] = useState('all');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [offerSort, setOfferSort] = useState<OfferSort>('name');
+  const [offerPagination, setOfferPagination] = useState<
+    NonNullable<RegionOffersApiResponse['pagination']>
+  >({
+    page: 1,
+    pageSize: 24,
+    totalItems: 0,
+    totalPages: 1,
+    hasPreviousPage: false,
+    hasNextPage: false,
+  });
+  const [availableStores, setAvailableStores] = useState<string[]>([]);
+  const [availableCategories, setAvailableCategories] = useState<string[]>([]);
   const [isCitySelectionOpen, setIsCitySelectionOpen] = useState(false);
+  const searchQuery = searchParams.get('q') ?? '';
+  const storeFilter = searchParams.get('store') ?? 'all';
+  const categoryFilter = searchParams.get('category') ?? 'all';
+  const confidenceFilter = searchParams.get('confidence') ?? 'all';
+  const offerSort = searchParams.get('sort') ?? 'name';
+  const requestedPage = Math.max(
+    1,
+    Number.parseInt(searchParams.get('page') ?? '1', 10) || 1,
+  );
 
   useEffect(() => {
     let disposed = false;
@@ -2118,15 +2083,57 @@ export function OffersPage() {
     const load = async () => {
       if (!cityId) {
         setOfferGroups([]);
+        setOfferPagination((current) => ({
+          ...current,
+          page: 1,
+          totalItems: 0,
+          totalPages: 1,
+          hasPreviousPage: false,
+          hasNextPage: false,
+        }));
         return;
       }
 
       try {
-        const response = await fetchRegionOffers(cityId);
+        const response = await fetchRegionOffers(cityId, {
+          q: searchQuery,
+          store: storeFilter,
+          category: categoryFilter,
+          confidence: confidenceFilter,
+          sort: offerSort,
+          page: requestedPage,
+          pageSize: 24,
+        });
         if (!disposed) {
           setOfferGroups(
             response.groupedOffers ?? groupFlatRegionalOffers(response.offers),
           );
+          setOfferPagination(
+            response.pagination ?? {
+              page: 1,
+              pageSize: response.groupedOffers?.length ?? response.offers.length,
+              totalItems:
+                response.groupedOffers?.length ?? response.offers.length,
+              totalPages: 1,
+              hasPreviousPage: false,
+              hasNextPage: false,
+            },
+          );
+          setAvailableStores(response.filters?.stores ?? []);
+          setAvailableCategories(response.filters?.categories ?? []);
+
+          if (
+            response.pagination &&
+            response.pagination.page !== requestedPage
+          ) {
+            const next = new URLSearchParams(searchParams);
+            if (response.pagination.page === 1) {
+              next.delete('page');
+            } else {
+              next.set('page', String(response.pagination.page));
+            }
+            setSearchParams(next, { replace: true });
+          }
         }
       } catch {
         if (!disposed) {
@@ -2140,21 +2147,37 @@ export function OffersPage() {
     return () => {
       disposed = true;
     };
-  }, [cityId]);
+  }, [
+    categoryFilter,
+    cityId,
+    confidenceFilter,
+    offerSort,
+    requestedPage,
+    searchParams,
+    searchQuery,
+    setSearchParams,
+    storeFilter,
+  ]);
 
   const storeOptions = Array.from(
-    new Set(
-      offerGroups.flatMap((group) =>
+    new Set([
+      ...availableStores,
+      ...(storeFilter !== 'all' ? [storeFilter] : []),
+      ...offerGroups.flatMap((group) =>
         getComparableOffers(group).map((offer) => offer.storeName),
       ),
-    ),
+    ]),
   ).sort((left, right) => left.localeCompare(right));
 
   const categoryOptions = Array.from(
     new Set(
-      offerGroups
-        .map((group) => group.category ?? group.bestOffer.category)
-        .filter((category): category is string => Boolean(category)),
+      [
+        ...availableCategories,
+        ...(categoryFilter !== 'all' ? [categoryFilter] : []),
+        ...offerGroups.map(
+          (group) => group.category ?? group.bestOffer.category,
+        ),
+      ].filter((category): category is string => Boolean(category)),
     ),
   ).sort((left, right) => left.localeCompare(right));
 
@@ -2164,108 +2187,41 @@ export function OffersPage() {
     categoryFilter !== 'all' ||
     confidenceFilter !== 'all';
 
-  const storeScopedOfferGroups =
-    storeFilter === 'all'
-      ? offerGroups
-      : offerGroups
-          .map((group) => {
-            const filteredOffers = getComparableOffers(group).filter(
-              (offer) => offer.storeName === storeFilter,
-            );
+  const visibleOfferGroups = offerGroups;
 
-            return buildOfferGroupFromOffers(group, filteredOffers);
-          })
-          .filter((group): group is NonNullable<typeof group> =>
-            Boolean(group),
-          );
-  const normalizedSearchQuery = normalizeSearchText(searchQuery);
-  const visibleOfferGroups = storeScopedOfferGroups
-    .filter((group) => {
-      const groupCategory = group.category ?? group.bestOffer.category ?? '';
-      const comparableOffers = getComparableOffers(group);
+  const updateOfferSearchParams = (
+    key: 'q' | 'store' | 'category' | 'confidence' | 'sort' | 'page',
+    value: string,
+    resetPage = true,
+  ) => {
+    const next = new URLSearchParams(searchParams);
 
-      if (categoryFilter !== 'all' && groupCategory !== categoryFilter) {
-        return false;
-      }
+    if (
+      !value ||
+      value === 'all' ||
+      (key === 'sort' && value === 'name') ||
+      (key === 'page' && value === '1')
+    ) {
+      next.delete(key);
+    } else {
+      next.set(key, value);
+    }
 
-      if (
-        confidenceFilter !== 'all' &&
-        group.bestOffer.confidenceLevel !== confidenceFilter
-      ) {
-        return false;
-      }
+    if (resetPage && key !== 'page') {
+      next.delete('page');
+    }
 
-      if (!normalizedSearchQuery) {
-        return true;
-      }
-
-      const searchableText = normalizeSearchText(
-        [
-          group.productName,
-          group.variantName,
-          group.packageLabel,
-          groupCategory,
-          group.bestOffer.displayName,
-          ...comparableOffers.flatMap((offer) => [
-            offer.productName,
-            offer.variantName,
-            offer.displayName,
-            offer.packageLabel,
-            offer.storeName,
-            offer.neighborhood,
-            offer.sourceLabel,
-          ]),
-        ].join(' '),
-      );
-
-      return searchableText.includes(normalizedSearchQuery);
-    })
-    .sort((left, right) => {
-      if (offerSort === 'lowest-price') {
-        return left.cheapestPriceAmount - right.cheapestPriceAmount;
-      }
-
-      if (offerSort === 'highest-savings') {
-        const leftSavings = Math.max(
-          left.savingsVsSecondCheapest ?? 0,
-          left.bestOffer.savingsVsRegionalAverage ?? 0,
-          left.bestOffer.savingsVsComparison ?? 0,
-        );
-        const rightSavings = Math.max(
-          right.savingsVsSecondCheapest ?? 0,
-          right.bestOffer.savingsVsRegionalAverage ?? 0,
-          right.bestOffer.savingsVsComparison ?? 0,
-        );
-
-        return rightSavings - leftSavings;
-      }
-
-      if (offerSort === 'highest-confidence') {
-        const confidenceRank = { high: 3, medium: 2, low: 1 };
-        return (
-          confidenceRank[right.bestOffer.confidenceLevel] -
-          confidenceRank[left.bestOffer.confidenceLevel]
-        );
-      }
-
-      if (offerSort === 'most-recent') {
-        return (
-          new Date(right.bestOffer.observedAt).getTime() -
-          new Date(left.bestOffer.observedAt).getTime()
-        );
-      }
-
-      return (left.variantName ?? left.productName).localeCompare(
-        right.variantName ?? right.productName,
-        'pt-BR',
-      );
-    });
+    setSearchParams(next);
+  };
 
   const clearOfferFilters = () => {
-    setSearchQuery('');
-    setStoreFilter('all');
-    setCategoryFilter('all');
-    setConfidenceFilter('all');
+    const next = new URLSearchParams(searchParams);
+    next.delete('q');
+    next.delete('store');
+    next.delete('category');
+    next.delete('confidence');
+    next.delete('page');
+    setSearchParams(next);
   };
 
   return (
@@ -2304,9 +2260,10 @@ export function OffersPage() {
                 Buscar e filtrar ofertas
               </div>
               <div className="text-sm text-muted-foreground">
-                {visibleOfferGroups.length} de {offerGroups.length} produtos
-                agrupados. Cada produto aparece uma vez, com o menor preço
-                primeiro.
+                {offerPagination.totalItems === 0
+                  ? 'Nenhum produto encontrado.'
+                  : `${visibleOfferGroups.length} produtos nesta página de ${offerPagination.totalItems} produtos encontrados.`}{' '}
+                Cada produto aparece uma vez.
               </div>
             </div>
             {hasActiveOfferFilters ? (
@@ -2322,7 +2279,9 @@ export function OffersPage() {
                 <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                 <Input
                   className="pl-9"
-                  onChange={(event) => setSearchQuery(event.target.value)}
+                  onChange={(event) =>
+                    updateOfferSearchParams('q', event.target.value)
+                  }
                   placeholder="Nome, produto, mercado, bairro..."
                   value={searchQuery}
                 />
@@ -2330,7 +2289,12 @@ export function OffersPage() {
             </label>
             <label className="grid gap-1 text-sm">
               <span className="font-medium">Mercado</span>
-              <Select onValueChange={setStoreFilter} value={storeFilter}>
+              <Select
+                onValueChange={(value) =>
+                  updateOfferSearchParams('store', value)
+                }
+                value={storeFilter}
+              >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Todos os mercados" />
                 </SelectTrigger>
@@ -2350,7 +2314,9 @@ export function OffersPage() {
               <span className="font-medium">Categoria</span>
               <Select
                 disabled={categoryOptions.length === 0}
-                onValueChange={setCategoryFilter}
+                onValueChange={(value) =>
+                  updateOfferSearchParams('category', value)
+                }
                 value={categoryFilter}
               >
                 <SelectTrigger className="w-full">
@@ -2377,7 +2343,9 @@ export function OffersPage() {
             <label className="grid gap-1 text-sm">
               <span className="font-medium">Confiança</span>
               <Select
-                onValueChange={setConfidenceFilter}
+                onValueChange={(value) =>
+                  updateOfferSearchParams('confidence', value)
+                }
                 value={confidenceFilter}
               >
                 <SelectTrigger className="w-full">
@@ -2396,7 +2364,9 @@ export function OffersPage() {
             <label className="grid gap-1 text-sm">
               <span className="font-medium">Ordenar por</span>
               <Select
-                onValueChange={(value) => setOfferSort(value as OfferSort)}
+                onValueChange={(value) =>
+                  updateOfferSearchParams('sort', value, false)
+                }
                 value={offerSort}
               >
                 <SelectTrigger className="w-full">
@@ -2548,6 +2518,51 @@ export function OffersPage() {
           </Card>
         ))}
       </div>
+      {cityId && offerPagination.totalItems > 0 ? (
+        <nav
+          aria-label="Paginação de ofertas"
+          className="flex flex-col gap-3 rounded-lg border border-border/70 bg-card/90 p-3 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div className="text-sm text-muted-foreground">
+            Página {offerPagination.page} de {offerPagination.totalPages} ·{' '}
+            {offerPagination.totalItems} produtos
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              disabled={!offerPagination.hasPreviousPage}
+              onClick={() =>
+                updateOfferSearchParams(
+                  'page',
+                  String(offerPagination.page - 1),
+                  false,
+                )
+              }
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              <ChevronLeftIcon data-icon="inline-start" />
+              Anterior
+            </Button>
+            <Button
+              disabled={!offerPagination.hasNextPage}
+              onClick={() =>
+                updateOfferSearchParams(
+                  'page',
+                  String(offerPagination.page + 1),
+                  false,
+                )
+              }
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              Próxima
+              <ChevronRightIcon data-icon="inline-end" />
+            </Button>
+          </div>
+        </nav>
+      ) : null}
       {cityId && visibleOfferGroups.length === 0 ? (
         <ActionPlaceholder
           icon={<MapPinIcon className="size-5" />}


### PR DESCRIPTION
## Summary
- Add server-side public offer search, store/category/confidence filters, sorting, and bounded pagination
- Return pagination metadata and available filter options
- Persist public offer query, filters, sorting, and page in URL search params
- Add accessible previous/next navigation with 24 products per page

## Validation
- backend lint/build and 131 tests
- web lint/build and 55 tests
- Chromium MVP/responsive suite: 10 passed, 1 skipped
- 60-product smoke: pages 24/24/12, page-2 reload persistence, category URL filter with 15 results, no mobile overflow
- Screenshots: .tmp/smoke-screens-414-paginated-offers-2026-06-24/

Issue: #414