### PR TITLE
Optimize public offer text search

### DIFF
--- a/backend/src/pricing/application/public-pricing.service.ts
+++ b/backend/src/pricing/application/public-pricing.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import type { Prisma } from '@prisma/client';
 
 import { PrismaService } from '../../persistence/prisma.service';
 
@@ -21,6 +22,7 @@ type PublicOfferQuery = {
 
 @Injectable()
 export class PublicPricingService {
+  private static readonly searchCandidateLimit = 5_000;
   private readonly logger = new Logger(PublicPricingService.name);
 
   constructor(private readonly prisma: PrismaService) {}
@@ -51,6 +53,9 @@ export class PublicPricingService {
       48,
     );
     const sort = this.parseOfferSort(query.sort);
+    const textSearchWhere = normalizedQuery
+      ? await this.buildTextSearchWhere(normalizedQuery, region.id)
+      : {};
 
     const offers = await this.prisma.productOffer.findMany({
       where: {
@@ -80,56 +85,7 @@ export class PublicPricingService {
               }
             : {}),
         },
-        ...(normalizedQuery
-          ? {
-              OR: [
-                {
-                  displayName: {
-                    contains: normalizedQuery,
-                    mode: 'insensitive' as const,
-                  },
-                },
-                {
-                  packageLabel: {
-                    contains: normalizedQuery,
-                    mode: 'insensitive' as const,
-                  },
-                },
-                {
-                  catalogProduct: {
-                    name: {
-                      contains: normalizedQuery,
-                      mode: 'insensitive' as const,
-                    },
-                  },
-                },
-                {
-                  productVariant: {
-                    displayName: {
-                      contains: normalizedQuery,
-                      mode: 'insensitive' as const,
-                    },
-                  },
-                },
-                {
-                  establishment: {
-                    unitName: {
-                      contains: normalizedQuery,
-                      mode: 'insensitive' as const,
-                    },
-                  },
-                },
-                {
-                  establishment: {
-                    neighborhood: {
-                      contains: normalizedQuery,
-                      mode: 'insensitive' as const,
-                    },
-                  },
-                },
-              ],
-            }
-          : {}),
+        ...textSearchWhere,
       },
       include: {
         catalogProduct: true,
@@ -212,6 +168,114 @@ export class PublicPricingService {
     }
 
     return response;
+  }
+
+  private async buildTextSearchWhere(
+    query: string,
+    regionId: string,
+  ): Promise<Prisma.ProductOfferWhereInput> {
+    const take = PublicPricingService.searchCandidateLimit + 1;
+    const insensitiveContains = {
+      contains: query,
+      mode: 'insensitive' as const,
+    };
+    const [offers, products, variants, establishments] = await Promise.all([
+      this.prisma.productOffer.findMany({
+        where: {
+          isActive: true,
+          availabilityStatus: 'available',
+          OR: [
+            { displayName: insensitiveContains },
+            { packageLabel: insensitiveContains },
+          ],
+          establishment: {
+            isActive: true,
+            regionId,
+          },
+        },
+        select: { id: true },
+        take,
+      }),
+      this.prisma.catalogProduct.findMany({
+        where: {
+          isActive: true,
+          name: insensitiveContains,
+        },
+        select: { id: true },
+        take,
+      }),
+      this.prisma.productVariant.findMany({
+        where: {
+          isActive: true,
+          displayName: insensitiveContains,
+        },
+        select: { id: true },
+        take,
+      }),
+      this.prisma.establishment.findMany({
+        where: {
+          isActive: true,
+          regionId,
+          OR: [
+            { unitName: insensitiveContains },
+            { neighborhood: insensitiveContains },
+          ],
+        },
+        select: { id: true },
+        take,
+      }),
+    ]);
+
+    if (
+      [offers, products, variants, establishments].some(
+        (candidates) =>
+          candidates.length > PublicPricingService.searchCandidateLimit,
+      )
+    ) {
+      return this.buildBroadTextSearchWhere(query);
+    }
+
+    const candidates: Prisma.ProductOfferWhereInput[] = [];
+    if (offers.length > 0) {
+      candidates.push({ id: { in: offers.map(({ id }) => id) } });
+    }
+    if (products.length > 0) {
+      candidates.push({
+        catalogProductId: { in: products.map(({ id }) => id) },
+      });
+    }
+    if (variants.length > 0) {
+      candidates.push({
+        productVariantId: { in: variants.map(({ id }) => id) },
+      });
+    }
+    if (establishments.length > 0) {
+      candidates.push({
+        establishmentId: { in: establishments.map(({ id }) => id) },
+      });
+    }
+
+    return candidates.length > 0 ? { OR: candidates } : { id: { in: [] } };
+  }
+
+  private buildBroadTextSearchWhere(
+    query: string,
+  ): Prisma.ProductOfferWhereInput {
+    const insensitiveContains = {
+      contains: query,
+      mode: 'insensitive' as const,
+    };
+
+    return {
+      OR: [
+        { displayName: insensitiveContains },
+        { packageLabel: insensitiveContains },
+        { catalogProduct: { name: insensitiveContains } },
+        { productVariant: { displayName: insensitiveContains } },
+        { establishment: { unitName: insensitiveContains } },
+        { establishment: { neighborhood: insensitiveContains } },
+      ],
+    };
   }
 
   async getOfferDetail(offerId: string) {

--- a/backend/test/unit/pricing/public-pricing.service.spec.ts
+++ b/backend/test/unit/pricing/public-pricing.service.spec.ts
@@ -350,11 +350,14 @@ describe('PublicPricingService', () => {
         neighborhood: 'Centro',
       },
     });
-    const findMany = jest.fn().mockResolvedValue([
-      makeOffer('cafe', 'Cafe 500g', 16.9, 'mercearia'),
-      makeOffer('acucar', 'Acucar 1kg', 4.19, 'mercearia'),
-      makeOffer('arroz', 'Arroz 5kg', 20.9, 'mercearia'),
-    ]);
+    const findMany = jest
+      .fn()
+      .mockResolvedValueOnce([{ id: 'offer-cafe' }])
+      .mockResolvedValueOnce([
+        makeOffer('cafe', 'Cafe 500g', 16.9, 'mercearia'),
+        makeOffer('acucar', 'Acucar 1kg', 4.19, 'mercearia'),
+        makeOffer('arroz', 'Arroz 5kg', 20.9, 'mercearia'),
+      ]);
     const prisma = {
       region: {
         findUnique: jest.fn().mockResolvedValue({
@@ -367,6 +370,13 @@ describe('PublicPricingService', () => {
       },
       establishment: {
         count: jest.fn().mockResolvedValue(1),
+        findMany: jest.fn().mockResolvedValue([{ id: 'store-1' }]),
+      },
+      catalogProduct: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'product-cafe' }]),
+      },
+      productVariant: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'variant-cafe' }]),
       },
       productOffer: {
         findMany,
@@ -399,7 +409,12 @@ describe('PublicPricingService', () => {
       expect.objectContaining({
         where: expect.objectContaining({
           confidenceLevel: 'high',
-          OR: expect.any(Array),
+          OR: [
+            { id: { in: ['offer-cafe'] } },
+            { catalogProductId: { in: ['product-cafe'] } },
+            { productVariantId: { in: ['variant-cafe'] } },
+            { establishmentId: { in: ['store-1'] } },
+          ],
           catalogProduct: expect.objectContaining({
             category: expect.objectContaining({
               equals: 'mercearia',
@@ -410,6 +425,71 @@ describe('PublicPricingService', () => {
               equals: 'Mercado Centro',
             }),
           }),
+        }),
+      }),
+    );
+  });
+
+  it('falls back to the broad relational search for high-cardinality terms', async () => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    const candidateLimit = 5_001;
+    const broadCandidates = Array.from(
+      { length: candidateLimit },
+      (_, index) => ({
+        id: `offer-${index}`,
+      }),
+    );
+    const finalFindMany = jest.fn().mockResolvedValue([]);
+    const prisma = {
+      region: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'region-1',
+          slug: 'sao-paulo-sp',
+          name: 'Sao Paulo',
+          stateCode: 'SP',
+          implantationStatus: 'active',
+        }),
+      },
+      establishment: {
+        count: jest.fn().mockResolvedValue(1),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      catalogProduct: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      productVariant: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      productOffer: {
+        findMany: jest
+          .fn()
+          .mockResolvedValueOnce(broadCandidates)
+          .mockImplementationOnce(finalFindMany),
+      },
+    };
+    const service = new PublicPricingService(prisma as never);
+
+    await service.listRegionOffers('sao-paulo-sp', { query: 'produto' });
+
+    expect(finalFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            {
+              displayName: {
+                contains: 'produto',
+                mode: 'insensitive',
+              },
+            },
+            {
+              catalogProduct: {
+                name: {
+                  contains: 'produto',
+                  mode: 'insensitive',
+                },
+              },
+            },
+          ]),
         }),
       }),
     );

