### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   workflow-security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Check workflow permissions and trigger safety
         shell: bash
         run: |
@@ -45,9 +45,9 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -67,9 +67,9 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -89,7 +89,7 @@ jobs:
       run:
         working-directory: mobile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/deploy-homolog-server.yml
+++ b/.github/workflows/deploy-homolog-server.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   build-backend:
     name: Build backend image
-    uses: Gabrimeireles/reusable-workflows/.github/workflows/docker-build.yml@master
+    uses: Gabrimeireles/reusable-workflows/.github/workflows/docker-build.yml@dd91057fc0ac8afcebbc7ae6ee1d1bdb65792e5a
     with:
       image_name: pricely-backend
       dockerfile: ./backend/Dockerfile
@@ -41,7 +41,7 @@ jobs:
 
   build-web:
     name: Build web image
-    uses: Gabrimeireles/reusable-workflows/.github/workflows/docker-build.yml@master
+    uses: Gabrimeireles/reusable-workflows/.github/workflows/docker-build.yml@dd91057fc0ac8afcebbc7ae6ee1d1bdb65792e5a
     with:
       image_name: pricely-web
       dockerfile: ./web/Dockerfile
@@ -78,7 +78,7 @@ jobs:
       NODE_ENV: ${{ vars.NODE_ENV || 'production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,6 @@ jobs:
   terraform-plan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Placeholder deploy step
         run: echo "Terraform deployment workflow will be expanded in later tasks."

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -603,6 +603,7 @@ sensitive monetary values across web surfaces.
 - [X] T247 Add server-side public offer querying and pagination with URL-persisted web catalog state in `backend/src/pricing/` and `web/src/public/`
 - [X] T248 Debounce public offer search, add query-aligned Prisma indexes, and render compact numbered pagination in `backend/prisma/` and `web/src/public/`
 - [X] T249 Benchmark public offer text search and add adaptive candidate filtering with a high-cardinality fallback in `backend/src/pricing/`
+- [X] T250 Update GitHub Actions to Node 24-compatible releases and pin the reusable Docker build workflow in `.github/workflows/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.


### PR DESCRIPTION
## Summary
- update local checkout actions to v7 and setup-node actions to v6
- pin reusable Docker builds to validated commit dd91057
- update the reusable workflow repository to current Node 24 and Docker action majors

## Related reusable workflow
- Gabrimeireles/reusable-workflows#3

## Validation
- parsed all workflow YAML files
- workflow permission/trigger safety checks passed
- backend: lint, build, 132 tests
- web: lint, build, 55 tests

Refs #419