### PR TITLE
Add router hydration fallback

### DIFF
--- a/web/src/routes/app-router.tsx
+++ b/web/src/routes/app-router.tsx
@@ -2,6 +2,17 @@ import { createBrowserRouter, type RouteObject } from 'react-router-dom';
 
 import { RouteErrorPage } from './route-error';
 
+function RouteHydrationFallback() {
+  return (
+    <div
+      className="grid min-h-screen place-items-center bg-background text-sm text-muted-foreground"
+      role="status"
+    >
+      Carregando Pricely...
+    </div>
+  );
+}
+
 const publicChildren: RouteObject[] = [
   {
     index: true,
@@ -199,6 +210,7 @@ export const appRouter = createBrowserRouter([
   {
     path: '/',
     errorElement: <RouteErrorPage />,
+    hydrateFallbackElement: <RouteHydrationFallback />,
     lazy: async () => {
       const { PublicLayout } = await import('@/public/public-shell');
       return { Component: PublicLayout };
@@ -208,6 +220,7 @@ export const appRouter = createBrowserRouter([
   {
     path: '/dashboard',
     errorElement: <RouteErrorPage />,
+    hydrateFallbackElement: <RouteHydrationFallback />,
     lazy: async () => {
       const { AdminLayout } = await import('@/dashboard/admin-shell');
       return { Component: AdminLayout };


### PR DESCRIPTION
## Summary
- add explicit hydration fallbacks for public and admin lazy route roots
- remove the React Router production warning found during homolog smoke testing

## Validation
- web build and lint
- router tests (5 passed)
- Chromium smoke (11 passed, 1 conditional skip)

Refs #425