### PR TITLE
Phase 32: close mobile and UX parity

### DIFF
--- a/backend/src/receipts/api/receipts.controller.ts
+++ b/backend/src/receipts/api/receipts.controller.ts
@@ -1,8 +1,10 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
+  Param,
   Post,
   UseGuards,
 } from '@nestjs/common';
@@ -16,7 +18,9 @@ import { ReceiptIngestionDto } from './dto/receipt-ingestion.dto';
 @Controller('receipts')
 @UseGuards(JwtAuthGuard)
 export class ReceiptsController {
-  constructor(private readonly receiptIngestionService: ReceiptIngestionService) {}
+  constructor(
+    private readonly receiptIngestionService: ReceiptIngestionService,
+  ) {}
 
   @Post()
   @HttpCode(HttpStatus.ACCEPTED)
@@ -25,5 +29,13 @@ export class ReceiptsController {
     @Body() body: ReceiptIngestionDto,
   ) {
     return this.receiptIngestionService.ingest(user.sub, body);
+  }
+
+  @Get(':receiptId')
+  async detail(
+    @CurrentUser() user: JwtUserPayload,
+    @Param('receiptId') receiptId: string,
+  ) {
+    return this.receiptIngestionService.findForUser(user.sub, receiptId);
   }
 }

--- a/backend/src/receipts/application/receipt-ingestion.service.ts
+++ b/backend/src/receipts/application/receipt-ingestion.service.ts
@@ -209,6 +209,14 @@ export class ReceiptIngestionService {
     };
   }
 