--- a/docs/performance/public-offer-search-benchmark.md
+++ b/docs/performance/public-offer-search-benchmark.md
@@ -1,0 +1,55 @@
+# Public offer search benchmark
+
+Date: 2026-06-25
+
+## Goal
+
+Measure the public offer text search before enabling PostgreSQL `pg_trgm`.
+The production query searches six fields across offers, products, variants, and
+establishments with case-insensitive `contains` filters.
+
+## Dataset
+
+- PostgreSQL 17
+- 1 region
+- 100 establishments
+- 50,000 catalog products
+- 50,000 variants
+- 500,000 active offers
+- Parallel query execution disabled for stable comparisons
+
+The benchmark used `EXPLAIN (ANALYZE, BUFFERS)` against an isolated temporary
+cluster. It did not use project or homolog data.
+
+## Results
+
+| Plan | Selective `cafe` | Common `produto` |
+| --- | ---: | ---: |
+| Relational `OR`, B-tree indexes | 844 ms | 476 ms |
+| Relational `OR`, six trigram indexes | 814 ms | 468 ms |
+| Candidate union, no trigram indexes | 281 ms | Not selected |
+| Candidate union, six trigram indexes | 195 ms | 1,464 ms |
+
+The six trigram indexes occupied 43 MB alongside a 124 MB offer table.
+
+## Decision
+
+Do not enable `pg_trgm` yet.
+
+The original relational `OR` prevents PostgreSQL from using the trigram indexes,
+so adding indexes alone provides no material improvement. A candidate-first
+query is roughly 3x faster without an extension. Trigram indexes improve the
+selective candidate query by another 30%, but make broad candidate expansion
+expensive and require extension lifecycle support that the current `db push`
+deployment does not provide.
+
+The implemented strategy:
+
+1. Queries candidate IDs concurrently from each searchable entity.
+2. Uses indexed ID filters when every candidate set is at most 5,000 rows.
+3. Falls back to the existing relational search for high-cardinality terms.
+4. Preserves the existing response and URL contracts.
+
+Reconsider `pg_trgm` after the deployment moves from `prisma db push` to
+versioned Prisma migrations. At that point, add the extension and indexes in a
+custom migration and repeat this benchmark with production-like cardinality.

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -602,6 +602,7 @@ sensitive monetary values across web surfaces.
 - [X] T246 Preserve offer categories in regional pricing responses and add scalable public offer sorting in `backend/src/pricing/` and `web/src/public/`
 - [X] T247 Add server-side public offer querying and pagination with URL-persisted web catalog state in `backend/src/pricing/` and `web/src/public/`
 - [X] T248 Debounce public offer search, add query-aligned Prisma indexes, and render compact numbered pagination in `backend/prisma/` and `web/src/public/`
+- [X] T249 Benchmark public offer text search and add adaptive candidate filtering with a high-cardinality fallback in `backend/src/pricing/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.


### PR DESCRIPTION
## Summary
- benchmark public offer text search with 500,000 synthetic offers
- replace cross-table text OR with adaptive candidate ID filtering for selective terms
- retain the original relational query as a high-cardinality fallback
- document why pg_trgm is deferred until versioned Prisma migrations

## Benchmark
- baseline selective query: 844 ms
- candidate filtering without pg_trgm: 281 ms
- pg_trgm alone: no material improvement

## Validation
- `npm --prefix backend run lint`
- `npm --prefix backend run build`
- `npm --prefix backend test -- --runInBand` (132 tests)
- Prisma schema validation against isolated PostgreSQL 17

Refs #418