### PR TITLE
Update SSH agent action for Node 24

### DIFF
--- a/.github/workflows/deploy-homolog-server.yml
+++ b/.github/workflows/deploy-homolog-server.yml
@@ -118,7 +118,7 @@ jobs:
           [ -f docker-compose.homolog.yml ] || { echo "Missing docker-compose.homolog.yml"; exit 1; }
 
       - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
 


### PR DESCRIPTION
## Summary
- update webfactory/ssh-agent from v0.9.0 to v0.10.0
- remove the final Node.js 20 deprecation annotation observed in homolog deploy

## Validation
- workflow YAML parses successfully
- v0.10.0 confirmed as the current official release

Refs #419