### PR TITLE
Run release readiness for homolog candidates

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,6 +1,9 @@
 name: Release Readiness
 
 on:
+  push:
+    branches:
+      - homolog
   workflow_dispatch:
     inputs:
       run_android_build:
@@ -101,10 +104,10 @@ jobs:
       - run: flutter analyze
       - run: flutter test
       - name: Build Android release candidate
-        if: inputs.run_android_build
+        if: github.event_name == 'push' || inputs.run_android_build
         run: flutter build apk --release
       - name: Upload Android release candidate
-        if: inputs.run_android_build
+        if: github.event_name == 'push' || inputs.run_android_build
         uses: actions/upload-artifact@v6
         with:
           name: pricely-android-release-candidate


### PR DESCRIPTION
## Summary
- trigger the release-readiness matrix on every homolog candidate
- build and retain the Android release APK for homolog pushes
- preserve optional Android builds for manual dispatches

Closes #430