### PR TITLE
Debounce offer search and add numbered pagination

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -263,6 +263,7 @@ model Establishment {
   preferredRuns  OptimizationRun[] @relation("PreferredEstablishment")
 
   @@index([regionId, isActive])
+  @@index([regionId, isActive, unitName])
 }
 
 model UserLocationPreference {
@@ -303,6 +304,7 @@ model CatalogProduct {
   shoppingListItems ShoppingListItem[]
 
   @@unique([name, category, defaultUnit])
+  @@index([category, isActive])
 }
 
 model CatalogProductAlias {
@@ -370,6 +372,7 @@ model ProductOffer {
   @@index([productVariantId, isActive, observedAt])
   @@index([establishmentId, isActive])
   @@index([productVariantId, establishmentId, isActive])
+  @@index([isActive, availabilityStatus, confidenceLevel, establishmentId])
   @@index([receiptRecordId])
   @@index([moderationStatus])
 }

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -601,6 +601,7 @@ sensitive monetary values across web surfaces.
 - [X] T245 Compact public offer cards and add scalable offer search/filter controls in `web/src/public/`
 - [X] T246 Preserve offer categories in regional pricing responses and add scalable public offer sorting in `backend/src/pricing/` and `web/src/public/`
 - [X] T247 Add server-side public offer querying and pagination with URL-persisted web catalog state in `backend/src/pricing/` and `web/src/public/`
+- [X] T248 Debounce public offer search, add query-aligned Prisma indexes, and render compact numbered pagination in `backend/prisma/` and `web/src/public/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.

--- a/web/e2e/responsive-qa.spec.ts
+++ b/web/e2e/responsive-qa.spec.ts
@@ -139,10 +139,10 @@ async function mockResponsiveApi(
         pagination: {
           page: currentPage,
           pageSize: 24,
-          totalItems: 50,
-          totalPages: 3,
+          totalItems: 240,
+          totalPages: 10,
           hasPreviousPage: currentPage > 1,
-          hasNextPage: currentPage < 3,
+          hasNextPage: currentPage < 10,
         },
         filters: {
           stores: ['Mercado Centro'],
@@ -377,6 +377,16 @@ for (const viewport of [
     test('keeps public shopper surfaces usable without horizontal overflow', async ({
       page,
     }) => {
+      const debouncedSearchRequests: string[] = [];
+      page.on('request', (request) => {
+        const url = new URL(request.url());
+        if (
+          url.pathname === '/regions/sao-paulo-sp/offers' &&
+          url.searchParams.has('q')
+        ) {
+          debouncedSearchRequests.push(request.url());
+        }
+      });
       await mockResponsiveApi(page, 'customer-token');
 
       await page.goto('/');
@@ -399,18 +409,38 @@ for (const viewport of [
       await expect(page.getByText('Ordenar por')).toBeVisible();
       await expect(page.getByText('Cafe Pilao 500g').first()).toBeVisible();
       await expectNoHorizontalOverflow(page);
-      await page
-        .getByPlaceholder('Nome, produto, mercado, bairro...')
-        .fill('cafe');
+      const searchInput = page.getByPlaceholder(
+        'Nome, produto, mercado, bairro...',
+      );
+      await searchInput.pressSequentially('cafe', { delay: 40 });
+      await expect(page).not.toHaveURL(/q=cafe/, { timeout: 150 });
       await expect(page).toHaveURL(/q=cafe/);
-      await page
-        .getByPlaceholder('Nome, produto, mercado, bairro...')
-        .fill('');
+      await expect.poll(() => debouncedSearchRequests.length).toBe(1);
+      await searchInput.fill('');
       await expect(page).not.toHaveURL(/q=/);
       await page.getByRole('button', { name: 'Próxima' }).click();
       await expect(page).toHaveURL(/page=2/);
-      await expect(page.getByText('Página 2 de 3')).toBeVisible();
+      await expect(page.getByText('Página 2 de 10')).toBeVisible();
+      if (viewport.name === 'desktop') {
+        await expect(
+          page.getByRole('button', { name: 'Ir para página 2' }),
+        ).toHaveAttribute('aria-current', 'page');
+        await expect(
+          page.getByRole('button', { name: 'Ir para página 10' }),
+        ).toBeVisible();
+        await page.getByRole('button', { name: 'Ir para página 3' }).click();
+        await expect(page).toHaveURL(/page=3/);
+        await page.goto('/ofertas?page=5');
+        await expect(page).toHaveURL(/page=5/);
+        await expect(
+          page.getByRole('button', { name: 'Ir para página 5' }),
+        ).toHaveAttribute('aria-current', 'page');
+      }
       await expectNoHorizontalOverflow(page);
+      await attachViewportScreenshot(
+        page,
+        `public-offers-pagination-${viewport.name}.png`,
+      );
 
       await page.goto('/listas');
       await expect(page.getByText('Compra responsiva')).toBeVisible();

--- a/web/src/public/public-pages.tsx
+++ b/web/src/public/public-pages.tsx
@@ -139,6 +139,34 @@ type OptimizationResultTab =
   | 'savings';
 type OptimizationItemFilter = 'all' | 'selected' | 'review';
 
+function getPaginationItems(currentPage: number, totalPages: number) {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const pages = new Set([
+    1,
+    totalPages,
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+  ]);
+  const visiblePages = [...pages]
+    .filter((page) => page > 0 && page <= totalPages)
+    .sort((left, right) => left - right);
+  const items: Array<number | 'ellipsis'> = [];
+
+  for (const page of visiblePages) {
+    const previous = items[items.length - 1];
+    if (typeof previous === 'number' && page - previous > 1) {
+      items.push('ellipsis');
+    }
+    items.push(page);
+  }
+
+  return items;
+}
+
 function CitySelectionDialog({
   cityId,
   cities,
@@ -2068,6 +2096,7 @@ export function OffersPage() {
   const [availableCategories, setAvailableCategories] = useState<string[]>([]);
   const [isCitySelectionOpen, setIsCitySelectionOpen] = useState(false);
   const searchQuery = searchParams.get('q') ?? '';
+  const [searchInput, setSearchInput] = useState(searchQuery);
   const storeFilter = searchParams.get('store') ?? 'all';
   const categoryFilter = searchParams.get('category') ?? 'all';
   const confidenceFilter = searchParams.get('confidence') ?? 'all';
@@ -2076,6 +2105,29 @@ export function OffersPage() {
     1,
     Number.parseInt(searchParams.get('page') ?? '1', 10) || 1,
   );
+
+  useEffect(() => {
+    setSearchInput(searchQuery);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    if (searchInput === searchQuery) {
+      return;
+    }
+
+    const timeout = globalThis.setTimeout(() => {
+      const next = new URLSearchParams(searchParams);
+      if (searchInput.trim()) {
+        next.set('q', searchInput.trim());
+      } else {
+        next.delete('q');
+      }
+      next.delete('page');
+      setSearchParams(next, { replace: true });
+    }, 300);
+
+    return () => globalThis.clearTimeout(timeout);
+  }, [searchInput, searchParams, searchQuery, setSearchParams]);
 
   useEffect(() => {
     let disposed = false;
@@ -2215,6 +2267,7 @@ export function OffersPage() {
   };
 
   const clearOfferFilters = () => {
+    setSearchInput('');
     const next = new URLSearchParams(searchParams);
     next.delete('q');
     next.delete('store');
@@ -2279,11 +2332,9 @@ export function OffersPage() {
                 <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                 <Input
                   className="pl-9"
-                  onChange={(event) =>
-                    updateOfferSearchParams('q', event.target.value)
-                  }
+                  onChange={(event) => setSearchInput(event.target.value)}
                   placeholder="Nome, produto, mercado, bairro..."
-                  value={searchQuery}
+                  value={searchInput}
                 />
               </div>
             </label>
@@ -2544,6 +2595,41 @@ export function OffersPage() {
               <ChevronLeftIcon data-icon="inline-start" />
               Anterior
             </Button>
+            <div className="hidden items-center gap-1 sm:flex">
+              {getPaginationItems(
+                offerPagination.page,
+                offerPagination.totalPages,
+              ).map((item, index) =>
+                item === 'ellipsis' ? (
+                  <span
+                    aria-hidden="true"
+                    className="flex size-8 items-center justify-center text-muted-foreground"
+                    key={`ellipsis-${index}`}
+                  >
+                    ...
+                  </span>
+                ) : (
+                  <Button
+                    aria-current={
+                      item === offerPagination.page ? 'page' : undefined
+                    }
+                    aria-label={`Ir para página ${item}`}
+                    className="size-8 p-0"
+                    key={item}
+                    onClick={() =>
+                      updateOfferSearchParams('page', String(item), false)
+                    }
+                    size="sm"
+                    type="button"
+                    variant={
+                      item === offerPagination.page ? 'default' : 'outline'
+                    }
+                  >
+                    {item}
+                  </Button>
+                ),
+              )}
+            </div>
             <Button
               disabled={!offerPagination.hasNextPage}
               onClick={() =>


### PR DESCRIPTION
## Summary
- debounce public offer search by 300 ms while keeping URL state authoritative
- add compact numbered pagination for large catalogs on desktop
- add Prisma indexes aligned with offer catalog filters
- strengthen responsive E2E coverage with a 240-item, 10-page catalog

## Validation
- `npm --prefix backend run db:generate`
- `npm --prefix backend run lint`
- `npm --prefix backend run build`
- `npm --prefix backend test -- --runInBand`
- `npm --prefix web run lint`
- `npm --prefix web run build`
- `npm --prefix web run test`
- `npm --prefix web run e2e -- --project=chromium`

Refs #416