+  async findForUser(userId: string, receiptRecordId: string) {
+    const record = await this.receiptRecordRepository.findById(receiptRecordId);
+    if (!record || record.userId !== userId) {
+      throw new NotFoundException(`Receipt ${receiptRecordId} was not found`);
+    }
+    return this.projectReceiptRecord(record);
+  }
+
   async reprocess(receiptRecordId: string): Promise<ReceiptRecord> {
     const record = await this.receiptRecordRepository.findById(receiptRecordId);
     if (!record) {
@@ -450,7 +458,9 @@ export class ReceiptIngestionService {
       }
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : 'unknown SEFAZ extraction error';
+        error instanceof Error
+          ? error.message
+          : 'unknown SEFAZ extraction error';
       this.logger.warn(`SEFAZ receipt extraction failed: ${message}`);
       return {};
     }
@@ -467,17 +477,33 @@ export class ReceiptIngestionService {
         .trim(),
     );
     const storeName =
-      this.matchText(text, /Nota Fiscal de Consumidor Eletrônica \(NFC-e\)\s+(.+?)\s+CNPJ:/i) ??
-      this.matchText(text, /Emitente\s+Nome \/ Razão Social\s+CNPJ\s+Inscrição Estadual\s+UF\s+(.+?)\s+\d{14}/i);
+      this.matchText(
+        text,
+        /Nota Fiscal de Consumidor Eletrônica \(NFC-e\)\s+(.+?)\s+CNPJ:/i,
+      ) ??
+      this.matchText(
+        text,
+        /Emitente\s+Nome \/ Razão Social\s+CNPJ\s+Inscrição Estadual\s+UF\s+(.+?)\s+\d{14}/i,
+      );
     const storeCnpj = this.matchText(text, /CNPJ:\s*(\d{14})/i);
     const storeAddress = this.parseStoreAddress(text);
     const purchaseDate = this.parseBrazilianDate(
-      this.matchText(text, /Data Emissão\s+(\d{2}\/\d{2}\/\d{4}\s+\d{2}:\d{2}:\d{2})/i),
+      this.matchText(
+        text,
+        /Data Emissão\s+(\d{2}\/\d{2}\/\d{4}\s+\d{2}:\d{2}:\d{2})/i,
+      ),
     );
-    const items = [...decodedHtml.matchAll(/<tr>\s*<td><h7>([\s\S]*?)<\/h7>\s*\(Código:\s*([^)]+)\)<\/td>\s*<td>Qtde total de ítens:\s*([\d.,]+)<\/td>\s*<td>UN:\s*([^<]+)<\/td>\s*<td>Valor total R\$:\s*R\$\s*([\d.,]+)<\/td>\s*<\/tr>/gi)]
+    const items = [
+      ...decodedHtml.matchAll(
+        /<tr>\s*<td><h7>([\s\S]*?)<\/h7>\s*\(Código:\s*([^)]+)\)<\/td>\s*<td>Qtde total de ítens:\s*([\d.,]+)<\/td>\s*<td>UN:\s*([^<]+)<\/td>\s*<td>Valor total R\$:\s*R\$\s*([\d.,]+)<\/td>\s*<\/tr>/gi,
+      ),
+    ]
       .map((match) => {
         const rawProductName = this.decodeHtml(
-          match[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim(),
+          match[1]
+            .replace(/<[^>]+>/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim(),
         );
         const quantity = this.parseBrazilianQuantity(match[3]);
         const lineTotal = this.parseBrazilianNumber(match[5]);
@@ -579,7 +605,9 @@ export class ReceiptIngestionService {
   }
 
   private inferPackageSize(rawProductName: string): string | undefined {
-    const match = rawProductName.match(/\b(\d+(?:[,.]\d+)?)\s*(kg|g|ml|l|un)\b/i);
+    const match = rawProductName.match(
+      /\b(\d+(?:[,.]\d+)?)\s*(kg|g|ml|l|un)\b/i,
+    );
     if (!match) {
       return undefined;
     }

--- a/backend/test/unit/receipts/receipts.controller.spec.ts
+++ b/backend/test/unit/receipts/receipts.controller.spec.ts
@@ -1,0 +1,51 @@
+import { NotFoundException } from '@nestjs/common';
+
+import { ReceiptsController } from '../../../src/receipts/api/receipts.controller';
+
+describe('ReceiptsController', () => {
+  it('returns only the authenticated user receipt projection', async () => {
+    const service = {
+      findForUser: jest.fn().mockResolvedValue({
+        id: 'receipt-1',
+        processingStatus: 'running',
+        rewardEligibilityStatus: 'eligible_pending',
+      }),
+    };
+    const controller = new ReceiptsController(service as never);
+
+    await expect(
+      controller.detail(
+        {
+          sub: 'user-1',
+          email: 'user@pricely.app',
+          role: 'customer',
+        },
+        'receipt-1',
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: 'receipt-1',
+        processingStatus: 'running',
+      }),
+    );
+    expect(service.findForUser).toHaveBeenCalledWith('user-1', 'receipt-1');
+  });
+
+  it('does not expose receipts owned by another account', async () => {
+    const service = {
+      findForUser: jest.fn().mockRejectedValue(new NotFoundException()),
+    };
+    const controller = new ReceiptsController(service as never);
+
+    await expect(
+      controller.detail(
+        {
+          sub: 'user-2',
+          email: 'other@pricely.app',
+          role: 'customer',
+        },
+        'receipt-1',
+      ),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:label="pricely_mobile"

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -27,7 +27,9 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Usamos sua localização apenas para encontrar estabelecimentos dentro do raio de otimização local.</string>
+	<string>Usamos sua localizacao apenas para encontrar estabelecimentos dentro do raio de otimizacao local.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Usamos a camera para ler o QR Code da NFC-e que voce escolher enviar.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/mobile/lib/app/app.dart
+++ b/mobile/lib/app/app.dart
@@ -35,7 +35,9 @@ class _PricelyAppState extends State<PricelyApp> {
         if (!snapshot.hasData) {
           return MaterialApp(
             title: 'Pricely',
-            theme: _buildTheme(),
+            theme: _buildTheme(Brightness.light),
+            darkTheme: _buildTheme(Brightness.dark),
+            themeMode: ThemeMode.system,
             home: const Scaffold(
               body: Center(child: CircularProgressIndicator()),
             ),
@@ -45,46 +47,60 @@ class _PricelyAppState extends State<PricelyApp> {
         final services = snapshot.data!;
         final router = AppRouter(services);
 
-        return AppScope(
-          services: services,
-          child: MaterialApp(
-            title: 'Pricely',
-            theme: _buildTheme(),
-            onGenerateRoute: router.onGenerateRoute,
-            initialRoute: AppRouter.homeRoute,
+        return AnimatedBuilder(
+          animation: services.themeController,
+          builder: (context, _) => AppScope(
+            services: services,
+            child: MaterialApp(
+              title: 'Pricely',
+              theme: _buildTheme(Brightness.light),
+              darkTheme: _buildTheme(Brightness.dark),
+              themeMode: services.themeController.themeMode,
+              onGenerateRoute: router.onGenerateRoute,
+              initialRoute: AppRouter.homeRoute,
+            ),
           ),
         );
       },
     );
   }
 
-  ThemeData _buildTheme() {
+  ThemeData _buildTheme(Brightness brightness) {
+    final isDark = brightness == Brightness.dark;
     final colorScheme = ColorScheme.fromSeed(
       seedColor: const Color(0xFF0F766E),
-      brightness: Brightness.light,
-      surface: const Color(0xFFF1FCF7),
+      brightness: brightness,
+      surface: isDark ? const Color(0xFF101915) : const Color(0xFFF1FCF7),
     ).copyWith(
-      primary: const Color(0xFF005C55),
-      onPrimary: Colors.white,
-      primaryContainer: const Color(0xFF0F766E),
+      primary: isDark ? const Color(0xFF80D5CB) : const Color(0xFF005C55),
+      onPrimary: isDark ? const Color(0xFF003733) : Colors.white,
+      primaryContainer:
+          isDark ? const Color(0xFF004F49) : const Color(0xFF0F766E),
       onPrimaryContainer: const Color(0xFFA3FAEF),
-      secondary: const Color(0xFF0051D5),
-      onSecondary: Colors.white,
-      secondaryContainer: const Color(0xFFDBE1FF),
-      onSecondaryContainer: const Color(0xFF00174B),
-      tertiary: const Color(0xFF375B00),
-      onTertiary: Colors.white,
-      tertiaryContainer: const Color(0xFF487500),
+      secondary: isDark ? const Color(0xFFB4C5FF) : const Color(0xFF0051D5),
+      onSecondary: isDark ? const Color(0xFF002B74) : Colors.white,
+      secondaryContainer:
+          isDark ? const Color(0xFF173F8C) : const Color(0xFFDBE1FF),
+      onSecondaryContainer:
+          isDark ? const Color(0xFFDCE2FF) : const Color(0xFF00174B),
+      tertiary: isDark ? const Color(0xFFB5E879) : const Color(0xFF375B00),
+      onTertiary: isDark ? const Color(0xFF1C3700) : Colors.white,
+      tertiaryContainer:
+          isDark ? const Color(0xFF2E5200) : const Color(0xFF487500),
       onTertiaryContainer: const Color(0xFFB5FF56),
       error: const Color(0xFFBA1A1A),
       onError: Colors.white,
-      errorContainer: const Color(0xFFFFDAD6),
-      onErrorContainer: const Color(0xFF93000A),
-      surface: const Color(0xFFF1FCF7),
-      onSurface: const Color(0xFF141E1B),
-      onSurfaceVariant: const Color(0xFF3E4947),
-      outline: const Color(0xFF6E7977),
-      outlineVariant: const Color(0xFFBDC9C6),
+      errorContainer:
+          isDark ? const Color(0xFF93000A) : const Color(0xFFFFDAD6),
+      onErrorContainer:
+          isDark ? const Color(0xFFFFDAD6) : const Color(0xFF93000A),
+      surface: isDark ? const Color(0xFF101915) : const Color(0xFFF1FCF7),
+      onSurface: isDark ? const Color(0xFFDDE6E1) : const Color(0xFF141E1B),
+      onSurfaceVariant:
+          isDark ? const Color(0xFFBEC9C5) : const Color(0xFF3E4947),
+      outline: isDark ? const Color(0xFF89938F) : const Color(0xFF6E7977),
+      outlineVariant:
+          isDark ? const Color(0xFF3F4946) : const Color(0xFFBDC9C6),
       inverseSurface: const Color(0xFF28332F),
       onInverseSurface: const Color(0xFFE8F3EE),
       inversePrimary: const Color(0xFF80D5CB),
@@ -94,16 +110,18 @@ class _PricelyAppState extends State<PricelyApp> {
 
     return ThemeData(
       colorScheme: colorScheme,
-      scaffoldBackgroundColor: const Color(0xFFF1FCF7),
+      scaffoldBackgroundColor: colorScheme.surface,
       useMaterial3: true,
-      appBarTheme: const AppBarTheme(
+      appBarTheme: AppBarTheme(
         backgroundColor: Colors.transparent,
-        foregroundColor: Color(0xFF141E1B),
+        foregroundColor: colorScheme.onSurface,
         elevation: 0,
       ),
       navigationBarTheme: NavigationBarThemeData(
-        backgroundColor: Colors.white,
-        indicatorColor: const Color(0xFFE0F3EF),
+        backgroundColor:
+            isDark ? const Color(0xFF17211D) : Colors.white,
+        indicatorColor:
+            isDark ? const Color(0xFF004F49) : const Color(0xFFE0F3EF),
         labelTextStyle: WidgetStateProperty.resolveWith<TextStyle?>(
           (states) => TextStyle(
             fontWeight: states.contains(WidgetState.selected)
@@ -114,7 +132,7 @@ class _PricelyAppState extends State<PricelyApp> {
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: Colors.white,
+        fillColor: isDark ? const Color(0xFF17211D) : Colors.white,
         contentPadding:
             const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
         border: OutlineInputBorder(
@@ -134,15 +152,15 @@ class _PricelyAppState extends State<PricelyApp> {
       ),
       filledButtonTheme: FilledButtonThemeData(
         style: FilledButton.styleFrom(
-          backgroundColor: const Color(0xFF005C55),
-          foregroundColor: Colors.white,
+          backgroundColor: colorScheme.primary,
+          foregroundColor: colorScheme.onPrimary,
           minimumSize: const Size(0, 52),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: OutlinedButton.styleFrom(
-          foregroundColor: const Color(0xFF005C55),
+          foregroundColor: colorScheme.primary,
           minimumSize: const Size(0, 52),
           side: BorderSide(
               color: colorScheme.outlineVariant.withValues(alpha: 0.4)),

--- a/mobile/lib/app/app_services.dart
+++ b/mobile/lib/app/app_services.dart
@@ -12,6 +12,7 @@ import '../features/privacy/application/monetary_privacy_controller.dart';
 import '../features/receipts/application/receipt_flow_controller.dart';
 import '../features/shared/data/pricely_backend_gateway.dart';
 import '../features/shopping_lists/application/shopping_list_controller.dart';
+import '../features/theme/application/theme_controller.dart';
 
 class AppServices {
   AppServices._({
@@ -20,7 +21,8 @@ class AppServices {
     required this.workflowGateway,
   })  : localCacheService = LocalCacheService(keyValueStore),
         backendGateway = PricelyBackendGateway(apiClient),
-        monetaryPrivacyController = MonetaryPrivacyController(keyValueStore) {
+        monetaryPrivacyController = MonetaryPrivacyController(keyValueStore),
+        themeController = ThemeController(keyValueStore) {
     authController = AuthController(
       cacheService: localCacheService,
       backendGateway: backendGateway,
@@ -57,6 +59,7 @@ class AppServices {
   final PricelyBackendGateway backendGateway;
   final DemoGroceryWorkflowGateway workflowGateway;
   final MonetaryPrivacyController monetaryPrivacyController;
+  final ThemeController themeController;
 
   late final AuthController authController;
   late final MarketDiscoveryController marketDiscoveryController;
@@ -89,6 +92,7 @@ class AppServices {
   }
 
   Future<void> initialize() async {
+    await themeController.initialize();
     await monetaryPrivacyController.initialize();
     await authController.bootstrap();
     await marketDiscoveryController.loadInitialData();

--- a/mobile/lib/features/home/presentation/mobile_home_screen.dart
+++ b/mobile/lib/features/home/presentation/mobile_home_screen.dart
@@ -852,6 +852,19 @@ class _CoverageHomeCard extends StatelessWidget {
               ),
             ),
           ),
+          const SizedBox(height: 8),
+          SizedBox(
+            width: double.infinity,
+            child: TextButton.icon(
+              onPressed: authController.isAuthenticated &&
+                      region != null &&
+                      !controller.isRequesting
+                  ? () => _showManualLocationDialog(context)
+                  : null,
+              icon: const Icon(Icons.edit_location_alt_outlined),
+              label: const Text('Usar CEP manualmente'),
+            ),
+          ),
         ],
       ),
     );
@@ -892,6 +905,60 @@ class _CoverageHomeCard extends StatelessWidget {
       case MobileLocationStatus.manual:
         return const Color(0xFF003EA8);
     }
+  }
+
+  Future<void> _showManualLocationDialog(BuildContext context) async {
+    final postalCodeController = TextEditingController();
+    var radius = 5.0;
+    final submitted = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (context, setState) => AlertDialog(
+          title: const Text('Configurar localizacao manual'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Text(
+                'O CEP fornece somente cobertura aproximada. Distancias reais exigem permissao de localizacao.',
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: postalCodeController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(labelText: 'CEP'),
+              ),
+              const SizedBox(height: 12),
+              Text('Raio de cobertura: ${radius.toStringAsFixed(0)} km'),
+              Slider(
+                value: radius,
+                min: 1,
+                max: 25,
+                divisions: 24,
+                onChanged: (value) => setState(() => radius = value),
+              ),
+            ],
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Cancelar'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Salvar'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (submitted == true) {
+      await controller.saveManualPostalCode(
+        postalCode: postalCodeController.text,
+        coverageRadiusKm: radius,
+      );
+    }
+    postalCodeController.dispose();
   }
 }
 
@@ -974,7 +1041,7 @@ class _HomeSectionCard extends StatelessWidget {
       width: double.infinity,
       padding: padding,
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: Theme.of(context).colorScheme.surfaceContainerLowest,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
         boxShadow: const <BoxShadow>[
@@ -1015,7 +1082,7 @@ class _MetricHomeCard extends StatelessWidget {
       child: Ink(
         padding: const EdgeInsets.all(14),
         decoration: BoxDecoration(
-          color: Colors.white,
+          color: theme.colorScheme.surfaceContainerLowest,
           borderRadius: BorderRadius.circular(8),
           border: Border.all(color: theme.colorScheme.outlineVariant),
         ),
@@ -1272,7 +1339,7 @@ class _ShoppingListTabState extends State<_ShoppingListTab> {
           Container(
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: theme.colorScheme.surfaceContainerLowest,
               borderRadius: BorderRadius.circular(18),
             ),
             child: Column(
@@ -1371,7 +1438,7 @@ class _ShoppingListTabState extends State<_ShoppingListTab> {
                     child: Container(
                       padding: const EdgeInsets.all(14),
                       decoration: BoxDecoration(
-                        color: Colors.white,
+                        color: theme.colorScheme.surfaceContainerLowest,
                         borderRadius: BorderRadius.circular(18),
                       ),
                       child: Row(
@@ -1464,7 +1531,7 @@ class _OptimizationTab extends StatelessWidget {
         Container(
           padding: const EdgeInsets.all(16),
           decoration: BoxDecoration(
-            color: Colors.white,
+            color: theme.colorScheme.surfaceContainerLowest,
             borderRadius: BorderRadius.circular(18),
           ),
           child: Column(
@@ -1583,7 +1650,7 @@ class _OptimizationTab extends StatelessWidget {
             Container(
               padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
-                color: Colors.white,
+                color: theme.colorScheme.surfaceContainerLowest,
                 borderRadius: BorderRadius.circular(18),
               ),
               child: Column(
@@ -1735,6 +1802,7 @@ class _ProfileTab extends StatelessWidget {
     final user = authController.currentUser;
     final privacyController =
         AppScope.maybeOf(context)?.monetaryPrivacyController;
+    final themeController = AppScope.maybeOf(context)?.themeController;
 
     if (user == null) {
       return ListView(
@@ -1762,7 +1830,7 @@ class _ProfileTab extends StatelessWidget {
         Container(
           padding: const EdgeInsets.all(20),
           decoration: BoxDecoration(
-            color: Colors.white,
+            color: theme.colorScheme.surfaceContainerLowest,
             borderRadius: BorderRadius.circular(22),
           ),
           child: Column(
@@ -1805,7 +1873,7 @@ class _ProfileTab extends StatelessWidget {
           Container(
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: theme.colorScheme.surfaceContainerLowest,
               borderRadius: BorderRadius.circular(20),
             ),
             child: Row(
@@ -1830,6 +1898,46 @@ class _ProfileTab extends StatelessWidget {
                 Switch(
                   value: privacyController.isVisible,
                   onChanged: (_) => privacyController.toggle(),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 14),
+        ],
+        if (themeController != null) ...<Widget>[
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainer,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text('Aparencia', style: theme.textTheme.titleMedium),
+                const SizedBox(height: 10),
+                SegmentedButton<ThemeMode>(
+                  segments: const <ButtonSegment<ThemeMode>>[
+                    ButtonSegment<ThemeMode>(
+                      value: ThemeMode.system,
+                      icon: Icon(Icons.settings_brightness),
+                      label: Text('Sistema'),
+                    ),
+                    ButtonSegment<ThemeMode>(
+                      value: ThemeMode.light,
+                      icon: Icon(Icons.light_mode_outlined),
+                      label: Text('Claro'),
+                    ),
+                    ButtonSegment<ThemeMode>(
+                      value: ThemeMode.dark,
+                      icon: Icon(Icons.dark_mode_outlined),
+                      label: Text('Escuro'),
+                    ),
+                  ],
+                  selected: <ThemeMode>{themeController.themeMode},
+                  onSelectionChanged: (selection) {
+                    themeController.setThemeMode(selection.first);
+                  },
                 ),
               ],
             ),
@@ -1908,7 +2016,7 @@ class _OfferCard extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: Colors.white,
+          color: theme.colorScheme.surfaceContainerLowest,
           borderRadius: BorderRadius.circular(20),
         ),
         child: Column(
@@ -2176,7 +2284,7 @@ class _StorePlanCard extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: Colors.white,
+          color: Theme.of(context).colorScheme.surfaceContainerLowest,
           borderRadius: BorderRadius.circular(18),
         ),
         child: Column(
@@ -2258,7 +2366,7 @@ class _ReceiptSummaryCard extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: Theme.of(context).colorScheme.surfaceContainerLowest,
         borderRadius: BorderRadius.circular(18),
       ),
       child: Column(

--- a/mobile/lib/features/location/application/mobile_location_controller.dart
+++ b/mobile/lib/features/location/application/mobile_location_controller.dart
@@ -139,6 +139,56 @@ class MobileLocationController extends ChangeNotifier {
     }
   }
 
+  Future<void> saveManualPostalCode({
+    required String postalCode,
+    double coverageRadiusKm = 5,
+  }) async {
+    final accessToken = _authController.accessToken;
+    final region = _discoveryController.selectedRegion;
+    final normalizedPostalCode = postalCode.replaceAll(RegExp(r'\D'), '');
+    if (accessToken == null || region == null) {
+      _status = MobileLocationStatus.error;
+      _message = 'Entre na conta e escolha uma cidade antes de salvar o CEP.';
+      notifyListeners();
+      return;
+    }
+    if (normalizedPostalCode.length != 8) {
+      _status = MobileLocationStatus.error;
+      _message = 'Informe um CEP com 8 digitos.';
+      notifyListeners();
+      return;
+    }
+
+    _status = MobileLocationStatus.requesting;
+    _message = 'Calculando cobertura aproximada pelo CEP.';
+    notifyListeners();
+    try {
+      _coveragePreview = await _backendGateway.previewLocationCoverage(
+        accessToken: accessToken,
+        regionId: region.id,
+        postalCode: normalizedPostalCode,
+        coverageRadiusKm: coverageRadiusKm,
+      );
+      _activePreference = await _backendGateway.upsertLocationPreference(
+        accessToken: accessToken,
+        regionId: region.id,
+        label: 'CEP $normalizedPostalCode',
+        postalCode: normalizedPostalCode,
+        coverageRadiusKm: coverageRadiusKm,
+        isDefault: true,
+        locationSource: 'postal_code_fallback',
+      );
+      _status = MobileLocationStatus.manual;
+      _message =
+          'CEP salvo. A cobertura e aproximada e nao representa distancia real ate as lojas.';
+    } catch (_) {
+      _status = MobileLocationStatus.error;
+      _message = 'Nao foi possivel salvar o CEP agora.';
+    } finally {
+      notifyListeners();
+    }
+  }
+
   String _messageForStatus(MobileLocationStatus status) {
     switch (status) {
       case MobileLocationStatus.denied:

--- a/mobile/lib/features/receipts/application/receipt_flow_controller.dart
+++ b/mobile/lib/features/receipts/application/receipt_flow_controller.dart
@@ -20,10 +20,12 @@ class ReceiptFlowController extends ChangeNotifier {
   ReceiptSubmissionState _state = ReceiptSubmissionState.idle;
   ReceiptSubmissionSummary? _lastSubmission;
   String? _errorMessage;
+  bool _isRefreshing = false;
 
   ReceiptSubmissionState get state => _state;
   ReceiptSubmissionSummary? get lastSubmission => _lastSubmission;
   String? get errorMessage => _errorMessage;
+  bool get isRefreshing => _isRefreshing;
 
   Future<void> submitReceipt({
     required String storeName,
@@ -58,5 +60,32 @@ class ReceiptFlowController extends ChangeNotifier {
     }
 
     notifyListeners();
+  }
+
+  Future<void> refreshLastSubmission() async {
+    final submission = _lastSubmission;
+    final accessToken = _authController?.accessToken;
+    if (submission == null ||
+        _backendGateway == null ||
+        accessToken == null ||
+        accessToken.isEmpty) {
+      return;
+    }
+
+    _isRefreshing = true;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      _lastSubmission = await _backendGateway!.fetchReceipt(
+        accessToken: accessToken,
+        receiptId: submission.id,
+        fallbackQrCodeUrl: submission.qrCodeUrl,
+      );
+    } catch (_) {
+      _errorMessage = 'Nao foi possivel atualizar o andamento da nota.';
+    } finally {
+      _isRefreshing = false;
+      notifyListeners();
+    }
   }
 }

--- a/mobile/lib/features/receipts/domain/receipt_submission.dart
+++ b/mobile/lib/features/receipts/domain/receipt_submission.dart
@@ -56,7 +56,7 @@ class ReceiptSubmissionSummary {
       rewardOptimizationTokens:
           (json['rewardOptimizationTokens'] as num? ?? 0).toInt(),
       rewardMessage: json['rewardMessage'] as String? ??
-          'Reward em processamento até a nota ser validada.',
+          'Recompensa em processamento ate a nota ser validada.',
       qrCodeUrl: json['qrCodeUrl'] as String? ?? fallbackQrCodeUrl,
     );
   }

--- a/mobile/lib/features/receipts/presentation/receipt_qr_scanner_screen.dart
+++ b/mobile/lib/features/receipts/presentation/receipt_qr_scanner_screen.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+class ReceiptQrScannerScreen extends StatefulWidget {
+  const ReceiptQrScannerScreen({super.key});
+
+  @override
+  State<ReceiptQrScannerScreen> createState() => _ReceiptQrScannerScreenState();
+}
+
+class _ReceiptQrScannerScreenState extends State<ReceiptQrScannerScreen> {
+  bool _handled = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Ler QR Code da NFC-e')),
+      body: Stack(
+        fit: StackFit.expand,
+        children: <Widget>[
+          MobileScanner(
+            onDetect: (capture) {
+              if (_handled) {
+                return;
+              }
+              for (final barcode in capture.barcodes) {
+                final value = barcode.rawValue?.trim();
+                if (value == null || !isValidReceiptQrUrl(value)) {
+                  continue;
+                }
+                _handled = true;
+                Navigator.of(context).pop(value);
+                return;
+              }
+            },
+          ),
+          Center(
+            child: Container(
+              width: 260,
+              height: 260,
+              decoration: BoxDecoration(
+                border: Border.all(color: const Color(0xFFB5FF56), width: 3),
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+          ),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: SafeArea(
+              minimum: const EdgeInsets.all(20),
+              child: Material(
+                color: Theme.of(context)
+                    .colorScheme
+                    .inverseSurface
+                    .withValues(alpha: 0.92),
+                borderRadius: BorderRadius.circular(8),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Text(
+                    'Centralize o QR Code da NFC-e. A leitura e enviada somente depois da sua confirmacao.',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.onInverseSurface,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+bool isValidReceiptQrUrl(String value) {
+  final uri = Uri.tryParse(value.trim());
+  if (uri == null || !uri.hasAuthority) {
+    return false;
+  }
+  return uri.scheme == 'https' || uri.scheme == 'http';
+}

--- a/mobile/lib/features/receipts/presentation/receipt_submission_screen.dart
+++ b/mobile/lib/features/receipts/presentation/receipt_submission_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../app/router.dart';
 import '../application/receipt_flow_controller.dart';
 import '../domain/receipt_submission.dart';
+import 'receipt_qr_scanner_screen.dart';
 
 class ReceiptSubmissionScreen extends StatefulWidget {
   const ReceiptSubmissionScreen({
@@ -25,7 +26,7 @@ class _ReceiptSubmissionScreenState extends State<ReceiptSubmissionScreen> {
   @override
   void initState() {
     super.initState();
-    _storeController = TextEditingController(text: 'Mercado Azul');
+    _storeController = TextEditingController();
     _qrCodeController = TextEditingController();
     _receiptController = TextEditingController();
   }
@@ -41,19 +42,16 @@ class _ReceiptSubmissionScreenState extends State<ReceiptSubmissionScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Enviar nota fiscal'),
-      ),
+      appBar: AppBar(title: const Text('Enviar nota fiscal')),
       body: AnimatedBuilder(
         animation: widget.controller,
         builder: (context, _) {
           final submission = widget.controller.lastSubmission;
-
           return ListView(
             padding: const EdgeInsets.all(16),
             children: <Widget>[
               Text(
-                'Leia ou cole a URL do QR Code da NFC-e. A nota fica em fila aguardando liberação manual do admin antes do processamento automático.',
+                'Leia ou cole a URL do QR Code da NFC-e. A nota aguarda liberacao administrativa antes de atualizar precos e validar recompensas.',
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
               const SizedBox(height: 16),
@@ -61,7 +59,6 @@ class _ReceiptSubmissionScreenState extends State<ReceiptSubmissionScreen> {
                 controller: _storeController,
                 decoration: const InputDecoration(
                   labelText: 'Nome da loja (opcional)',
-                  border: OutlineInputBorder(),
                 ),
               ),
               const SizedBox(height: 16),
@@ -70,23 +67,23 @@ class _ReceiptSubmissionScreenState extends State<ReceiptSubmissionScreen> {
                 decoration: const InputDecoration(
                   labelText: 'URL do QR Code da NFC-e',
                   hintText: 'https://www.fazenda.../qrcode?p=...',
-                  border: OutlineInputBorder(),
                 ),
                 keyboardType: TextInputType.url,
               ),
               const SizedBox(height: 12),
               OutlinedButton.icon(
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text(
-                        'Leitor de câmera será ativado no app nativo; por enquanto cole a URL lida do QR Code.',
-                      ),
+                onPressed: () async {
+                  final scannedUrl = await Navigator.of(context).push<String>(
+                    MaterialPageRoute<String>(
+                      builder: (_) => const ReceiptQrScannerScreen(),
                     ),
                   );
+                  if (scannedUrl != null) {
+                    _qrCodeController.text = scannedUrl;
+                  }
                 },
                 icon: const Icon(Icons.qr_code_scanner),
-                label: const Text('Ler QR Code com a câmera'),
+                label: const Text('Ler QR Code com a camera'),
               ),
               const SizedBox(height: 16),
               TextField(
@@ -96,40 +93,28 @@ class _ReceiptSubmissionScreenState extends State<ReceiptSubmissionScreen> {
                 decoration: const InputDecoration(
                   labelText: 'Itens manuais opcionais',
                   hintText: 'Arroz 22.90\nFeijao 9.40',
-                  border: OutlineInputBorder(),
                 ),
               ),
               const SizedBox(height: 16),
               FilledButton.icon(
-                onPressed: widget.controller.state ==
-                        ReceiptSubmissionState.submitting
-                    ? null
-                    : () async {
-                        await widget.controller.submitReceipt(
-                          storeName: _storeController.text.trim(),
-                          rawReceipt: _receiptController.text,
-                          qrCodeUrl: _qrCodeController.text.trim(),
-                        );
-                        if (!context.mounted) {
-                          return;
-                        }
-                        if (widget.controller.state ==
-                            ReceiptSubmissionState.success) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text(
-                                'Nota enviada para a fila de liberação manual.',
-                              ),
-                            ),
-                          );
-                        }
-                      },
+                onPressed:
+                    widget.controller.state == ReceiptSubmissionState.submitting
+                        ? null
+                        : () => _submit(context),
                 icon: const Icon(Icons.receipt_long),
-                label: const Text('Enviar nota para fila'),
+                label: Text(
+                  widget.controller.state == ReceiptSubmissionState.submitting
+                      ? 'Enviando...'
+                      : 'Enviar nota para fila',
+                ),
               ),
               const SizedBox(height: 16),
               if (submission != null)
-                _SubmissionSummaryCard(summary: submission),
+                _SubmissionSummaryCard(
+                  summary: submission,
+                  isRefreshing: widget.controller.isRefreshing,
+                  onRefresh: widget.controller.refreshLastSubmission,
+                ),
               if (widget.controller.errorMessage != null)
                 Padding(
                   padding: const EdgeInsets.only(top: 12),
@@ -152,14 +137,43 @@ class _ReceiptSubmissionScreenState extends State<ReceiptSubmissionScreen> {
       ),
     );
   }
+
+  Future<void> _submit(BuildContext context) async {
+    final qrCodeUrl = _qrCodeController.text.trim();
+    if (qrCodeUrl.isNotEmpty && !isValidReceiptQrUrl(qrCodeUrl)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Informe uma URL valida de NFC-e.')),
+      );
+      return;
+    }
+
+    await widget.controller.submitReceipt(
+      storeName: _storeController.text.trim(),
+      rawReceipt: _receiptController.text,
+      qrCodeUrl: qrCodeUrl,
+    );
+    if (!context.mounted ||
+        widget.controller.state != ReceiptSubmissionState.success) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Nota enviada e aguardando liberacao.'),
+      ),
+    );
+  }
 }
 
 class _SubmissionSummaryCard extends StatelessWidget {
   const _SubmissionSummaryCard({
     required this.summary,
+    required this.isRefreshing,
+    required this.onRefresh,
   });
 
   final ReceiptSubmissionSummary summary;
+  final bool isRefreshing;
+  final Future<void> Function() onRefresh;
 
   @override
   Widget build(BuildContext context) {
@@ -175,19 +189,18 @@ class _SubmissionSummaryCard extends StatelessWidget {
             ),
             const SizedBox(height: 8),
             Text('Protocolo: ${summary.id}'),
-            if (summary.qrCodeUrl != null && summary.qrCodeUrl!.isNotEmpty)
+            if (summary.qrCodeUrl?.isNotEmpty ?? false)
               const Text('Origem: QR Code NFC-e'),
-            Text('${summary.ingestedItems} itens ingeridos'),
+            Text('${summary.ingestedItems} itens recebidos'),
             const SizedBox(height: 8),
             Text('Fila: ${_processingLabel(summary.processingStatus)}'),
-            Text('Moderação: ${summary.moderationStatus}'),
-            Text('Reward: ${_rewardLabel(summary.rewardEligibilityStatus)}'),
+            Text('Moderacao: ${summary.moderationStatus}'),
+            Text('Recompensa: ${_rewardLabel(summary.rewardEligibilityStatus)}'),
             if (summary.rewardPoints > 0 ||
                 summary.rewardOptimizationTokens > 0)
               Text(
-                '${summary.rewardPoints} pontos · ${summary.rewardOptimizationTokens} tokens',
+                '${summary.rewardPoints} pontos, ${summary.rewardOptimizationTokens} creditos',
               ),
-            Text('Motivo: ${summary.reviewReason}'),
             Text(summary.rewardMessage),
             if (summary.lowConfidenceItems.isNotEmpty) ...<Widget>[
               const SizedBox(height: 8),
@@ -195,6 +208,18 @@ class _SubmissionSummaryCard extends StatelessWidget {
                 'Baixa confianca: ${summary.lowConfidenceItems.join(', ')}',
               ),
             ],
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: isRefreshing ? null : onRefresh,
+              icon: isRefreshing
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.refresh),
+              label: const Text('Atualizar andamento'),
+            ),
           ],
         ),
       ),
@@ -202,36 +227,24 @@ class _SubmissionSummaryCard extends StatelessWidget {
   }
 
   String _processingLabel(String status) {
-    switch (status) {
-      case 'waiting_manual_release':
-        return 'aguardando liberação manual';
-      case 'queued':
-        return 'liberada para processamento';
-      case 'running':
-        return 'processando';
-      case 'completed':
-        return 'processada';
-      case 'failed':
-        return 'falhou';
-      case 'retrying':
-        return 'tentando novamente';
-      default:
-        return status;
-    }
+    return switch (status) {
+      'waiting_manual_release' => 'aguardando liberacao manual',
+      'queued' => 'liberada para processamento',
+      'running' => 'processando',
+      'completed' => 'processada',
+      'failed' => 'falhou',
+      'retrying' => 'tentando novamente',
+      _ => status,
+    };
   }
 
   String _rewardLabel(String status) {
-    switch (status) {
-      case 'granted':
-        return 'validado';
-      case 'eligible_pending':
-        return 'em processamento';
-      case 'ineligible':
-        return 'não elegível';
-      case 'disabled':
-        return 'desativado';
-      default:
-        return status;
-    }
+    return switch (status) {
+      'granted' => 'validada',
+      'eligible_pending' => 'em validacao',
+      'ineligible' => 'nao elegivel',
+      'disabled' => 'desativada',
+      _ => status,
+    };
   }
 }

--- a/mobile/lib/features/shared/data/pricely_backend_gateway.dart
+++ b/mobile/lib/features/shared/data/pricely_backend_gateway.dart
@@ -63,11 +63,12 @@ class PricelyBackendGateway {
     required String accessToken,
     required String regionId,
     required String label,
-    required double latitude,
-    required double longitude,
     required double coverageRadiusKm,
     required bool isDefault,
     required String locationSource,
+    double? latitude,
+    double? longitude,
+    String? postalCode,
   }) async {
     final response = await _apiClient.post<Map<String, dynamic>>(
       '/locations',
@@ -75,8 +76,10 @@ class PricelyBackendGateway {
       body: <String, dynamic>{
         'regionId': regionId,
         'label': label,
-        'latitude': latitude,
-        'longitude': longitude,
+        if (latitude != null) 'latitude': latitude,
+        if (longitude != null) 'longitude': longitude,
+        if (postalCode != null && postalCode.trim().isNotEmpty)
+          'postalCode': postalCode.trim(),
         'coverageRadiusKm': coverageRadiusKm,
         'isDefault': isDefault,
         'locationSource': locationSource,
@@ -214,6 +217,21 @@ class PricelyBackendGateway {
     return ReceiptSubmissionSummary.fromJson(
       response,
       fallbackQrCodeUrl: qrCodeUrl,
+    );
+  }
+
+  Future<ReceiptSubmissionSummary> fetchReceipt({
+    required String accessToken,
+    required String receiptId,
+    String? fallbackQrCodeUrl,
+  }) async {
+    final response = await _apiClient.get<Map<String, dynamic>>(
+      '/receipts/$receiptId',
+      accessToken: accessToken,
+    );
+    return ReceiptSubmissionSummary.fromJson(
+      response,
+      fallbackQrCodeUrl: fallbackQrCodeUrl,
     );
   }
 

--- a/mobile/lib/features/shopping_lists/presentation/shopping_list_screen.dart
+++ b/mobile/lib/features/shopping_lists/presentation/shopping_list_screen.dart
@@ -166,7 +166,8 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
               Container(
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
-                  color: theme.colorScheme.surfaceContainerLowest,
+                  color:
+                      Theme.of(context).colorScheme.surfaceContainerLowest,
                   borderRadius: BorderRadius.circular(16),
                 ),
                 child: Column(
@@ -234,7 +235,8 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
               Container(
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
-                  color: theme.colorScheme.surfaceContainerLowest,
+                  color:
+                      Theme.of(context).colorScheme.surfaceContainerLowest,
                   borderRadius: BorderRadius.circular(16),
                 ),
                 child: Column(
@@ -638,7 +640,7 @@ class _UnauthenticatedView extends StatelessWidget {
         Container(
           padding: const EdgeInsets.all(20),
           decoration: BoxDecoration(
-            color: theme.colorScheme.surfaceContainerLowest,
+            color: Theme.of(context).colorScheme.surfaceContainerLowest,
             borderRadius: BorderRadius.circular(20),
           ),
           child: Column(

--- a/mobile/lib/features/shopping_lists/presentation/shopping_list_screen.dart
+++ b/mobile/lib/features/shopping_lists/presentation/shopping_list_screen.dart
@@ -166,7 +166,7 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
               Container(
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: theme.colorScheme.surfaceContainerLowest,
                   borderRadius: BorderRadius.circular(16),
                 ),
                 child: Column(
@@ -234,7 +234,7 @@ class _ShoppingListScreenState extends State<ShoppingListScreen> {
               Container(
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: theme.colorScheme.surfaceContainerLowest,
                   borderRadius: BorderRadius.circular(16),
                 ),
                 child: Column(
@@ -638,7 +638,7 @@ class _UnauthenticatedView extends StatelessWidget {
         Container(
           padding: const EdgeInsets.all(20),
           decoration: BoxDecoration(
-            color: Colors.white,
+            color: theme.colorScheme.surfaceContainerLowest,
             borderRadius: BorderRadius.circular(20),
           ),
           child: Column(

--- a/mobile/lib/features/theme/application/theme_controller.dart
+++ b/mobile/lib/features/theme/application/theme_controller.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/storage/key_value_store.dart';
+
+class ThemeController extends ChangeNotifier {
+  ThemeController(this._keyValueStore);
+
+  static const storageKey = 'theme_mode';
+
+  final KeyValueStore _keyValueStore;
+  ThemeMode _themeMode = ThemeMode.system;
+
+  ThemeMode get themeMode => _themeMode;
+
+  Future<void> initialize() async {
+    final storedValue = await _keyValueStore.readString(storageKey);
+    _themeMode = switch (storedValue) {
+      'light' => ThemeMode.light,
+      'dark' => ThemeMode.dark,
+      _ => ThemeMode.system,
+    };
+  }
+
+  Future<void> setThemeMode(ThemeMode value) async {
+    if (_themeMode == value) {
+      return;
+    }
+    _themeMode = value;
+    await _keyValueStore.writeString(storageKey, value.name);
+    notifyListeners();
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   geolocator: ^14.0.2
   http: ^1.4.0
+  mobile_scanner: ^7.2.0
   shared_preferences: ^2.5.3
 
 dev_dependencies:

--- a/mobile/test/unit/features/location/mobile_location_controller_test.dart
+++ b/mobile/test/unit/features/location/mobile_location_controller_test.dart
@@ -146,6 +146,87 @@ void main() {
     expect(controller.activePreference, isNull);
     expect(controller.message, contains('Permissao negada'));
   });
+
+  test('saves a CEP fallback without claiming precise distance', () async {
+    final cacheService = LocalCacheService(InMemoryKeyValueStore());
+    await cacheService.saveAuthToken('token-123');
+    Map<String, dynamic>? locationPayload;
+    final backendGateway = PricelyBackendGateway(
+      HttpApiClient(
+        client: MockClient((request) async {
+          if (request.url.path == '/auth/me') {
+            return http.Response(jsonEncode(_profilePayload()), 200);
+          }
+          if (request.url.path == '/regions') {
+            return http.Response(jsonEncode(_regionsPayload()), 200);
+          }
+          if (request.url.path == '/regions/sao-paulo-sp/offers') {
+            return http.Response(
+              jsonEncode(<String, dynamic>{'offers': <dynamic>[]}),
+              200,
+            );
+          }
+          if (request.url.path == '/locations/coverage-preview') {
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'regionId': 'region-1',
+                'coverageRadiusKm': 8,
+                'activeEstablishmentCount': 6,
+                'fallbackUsed': true,
+                'fallbackReason': 'postal_code_only',
+                'establishments': <dynamic>[],
+              }),
+              200,
+            );
+          }
+          if (request.url.path == '/locations') {
+            locationPayload =
+                jsonDecode(request.body) as Map<String, dynamic>;
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'id': 'location-postal',
+                'regionId': 'region-1',
+                'regionSlug': 'sao-paulo-sp',
+                'label': 'CEP 01310100',
+                'postalCode': '01310100',
+                'coverageRadiusKm': 8,
+                'activeEstablishmentCount': 6,
+                'isDefault': true,
+                'locationSource': 'postal_code_fallback',
+              }),
+              201,
+            );
+          }
+          return http.Response('{}', 404);
+        }),
+      ),
+    );
+    final authController = AuthController(
+      cacheService: cacheService,
+      backendGateway: backendGateway,
+    );
+    await authController.bootstrap();
+    final discoveryController = MarketDiscoveryController(backendGateway);
+    await discoveryController.loadInitialData();
+    await discoveryController.selectRegion('sao-paulo-sp');
+    final controller = MobileLocationController(
+      authController: authController,
+      discoveryController: discoveryController,
+      backendGateway: backendGateway,
+      locationService: const _DeniedLocationService(),
+    );
+
+    await controller.saveManualPostalCode(
+      postalCode: '01310-100',
+      coverageRadiusKm: 8,
+    );
+
+    expect(controller.status, MobileLocationStatus.manual);
+    expect(controller.coveragePreview?.activeEstablishmentCount, 6);
+    expect(controller.message, contains('nao representa distancia real'));
+    expect(locationPayload?['postalCode'], '01310100');
+    expect(locationPayload?.containsKey('latitude'), isFalse);
+  });
 }
 
 Map<String, dynamic> _profilePayload() {

--- a/mobile/test/unit/features/receipts/receipt_qr_scanner_test.dart
+++ b/mobile/test/unit/features/receipts/receipt_qr_scanner_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pricely_mobile/features/receipts/presentation/receipt_qr_scanner_screen.dart';
+
+void main() {
+  test('accepts web URLs and rejects unsafe QR payloads', () {
+    expect(
+      isValidReceiptQrUrl('https://www.fazenda.sp.gov.br/qrcode?p=123'),
+      isTrue,
+    );
+    expect(isValidReceiptQrUrl('http://localhost/nfce'), isTrue);
+    expect(isValidReceiptQrUrl('javascript:alert(1)'), isFalse);
+    expect(isValidReceiptQrUrl('not-a-url'), isFalse);
+  });
+}

--- a/mobile/test/unit/features/theme/theme_controller_test.dart
+++ b/mobile/test/unit/features/theme/theme_controller_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pricely_mobile/features/theme/application/theme_controller.dart';
+
+import '../../../support/in_memory_key_value_store.dart';
+
+void main() {
+  test('persists the selected application theme', () async {
+    final store = InMemoryKeyValueStore();
+    final controller = ThemeController(store);
+    await controller.initialize();
+    expect(controller.themeMode, ThemeMode.system);
+
+    await controller.setThemeMode(ThemeMode.dark);
+    final restored = ThemeController(store);
+    await restored.initialize();
+
+    expect(restored.themeMode, ThemeMode.dark);
+  });
+}

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pricely_mobile/app/app.dart';
 import 'package:pricely_mobile/app/app_services.dart';
@@ -16,6 +17,24 @@ void main() {
 
     expect(find.text('Cliente Pricely'), findsOneWidget);
     expect(find.text('Cidade ativa'), findsWidgets);
+  });
+
+  testWidgets('renders at narrow width in dark mode without overflow',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(320, 700);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final services = AppServices(
+      keyValueStore: _InMemoryKeyValueStore(),
+    );
+    await services.themeController.setThemeMode(ThemeMode.dark);
+
+    await tester.pumpWidget(PricelyApp(services: services));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MaterialApp), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 }
 

--- a/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
+++ b/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
@@ -326,6 +326,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProcessingJob'
+  /receipts:
+    post:
+      summary: Submit a receipt contribution from manual items or an NFC-e QR URL
+      responses:
+        '202':
+          description: Receipt accepted for manual release or processing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReceiptSubmission'
+  /receipts/{receiptId}:
+    get:
+      summary: Fetch the authenticated shopper receipt processing and reward state
+      parameters:
+        - name: receiptId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Receipt state returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReceiptSubmission'
+        '404':
+          description: Receipt does not exist or belongs to another account
   /admin/metrics/overview:
     get:
       summary: Return overview metrics for the admin dashboard
@@ -1127,6 +1155,40 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OptimizationSelection'
+    ReceiptSubmission:
+      type: object
+      required:
+        - id
+        - processingStatus
+        - moderationStatus
+        - rewardEligibilityStatus
+      properties:
+        id:
+          type: string
+        storeName:
+          type: string
+          nullable: true
+        processingStatus:
+          type: string
+          enum:
+            - waiting_manual_release
+            - queued
+            - running
+            - completed
+            - failed
+            - retrying
+        moderationStatus:
+          type: string
+          enum: [pending, accepted, quarantined, duplicate, rejected]
+        rewardEligibilityStatus:
+          type: string
+          enum: [disabled, ineligible, eligible_pending, granted]
+        rewardPoints:
+          type: integer
+        rewardOptimizationTokens:
+          type: integer
+        rewardMessage:
+          type: string
     ProcessingJob:
       type: object
       required: [id, queueName, jobType, status, attemptCount, createdAt, updatedAt]

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -495,15 +495,15 @@ rules into implementation tasks against the real product.
 
 - [X] T178 [P] Audit implemented web/mobile/admin flows against the current product and document product, IA, visual-system, trust-evidence, receipt, and interaction gaps in `docs/product/stitch-ui-ux-alignment.md`
 - [X] T179 [P] Map design-system rules into implementation-ready tokens and component rules for web and mobile, including teal/lime/amber/coral status roles, tonal surfaces, 8px radius, action badges, and tabular price typography in `docs/product/stitch-ui-ux-alignment.md`
-- [~] T180 Split the broad Phase 24 refactor into issue-sized shopper lanes for `create list -> optimize -> shop -> contribute receipt`, including next-best-action strips, compact persistent city context, richer list item cards, sticky mobile actions, checklist completion, optional paid-total capture, price-mismatch reports, and checklist-to-receipt handoff in `web/src/public/` and `mobile/lib/features/`
-- [~] T181 Render persisted optimization explanations as shopper evidence modules with trust factor, source type, receipt/observation count, freshness decay, confidence notice, selected variant, true comparison math, and report/upload actions in `web/src/public/` and `mobile/lib/features/optimization/`
-- [~] T182 Render admin decision evidence modules with selected offers, rejected alternatives, trust decay, receipt provenance, moderation status, and source labels in `web/src/dashboard/`
-- [~] T183 Refactor receipt contribution surfaces so accepted, pending-review, duplicate, rejected, and low-confidence outcomes are visual and actionable without promising token rewards before T162 in `web/src/public/`, `web/src/dashboard/`, and `mobile/lib/features/receipts/`
-- [~] T184 Add Phase 23-ready location widgets as explicit city/location/radius preview states, keeping proximity claims disabled until T170-T177 add persisted coordinates and distance-aware optimization in `web/src/public/` and `mobile/lib/features/`
-- [~] T185 Refactor admin overview into an action-first operations surface that elevates stale offers, low-trust offers, failed jobs, quarantined receipts, catalog image gaps, and city coverage issues in `web/src/dashboard/`
+- [X] T180 Split the broad Phase 24 refactor into issue-sized shopper lanes for `create list -> optimize -> shop -> contribute receipt`, including next-best-action strips, compact persistent city context, richer list item cards, sticky mobile actions, checklist completion, optional paid-total capture, price-mismatch reports, and checklist-to-receipt handoff in `web/src/public/` and `mobile/lib/features/`
+- [X] T181 Render persisted optimization explanations as shopper evidence modules with trust factor, source type, receipt/observation count, freshness decay, confidence notice, selected variant, true comparison math, and report/upload actions in `web/src/public/` and `mobile/lib/features/optimization/`
+- [X] T182 Render admin decision evidence modules with selected offers, rejected alternatives, trust decay, receipt provenance, moderation status, and source labels in `web/src/dashboard/`
+- [X] T183 Refactor receipt contribution surfaces so accepted, pending-review, duplicate, rejected, and low-confidence outcomes are visual and actionable without promising token rewards before T162 in `web/src/public/`, `web/src/dashboard/`, and `mobile/lib/features/receipts/`
+- [X] T184 Add Phase 23-ready location widgets as explicit city/location/radius preview states, keeping proximity claims disabled until T170-T177 add persisted coordinates and distance-aware optimization in `web/src/public/` and `mobile/lib/features/`
+- [X] T185 Refactor admin overview into an action-first operations surface that elevates stale offers, low-trust offers, failed jobs, quarantined receipts, catalog image gaps, and city coverage issues in `web/src/dashboard/`
 - [X] T186 Refactor public city and offer surfaces so activating cities have explicit placeholders, supported-establishment sections show active stores or activation states, offers are grouped by product/variant with cheapest eligible establishment first, and establishment filters/comparison panels replace duplicate offer cards in `web/src/public/` and `web/src/app/`
-- [~] T187 Refactor public web surfaces toward the audited direction for landing, city selection, offers explorer, offer detail, lists, list editor, optimization result, receipt states, location widgets, premium/free entitlement copy, and disabled billing gate in `web/src/public/`
-- [~] T188 Refactor mobile surfaces toward the audited direction for onboarding/home, list, location widgets, optimization results by mode, receipt contribution, profile/value, error states, and dark-mode parity in `mobile/lib/features/`
+- [X] T187 Refactor public web surfaces toward the audited direction for landing, city selection, offers explorer, offer detail, lists, list editor, optimization result, receipt states, location widgets, premium/free entitlement copy, and disabled billing gate in `web/src/public/`
+- [X] T188 Refactor mobile surfaces toward the audited direction for onboarding/home, list, location widgets, optimization results by mode, receipt contribution, profile/value, error states, and dark-mode parity in `mobile/lib/features/`
 - [X] T189 Refactor admin catalog and offer operations so variants are managed through a dedicated detail route/tab, long variant lists are searchable/collapsible, variant images appear in price/offer rows, and raw IDs move behind detail affordances in `web/src/dashboard/`
 - [X] T190 Refactor admin list operations and queue health cards so they show human-readable owner, list, mode, elapsed time, status, and icon actions before technical job/resource IDs in `web/src/dashboard/`
 - [X] T191 Add visual regression/screenshot validation for key aligned web flows with Playwright and keep existing MVP E2E coverage green in `web/e2e/`
@@ -551,9 +551,9 @@ Premium access and extra optimization credits are support/admin operations for n
 - [X] T212 Change receipt ingestion to manual processing by default, keeping an `RECEIPT_PROCESSING_MODE=automatic` escape hatch for future automatic queueing in `backend/src/receipts/` and `backend/src/jobs/`
 - [X] T213 Add admin release action so received receipts can be manually sent to the receipt-processing queue, with pending/released states in `backend/src/admin/` and `web/src/dashboard/`
 - [X] T214 Expand admin receipt detail with extracted payload, product matcher result, missing-product maker actions, and price up/down comparison against current offers in `backend/src/admin/` and `web/src/dashboard/`
-- [~] T215 Add mobile QR-code receipt submission flow that posts the scanned NFC-e URL to backend and shows submitted -> waiting release -> processing -> reward validated states in `mobile/lib/features/receipts/`
+- [X] T215 Add mobile QR-code receipt submission flow that posts the scanned NFC-e URL to backend and shows submitted -> waiting release -> processing -> reward validated states in `mobile/lib/features/receipts/`
 - [X] T216 Adopt `web/src/assets/pricely-icon.png` as the official brand icon in web shell/header and plan reuse for favicon/mobile app assets.
-- [~] T217 Continue location web/mobile UX refactors with explicit location/radius preview, manual fallback, denied-permission states, and no-proximity claims until distance-aware optimization is fully active.
+- [X] T217 Continue location web/mobile UX refactors with explicit location/radius preview, manual fallback, denied-permission states, and no-proximity claims until distance-aware optimization is fully active.
 
 ### Phase 28: Web Button Integration Audit and Action Gaps
 
@@ -623,8 +623,8 @@ sensitive monetary values across web surfaces.
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.
 Validated public bundle load, customer login, receipt submission with
 `waiting_manual_release`, admin dashboard, admin queue, receipt audit, manual
-processing release, and backend coverage-preview API. `T183`, `T187`, and
-`T217` remain partial because their mobile surfaces are still pending.
+processing release, and backend coverage-preview API. Mobile receipt scanning,
+manual-location fallback, and dark-mode parity were completed in Phase 32.
 
 ---
 


### PR DESCRIPTION
## Summary
- add native NFC-e QR scanning and shopper receipt status refresh
- add manual CEP coverage fallback with explicit no-proximity copy
- add persisted system/light/dark theme support and dark responsive surfaces
- close remaining Stitch/mobile parity tasks T180-T188, T215, and T217

## Local validation
- backend build/lint: passed
- backend: 51 suites, 143 tests
- web build/lint: passed
- web: 55 tests
- Flutter analyze/test/APK delegated to required CI runner

Refs #432