### PR TITLE
Phase 34: notification center and preferences

### DIFF
--- a/backend/prisma/migrations/20260626000000_notification_center/migration.sql
+++ b/backend/prisma/migrations/20260626000000_notification_center/migration.sql
@@ -1,0 +1,53 @@
+CREATE TYPE "UserNotificationType" AS ENUM (
+  'price_drop',
+  'receipt_outcome',
+  'optimization_ready',
+  'optimization_failed'
+);
+
+CREATE TABLE "UserNotificationPreference" (
+  "id" UUID NOT NULL,
+  "userId" UUID NOT NULL,
+  "inAppEnabled" BOOLEAN NOT NULL DEFAULT true,
+  "priceDropsEnabled" BOOLEAN NOT NULL DEFAULT true,
+  "receiptOutcomesEnabled" BOOLEAN NOT NULL DEFAULT true,
+  "optimizationReadyEnabled" BOOLEAN NOT NULL DEFAULT true,
+  "emailEnabled" BOOLEAN NOT NULL DEFAULT false,
+  "pushEnabled" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "UserNotificationPreference_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "UserNotification" (
+  "id" UUID NOT NULL,
+  "userId" UUID NOT NULL,
+  "type" "UserNotificationType" NOT NULL,
+  "title" TEXT NOT NULL,
+  "message" TEXT NOT NULL,
+  "resourceType" TEXT,
+  "resourceId" TEXT,
+  "metadata" JSONB,
+  "readAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "UserNotification_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "UserNotificationPreference_userId_key"
+ON "UserNotificationPreference"("userId");
+
+CREATE INDEX "UserNotification_userId_readAt_createdAt_idx"
+ON "UserNotification"("userId", "readAt", "createdAt");
+
+CREATE INDEX "UserNotification_type_createdAt_idx"
+ON "UserNotification"("type", "createdAt");
+
+ALTER TABLE "UserNotificationPreference"
+ADD CONSTRAINT "UserNotificationPreference_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "UserAccount"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "UserNotification"
+ADD CONSTRAINT "UserNotification_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "UserAccount"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -191,6 +191,13 @@ enum MissingProductRequestStatus {
   rejected
 }
 
+enum UserNotificationType {
+  price_drop
+  receipt_outcome
+  optimization_ready
+  optimization_failed
+}
+
 model UserAccount {
   id                      String                         @id @default(uuid()) @db.Uuid
   email                   String                         @unique
@@ -211,6 +218,8 @@ model UserAccount {
   locationPreferences     UserLocationPreference[]
   sessions                UserSession[]
   missingProductRequests  MissingProductRequest[]
+  notifications           UserNotification[]
+  notificationPreference  UserNotificationPreference?
   preferredRegion         Region?                        @relation("UserPreferredRegion", fields: [preferredRegionId], references: [id], onDelete: SetNull)
 }
 
@@ -345,6 +354,37 @@ model MissingProductRequest {
 
   @@index([status, createdAt])
   @@index([userId, createdAt])
+}
+
+model UserNotificationPreference {
+  id                       String      @id @default(uuid()) @db.Uuid
+  userId                   String      @unique @db.Uuid
+  inAppEnabled             Boolean     @default(true)
+  priceDropsEnabled        Boolean     @default(true)
+  receiptOutcomesEnabled   Boolean     @default(true)
+  optimizationReadyEnabled Boolean     @default(true)
+  emailEnabled             Boolean     @default(false)
+  pushEnabled              Boolean     @default(false)
+  createdAt                DateTime    @default(now())
+  updatedAt                DateTime    @updatedAt
+  user                     UserAccount @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model UserNotification {
+  id           String               @id @default(uuid()) @db.Uuid
+  userId       String               @db.Uuid
+  type         UserNotificationType
+  title        String
+  message      String
+  resourceType String?
+  resourceId   String?
+  metadata     Json?
+  readAt       DateTime?
+  createdAt    DateTime             @default(now())
+  user         UserAccount          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, readAt, createdAt])
+  @@index([type, createdAt])
 }
 
 model CatalogProductAlias {

--- a/backend/src/admin/application/admin-dashboard.service.ts
+++ b/backend/src/admin/application/admin-dashboard.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  Optional,
+} from '@nestjs/common';
 
 import { CatalogProductsService } from '../../catalog/application/catalog-products.service';
 import { CatalogMediaService } from '../../catalog/application/catalog-media.service';
@@ -8,6 +13,7 @@ import { OfferManagementService } from '../../pricing/application/offer-manageme
 import { ReceiptIngestionService } from '../../receipts/application/receipt-ingestion.service';
 import { RegionsAdminService } from '../../regions/application/regions-admin.service';
 import { EntitlementsService } from '../../users/entitlements.service';
+import { NotificationsService } from '../../notifications/notifications.service';
 
 @Injectable()
 export class AdminDashboardService {
@@ -22,6 +28,8 @@ export class AdminDashboardService {
     private readonly offerManagementService: OfferManagementService,
     private readonly entitlementsService: EntitlementsService,
     private readonly receiptIngestionService: ReceiptIngestionService,
+    @Optional()
+    private readonly notificationsService?: NotificationsService,
   ) {}
 
   async getMetrics() {
@@ -1402,7 +1410,44 @@ export class AdminDashboardService {
       isActive: boolean;
     }>,
   ) {
+    const productOfferDelegate = (
+      this.prisma as unknown as {
+        productOffer?: {
+          findUnique?: (input: {
+            where: { id: string };
+            select: {
+              catalogProductId: true;
+              displayName: true;
+              priceAmount: true;
+            };
+          }) => Promise<{
+            catalogProductId: string;
+            displayName: string;
+            priceAmount: { toString(): string } | number;
+          } | null>;
+        };
+      }
+    ).productOffer;
+    const previous = productOfferDelegate?.findUnique
+      ? await productOfferDelegate.findUnique({
+          where: { id },
+          select: {
+            catalogProductId: true,
+            displayName: true,
+            priceAmount: true,
+          },
+        })
+      : null;
     const updated = await this.offerManagementService.update(id, input);
+    if (previous && input.priceAmount !== undefined) {
+      await this.notificationsService?.notifyPriceDropForProduct({
+        catalogProductId: previous.catalogProductId,
+        productName: previous.displayName,
+        previousPrice: Number(previous.priceAmount),
+        currentPrice: Number(updated.priceAmount),
+        offerId: id,
+      });
+    }
 
     this.logger.log(`Admin updated product offer ${id}`);
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { LocationsModule } from './locations/locations.module';
 import { LoggingModule } from './common/logging/logging.module';
 import { QueueModule } from './common/queue/queue.module';
 import { OptimizationModule } from './optimization/optimization.module';
+import { NotificationsModule } from './notifications/notifications.module';
 import { PrismaModule } from './persistence/prisma.module';
 import { PricingModule } from './pricing/pricing.module';
 import { ReceiptsModule } from './receipts/receipts.module';
@@ -32,6 +33,7 @@ import { StoresModule } from './stores/stores.module';
     StoresModule,
     PricingModule,
     OptimizationModule,
+    NotificationsModule,
     AdminModule,
     JobsModule,
   ],

--- a/backend/src/jobs/optimization-run.processor.ts
+++ b/backend/src/jobs/optimization-run.processor.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 
 import { ShoppingListsService } from '../lists/application/shopping-lists.service';
@@ -8,6 +8,7 @@ import { StoreOfferRepository } from '../stores/infrastructure/store-offer.repos
 import { type StoreOfferEntity } from '../stores/domain/store-offer.entity';
 import { OptimizationRunRepository } from '../optimization/infrastructure/optimization-run.repository';
 import { EntitlementsService } from '../users/entitlements.service';
+import { NotificationsService } from '../notifications/notifications.service';
 
 @Injectable()
 export class OptimizationRunProcessor {
@@ -20,6 +21,8 @@ export class OptimizationRunProcessor {
     private readonly multiMarketOptimizerService: MultiMarketOptimizerService,
     private readonly optimizationRunRepository: OptimizationRunRepository,
     private readonly entitlementsService: EntitlementsService,
+    @Optional()
+    private readonly notificationsService?: NotificationsService,
   ) {}
 
   async process(optimizationRunId: string): Promise<void> {
@@ -189,6 +192,18 @@ export class OptimizationRunProcessor {
     await this.entitlementsService.consumeOptimizationToken({
       userId: optimizationRun.userId,
       optimizationRunId: optimizationRun.id,
+    });
+    await this.notificationsService?.create({
+      userId: optimizationRun.userId,
+      type: 'optimization_ready',
+      title: 'Sua otimizacao esta pronta',
+      message: `${shoppingList.name}: resultado concluido com cobertura ${computed.coverageStatus}.`,
+      resourceType: 'optimization_run',
+      resourceId: optimizationRun.id,
+      metadata: {
+        shoppingListId: optimizationRun.shoppingListId,
+        estimatedSavings: computed.estimatedSavings ?? 0,
+      },
     });
 
     this.logger.log(

--- a/backend/src/jobs/optimization-worker.service.ts
+++ b/backend/src/jobs/optimization-worker.service.ts
@@ -4,6 +4,7 @@ import {
   Logger,
   OnModuleDestroy,
   OnModuleInit,
+  Optional,
 } from '@nestjs/common';
 import { type ConnectionOptions, Worker } from 'bullmq';
 
@@ -12,10 +13,13 @@ import { type OptimizationJob } from '../common/queue/queue.tokens';
 import { ProcessingJobsService } from '../processing/application/processing-jobs.service';
 import { PrismaService } from '../persistence/prisma.service';
 import { EntitlementsService } from '../users/entitlements.service';
+import { NotificationsService } from '../notifications/notifications.service';
 import { OptimizationRunProcessor } from './optimization-run.processor';
 
 @Injectable()
-export class OptimizationWorkerService implements OnModuleInit, OnModuleDestroy {
+export class OptimizationWorkerService
+  implements OnModuleInit, OnModuleDestroy
+{
   private readonly logger = new Logger(OptimizationWorkerService.name);
   private worker: Worker<OptimizationJob> | null = null;
 
@@ -26,11 +30,18 @@ export class OptimizationWorkerService implements OnModuleInit, OnModuleDestroy 
     private readonly entitlementsService: EntitlementsService,
     private readonly processingJobsService: ProcessingJobsService,
     private readonly optimizationRunProcessor: OptimizationRunProcessor,
+    @Optional()
+    private readonly notificationsService?: NotificationsService,
   ) {}
 
   onModuleInit() {
-    if (process.env.JEST_WORKER_ID || process.env.QUEUE_WORKERS_ENABLED === 'false') {
-      this.logger.log('Optimization worker bootstrap skipped for test or disabled environment');
+    if (
+      process.env.JEST_WORKER_ID ||
+      process.env.QUEUE_WORKERS_ENABLED === 'false'
+    ) {
+      this.logger.log(
+        'Optimization worker bootstrap skipped for test or disabled environment',
+      );
       return;
     }
 
@@ -77,7 +88,10 @@ export class OptimizationWorkerService implements OnModuleInit, OnModuleDestroy 
         this.logger.warn(
           `Retrying optimization job ${job.id} for run ${job.data.optimizationRunId}: ${message}`,
         );
-        await this.processingJobsService.markRetrying(job.data.processingJobId, message);
+        await this.processingJobsService.markRetrying(
+          job.data.processingJobId,
+          message,
+        );
         await this.prisma.optimizationRun.update({
           where: {
             id: job.data.optimizationRunId,
@@ -89,7 +103,10 @@ export class OptimizationWorkerService implements OnModuleInit, OnModuleDestroy 
         return;
       }
 
-      await this.processingJobsService.markFailed(job.data.processingJobId, message);
+      await this.processingJobsService.markFailed(
+        job.data.processingJobId,
+        message,
+      );
       const optimizationRun = await this.prisma.optimizationRun.findUnique({
         where: {
           id: job.data.optimizationRunId,
@@ -113,6 +130,15 @@ export class OptimizationWorkerService implements OnModuleInit, OnModuleDestroy 
           userId: optimizationRun.userId,
           optimizationRunId: optimizationRun.id,
           reason: 'optimization_failed',
+        });
+        await this.notificationsService?.create({
+          userId: optimizationRun.userId,
+          type: 'optimization_failed',
+          title: 'Nao foi possivel concluir a otimizacao',
+          message:
+            'O processamento falhou e o credito de otimizacao foi devolvido.',
+          resourceType: 'optimization_run',
+          resourceId: optimizationRun.id,
         });
       }
       this.logger.error(

--- a/backend/src/jobs/receipt-ingestion.processor.ts
+++ b/backend/src/jobs/receipt-ingestion.processor.ts
@@ -1,9 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 
 import { type ReceiptRecordEntity } from '../receipts/domain/receipt-record.entity';
 import { ReceiptRecordRepository } from '../receipts/infrastructure/receipt-record.repository';
 import { StoreOfferRepository } from '../stores/infrastructure/store-offer.repository';
 import { EntitlementsService } from '../users/entitlements.service';
+import { NotificationsService } from '../notifications/notifications.service';
 
 @Injectable()
 export class ReceiptIngestionProcessor {
@@ -13,13 +14,17 @@ export class ReceiptIngestionProcessor {
     private readonly receiptRecordRepository: ReceiptRecordRepository,
     private readonly storeOfferRepository: StoreOfferRepository,
     private readonly entitlementsService: EntitlementsService,
+    @Optional()
+    private readonly notificationsService?: NotificationsService,
   ) {}
 
   async process(receiptRecordId: string): Promise<void> {
     const record = await this.receiptRecordRepository.findById(receiptRecordId);
 
     if (!record) {
-      this.logger.warn(`Receipt ${receiptRecordId} was queued but could not be found`);
+      this.logger.warn(
+        `Receipt ${receiptRecordId} was queued but could not be found`,
+      );
       return;
     }
 
@@ -28,7 +33,9 @@ export class ReceiptIngestionProcessor {
         receiptRecordId,
         'structured_provider_or_ocr_not_configured',
       );
-      throw new Error('Receipt extraction provider or OCR extractor is not configured');
+      throw new Error(
+        'Receipt extraction provider or OCR extractor is not configured',
+      );
     }
 
     const resolvedStoreId =
@@ -39,7 +46,9 @@ export class ReceiptIngestionProcessor {
         receiptRecordId,
         'missing_store_identity',
       );
-      throw new Error('Receipt store identity is required before creating price offers');
+      throw new Error(
+        'Receipt store identity is required before creating price offers',
+      );
     }
 
     await this.persistStoreOffers({
@@ -48,6 +57,26 @@ export class ReceiptIngestionProcessor {
       storeName: record.storeName,
     });
     await this.grantRewardIfEligible(record);
+    const updatedRecord =
+      await this.receiptRecordRepository.findById(receiptRecordId);
+    await this.notificationsService?.create({
+      userId: record.userId,
+      type: 'receipt_outcome',
+      title: 'Nota fiscal processada',
+      message:
+        updatedRecord?.rewardEligibilityStatus === 'granted'
+          ? 'Sua nota foi validada e a recompensa foi liberada.'
+          : 'Sua nota terminou o processamento e esta disponivel para consulta.',
+      resourceType: 'receipt_record',
+      resourceId: record.id,
+      metadata: {
+        moderationStatus:
+          updatedRecord?.moderationStatus ?? record.moderationStatus,
+        rewardEligibilityStatus:
+          updatedRecord?.rewardEligibilityStatus ??
+          record.rewardEligibilityStatus,
+      },
+    });
     this.logger.log(`Receipt ${receiptRecordId} processed into store offers`);
   }
 

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+import { type JwtUserPayload } from '../auth/auth.types';
+import { CurrentUser } from '../common/auth/current-user.decorator';
+import { JwtAuthGuard } from '../common/auth/jwt-auth.guard';
+import { NotificationsService } from './notifications.service';
+
+class UpdateNotificationPreferencesDto {
+  @IsOptional()
+  @IsBoolean()
+  inAppEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  priceDropsEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  receiptOutcomesEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  optimizationReadyEnabled?: boolean;
+}
+
+@Controller()
+@UseGuards(JwtAuthGuard)
+export class NotificationsController {
+  constructor(private readonly notificationsService: NotificationsService) {}
+
+  @Get('notifications')
+  list(
+    @CurrentUser() user: JwtUserPayload,
+    @Query('unreadOnly') unreadOnly?: string,
+  ) {
+    return this.notificationsService.list(user.sub, unreadOnly === 'true');
+  }
+
+  @Patch('notifications/:id/read')
+  markRead(@CurrentUser() user: JwtUserPayload, @Param('id') id: string) {
+    return this.notificationsService.markRead(user.sub, id);
+  }
+
+  @Post('notifications/read-all')
+  markAllRead(@CurrentUser() user: JwtUserPayload) {
+    return this.notificationsService.markAllRead(user.sub);
+  }
+
+  @Get('notification-preferences')
+  preferences(@CurrentUser() user: JwtUserPayload) {
+    return this.notificationsService.getPreferences(user.sub);
+  }
+
+  @Patch('notification-preferences')
+  updatePreferences(
+    @CurrentUser() user: JwtUserPayload,
+    @Body() body: UpdateNotificationPreferencesDto,
+  ) {
+    return this.notificationsService.updatePreferences(user.sub, body);
+  }
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+
+import { PrismaModule } from '../persistence/prisma.module';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+
+@Global()
+@Module({
+  imports: [PrismaModule],
+  controllers: [NotificationsController],
+  providers: [NotificationsService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,0 +1,159 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { type Prisma, type UserNotificationType } from '@prisma/client';
+
+import { PrismaService } from '../persistence/prisma.service';
+
+@Injectable()
+export class NotificationsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(userId: string, unreadOnly = false) {
+    return this.prisma.userNotification.findMany({
+      where: {
+        userId,
+        ...(unreadOnly ? { readAt: null } : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 100,
+    });
+  }
+
+  async getPreferences(userId: string) {
+    return this.prisma.userNotificationPreference.upsert({
+      where: { userId },
+      create: { userId },
+      update: {},
+    });
+  }
+
+  async updatePreferences(
+    userId: string,
+    input: {
+      inAppEnabled?: boolean;
+      priceDropsEnabled?: boolean;
+      receiptOutcomesEnabled?: boolean;
+      optimizationReadyEnabled?: boolean;
+    },
+  ) {
+    return this.prisma.userNotificationPreference.upsert({
+      where: { userId },
+      create: {
+        userId,
+        ...input,
+        emailEnabled: false,
+        pushEnabled: false,
+      },
+      update: {
+        ...input,
+        emailEnabled: false,
+        pushEnabled: false,
+      },
+    });
+  }
+
+  async markRead(userId: string, notificationId: string) {
+    const notification = await this.prisma.userNotification.findFirst({
+      where: { id: notificationId, userId },
+    });
+    if (!notification) {
+      throw new NotFoundException('Notificacao nao encontrada');
+    }
+    return this.prisma.userNotification.update({
+      where: { id: notificationId },
+      data: { readAt: notification.readAt ?? new Date() },
+    });
+  }
+
+  async markAllRead(userId: string) {
+    await this.prisma.userNotification.updateMany({
+      where: { userId, readAt: null },
+      data: { readAt: new Date() },
+    });
+    return { status: 'ok' };
+  }
+
+  async create(input: {
+    userId: string;
+    type: UserNotificationType;
+    title: string;
+    message: string;
+    resourceType?: string;
+    resourceId?: string;
+    metadata?: Prisma.InputJsonValue;
+  }) {
+    const preferences = await this.getPreferences(input.userId);
+    if (
+      !preferences.inAppEnabled ||
+      !this.typeEnabled(preferences, input.type)
+    ) {
+      return null;
+    }
+    return this.prisma.userNotification.create({
+      data: {
+        userId: input.userId,
+        type: input.type,
+        title: input.title.slice(0, 160),
+        message: input.message.slice(0, 500),
+        resourceType: input.resourceType,
+        resourceId: input.resourceId,
+        metadata: input.metadata,
+      },
+    });
+  }
+
+  async notifyPriceDropForProduct(input: {
+    catalogProductId: string;
+    productName: string;
+    previousPrice: number;
+    currentPrice: number;
+    offerId: string;
+  }) {
+    if (input.currentPrice >= input.previousPrice) {
+      return;
+    }
+    const users = await this.prisma.shoppingListItem.findMany({
+      where: {
+        catalogProductId: input.catalogProductId,
+        shoppingList: { status: { not: 'archived' } },
+      },
+      select: { shoppingList: { select: { userId: true } } },
+      distinct: ['shoppingListId'],
+      take: 500,
+    });
+    const userIds = [...new Set(users.map((item) => item.shoppingList.userId))];
+    await Promise.all(
+      userIds.map((userId) =>
+        this.create({
+          userId,
+          type: 'price_drop',
+          title: `Preco menor para ${input.productName}`,
+          message: `O preco caiu de R$ ${input.previousPrice.toFixed(2)} para R$ ${input.currentPrice.toFixed(2)}.`,
+          resourceType: 'product_offer',
+          resourceId: input.offerId,
+          metadata: {
+            catalogProductId: input.catalogProductId,
+            previousPrice: input.previousPrice,
+            currentPrice: input.currentPrice,
+          },
+        }),
+      ),
+    );
+  }
+
+  private typeEnabled(
+    preferences: {
+      priceDropsEnabled: boolean;
+      receiptOutcomesEnabled: boolean;
+      optimizationReadyEnabled: boolean;
+    },
+    type: UserNotificationType,
+  ) {
+    if (type === 'price_drop') {
+      return preferences.priceDropsEnabled;
+    }
+    if (type === 'receipt_outcome') {
+      return preferences.receiptOutcomesEnabled;
+    }
+    return preferences.optimizationReadyEnabled;
+  }
+}

--- a/backend/test/unit/notifications/notifications.service.spec.ts
+++ b/backend/test/unit/notifications/notifications.service.spec.ts
@@ -1,0 +1,65 @@
+import { NotificationsService } from '../../../src/notifications/notifications.service';
+
+describe('NotificationsService', () => {
+  it('respects category preferences before creating an in-app notification', async () => {
+    const prisma = {
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({
+          inAppEnabled: true,
+          priceDropsEnabled: false,
+          receiptOutcomesEnabled: true,
+          optimizationReadyEnabled: true,
+        }),
+      },
+      userNotification: {
+        create: jest.fn(),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.create({
+      userId: 'user-1',
+      type: 'price_drop',
+      title: 'Preco menor',
+      message: 'Novo preco disponivel.',
+    });
+
+    expect(prisma.userNotification.create).not.toHaveBeenCalled();
+  });
+
+  it('creates only price-drop alerts relevant to saved list products', async () => {
+    const prisma = {
+      shoppingListItem: {
+        findMany: jest
+          .fn()
+          .mockResolvedValue([
+            { shoppingList: { userId: 'user-1' } },
+            { shoppingList: { userId: 'user-1' } },
+            { shoppingList: { userId: 'user-2' } },
+          ]),
+      },
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({
+          inAppEnabled: true,
+          priceDropsEnabled: true,
+          receiptOutcomesEnabled: true,
+          optimizationReadyEnabled: true,
+        }),
+      },
+      userNotification: {
+        create: jest.fn().mockResolvedValue({ id: 'notification-1' }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.notifyPriceDropForProduct({
+      catalogProductId: 'product-1',
+      productName: 'Arroz 1kg',
+      previousPrice: 10,
+      currentPrice: 8,
+      offerId: 'offer-1',
+    });
+
+    expect(prisma.userNotification.create).toHaveBeenCalledTimes(2);
+  });
+});

--- a/docs/product/notification-center.md
+++ b/docs/product/notification-center.md
@@ -1,0 +1,21 @@
+# Notification Center
+
+The current engagement channel is the authenticated in-app notification center.
+
+## Supported events
+
+- Relevant price drops for products present in active saved lists.
+- Receipt processing outcomes and reward validation.
+- Optimization completion and terminal failure.
+
+## Preferences
+
+Users can disable all in-app notifications or control price, receipt, and
+optimization categories independently.
+
+## Deferred channels
+
+Email and push fields are persisted as disabled capabilities. Enabling either
+channel requires provider configuration, verified destination ownership,
+delivery/retry tracking, unsubscribe handling, and quiet-hour policy. No
+external delivery is attempted in this phase.

--- a/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
+++ b/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
@@ -373,6 +373,35 @@ paths:
       responses:
         '201':
           description: Request rejected
+  /notifications:
+    get:
+      summary: List authenticated in-app notifications
+      responses:
+        '200':
+          description: Notifications returned newest first
+  /notifications/{notificationId}/read:
+    patch:
+      summary: Mark one owned notification as read
+      responses:
+        '200':
+          description: Notification updated
+  /notifications/read-all:
+    post:
+      summary: Mark all authenticated user notifications as read
+      responses:
+        '201':
+          description: Unread notifications updated
+  /notification-preferences:
+    get:
+      summary: Fetch in-app notification category preferences
+      responses:
+        '200':
+          description: Preferences returned
+    patch:
+      summary: Update in-app notification category preferences
+      responses:
+        '200':
+          description: Preferences updated; email and push remain disabled
   /receipts:
     post:
       summary: Submit a receipt contribution from manual items or an NFC-e QR URL

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -565,7 +565,7 @@ the missing feature.
 - [X] T219 [P] Wire existing public UI affordances for location confirmation, optimization-result tabs, result item filtering, per-item evidence expansion, and browser-settings guidance in `web/src/public/` and `web/src/components/design-system/`
 - [X] T220 [P] Add shopper shareable-list support with access policy, public/share route behavior, and copy-link UI in `specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml`, `backend/src/lists/`, and `web/src/public/`
 - [X] T221 [P] Add shopper missing-product request intake, admin triage, and catalog conversion workflow in `backend/src/catalog/`, `backend/src/admin/`, `web/src/public/`, and `web/src/dashboard/`
-- [ ] T222 [P] Specify and implement user notification preferences, alert triggers, and web notification-center states for price changes, receipt outcomes, and optimization readiness in `backend/src/users/`, `backend/src/receipts/`, `backend/src/optimization/`, and `web/src/public/`
+- [X] T222 [P] Specify and implement user notification preferences, alert triggers, and web notification-center states for price changes, receipt outcomes, and optimization readiness in `backend/src/users/`, `backend/src/receipts/`, `backend/src/optimization/`, and `web/src/public/`
 - [X] T223 [P] Add map/deep-link support for optimized store plans using saved establishment address/coordinates without exposing precise user location in `backend/src/establishments/`, `backend/src/optimization/`, and `web/src/public/`
 - [X] T224 Add generic processing-job lifecycle operations for retry, mark-reviewed, and cancel with queue safety rules, audit logging, admin API endpoints, and dashboard actions in `backend/src/processing/`, `backend/src/admin/`, and `web/src/dashboard/`
 

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -174,6 +174,30 @@ export type MissingProductRequestResponse = {
   } | null;
 };
 
+export type UserNotificationResponse = {
+  id: string;
+  type:
+    | 'price_drop'
+    | 'receipt_outcome'
+    | 'optimization_ready'
+    | 'optimization_failed';
+  title: string;
+  message: string;
+  resourceType?: string | null;
+  resourceId?: string | null;
+  readAt?: string | null;
+  createdAt: string;
+};
+
+export type NotificationPreferencesResponse = {
+  inAppEnabled: boolean;
+  priceDropsEnabled: boolean;
+  receiptOutcomesEnabled: boolean;
+  optimizationReadyEnabled: boolean;
+  emailEnabled: false;
+  pushEnabled: false;
+};
+
 type RegionOffersApiResponse = {
   region: {
     id: string;
@@ -966,6 +990,56 @@ export async function requestMissingProduct(
     '/missing-product-requests',
     {
       method: 'POST',
+      body: JSON.stringify(input),
+    },
+    token,
+  );
+}
+
+export async function fetchNotifications(token: string) {
+  return apiFetch<UserNotificationResponse[]>('/notifications', {}, token);
+}
+
+export async function markNotificationRead(token: string, id: string) {
+  return apiFetch<UserNotificationResponse>(
+    `/notifications/${id}/read`,
+    { method: 'PATCH' },
+    token,
+  );
+}
+
+export async function markAllNotificationsRead(token: string) {
+  return apiFetch<{ status: 'ok' }>(
+    '/notifications/read-all',
+    { method: 'POST' },
+    token,
+  );
+}
+
+export async function fetchNotificationPreferences(token: string) {
+  return apiFetch<NotificationPreferencesResponse>(
+    '/notification-preferences',
+    {},
+    token,
+  );
+}
+
+export async function updateNotificationPreferences(
+  token: string,
+  input: Partial<
+    Pick<
+      NotificationPreferencesResponse,
+      | 'inAppEnabled'
+      | 'priceDropsEnabled'
+      | 'receiptOutcomesEnabled'
+      | 'optimizationReadyEnabled'
+    >
+  >,
+) {
+  return apiFetch<NotificationPreferencesResponse>(
+    '/notification-preferences',
+    {
+      method: 'PATCH',
       body: JSON.stringify(input),
     },
     token,

--- a/web/src/components/design-system/app-sidebar-shell.tsx
+++ b/web/src/components/design-system/app-sidebar-shell.tsx
@@ -1,4 +1,9 @@
-import { useState, type FormEvent, type PropsWithChildren } from 'react';
+import {
+  useEffect,
+  useState,
+  type FormEvent,
+  type PropsWithChildren,
+} from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import {
   BellIcon,
@@ -25,6 +30,15 @@ import {
 import { useMonetaryPrivacy } from '@/app/monetary-privacy-context';
 import { usePricely } from '@/app/pricely-context';
 import { useTheme } from '@/app/theme-context';
+import {
+  fetchNotificationPreferences,
+  fetchNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+  updateNotificationPreferences,
+  type NotificationPreferencesResponse,
+  type UserNotificationResponse,
+} from '@/app/api';
 import pricelyIcon from '@/assets/pricely-icon.png';
 import { Button } from '@/components/ui/button';
 import {
@@ -36,6 +50,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import {
   Select,
   SelectContent,
@@ -69,7 +84,11 @@ const publicNavItems = [
   { label: 'Lojas', to: '/cidades', icon: Building2Icon },
   { label: 'Cupons', icon: TagsIcon, disabledReason: 'Cupons em breve' },
   { label: 'Notas fiscais', to: '/notas', icon: ReceiptTextIcon },
-  { label: 'Historico', icon: HistoryIcon, disabledReason: 'Historico em breve' },
+  {
+    label: 'Historico',
+    icon: HistoryIcon,
+    disabledReason: 'Historico em breve',
+  },
   {
     label: 'Configuracoes',
     icon: SettingsIcon,
@@ -99,6 +118,7 @@ function SidebarLogo() {
 export function PublicSidebarShell({ children }: PropsWithChildren) {
   const {
     cityId,
+    accessToken,
     cities,
     currentUser,
     isAuthenticated,
@@ -125,6 +145,28 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
   const [locationPreview, setLocationPreview] = useState<string | null>(null);
   const [isLocationDialogOpen, setIsLocationDialogOpen] = useState(false);
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
+  const [isNotificationsDialogOpen, setIsNotificationsDialogOpen] =
+    useState(false);
+  const [notifications, setNotifications] = useState<
+    UserNotificationResponse[]
+  >([]);
+  const [notificationPreferences, setNotificationPreferences] =
+    useState<NotificationPreferencesResponse | null>(null);
+  const unreadNotifications = notifications.filter(
+    (notification) => !notification.readAt,
+  ).length;
+
+  useEffect(() => {
+    if (!accessToken) {
+      return;
+    }
+    void fetchNotifications(accessToken).then(setNotifications);
+    if (isNotificationsDialogOpen) {
+      void fetchNotificationPreferences(accessToken).then(
+        setNotificationPreferences,
+      );
+    }
+  }, [accessToken, isNotificationsDialogOpen]);
 
   const activeCity = cityId
     ? (cities.find((city) => city.id === cityId) ?? null)
@@ -475,11 +517,18 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
             <WithTooltip label="Notificações de preço, cobertura e revisão aparecerão aqui quando habilitadas.">
               <Button
                 aria-label="Notificacoes"
+                className="relative"
+                onClick={() => setIsNotificationsDialogOpen(true)}
                 size="icon-sm"
                 type="button"
                 variant="outline"
               >
                 <BellIcon className="size-4" />
+                {unreadNotifications > 0 ? (
+                  <span className="absolute -right-1 -top-1 flex size-4 items-center justify-center rounded-full bg-destructive text-[10px] text-destructive-foreground">
+                    {Math.min(unreadNotifications, 9)}
+                  </span>
+                ) : null}
               </Button>
             </WithTooltip>
             {isAuthenticated ? (
@@ -529,8 +578,8 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
             <DialogTitle>Localizacao para otimizacao local</DialogTitle>
             <DialogDescription>
               {locationRadiusDisplay}. Modos locais so calculam distancia com
-              coordenadas salvas; CEP e modo cidade nao prometem proximidade.
-              Se o navegador bloquear a permissao, libere localizacao nas
+              coordenadas salvas; CEP e modo cidade nao prometem proximidade. Se
+              o navegador bloquear a permissao, libere localizacao nas
               configuracoes do site e tente novamente.
             </DialogDescription>
           </DialogHeader>
@@ -597,6 +646,131 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
         </DialogContent>
       </Dialog>
 
+      <Dialog
+        onOpenChange={setIsNotificationsDialogOpen}
+        open={isNotificationsDialogOpen}
+      >
+        <DialogContent className="max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Notificacoes</DialogTitle>
+            <DialogDescription>
+              Alertas in-app sobre precos, notas fiscais e otimizacoes.
+            </DialogDescription>
+          </DialogHeader>
+          {!isAuthenticated ? (
+            <div className="rounded-lg border border-border/70 bg-card p-4 text-sm">
+              Entre na conta para acessar suas notificacoes.
+            </div>
+          ) : (
+            <>
+              <div className="grid gap-2">
+                {notifications.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-border/70 p-4 text-sm text-muted-foreground">
+                    Nenhuma notificacao por enquanto.
+                  </div>
+                ) : (
+                  notifications.map((notification) => (
+                    <button
+                      className={`grid gap-1 rounded-lg border p-3 text-left ${
+                        notification.readAt
+                          ? 'border-border/60 bg-card/60'
+                          : 'border-primary/30 bg-primary/5'
+                      }`}
+                      key={notification.id}
+                      onClick={async () => {
+                        if (!accessToken || notification.readAt) return;
+                        const updated = await markNotificationRead(
+                          accessToken,
+                          notification.id,
+                        );
+                        setNotifications((current) =>
+                          current.map((item) =>
+                            item.id === updated.id ? updated : item,
+                          ),
+                        );
+                      }}
+                      type="button"
+                    >
+                      <span className="font-medium">{notification.title}</span>
+                      <span className="text-sm text-muted-foreground">
+                        {notification.message}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {new Date(notification.createdAt).toLocaleString(
+                          'pt-BR',
+                        )}
+                      </span>
+                    </button>
+                  ))
+                )}
+              </div>
+              {notificationPreferences ? (
+                <div className="grid gap-3 rounded-lg border border-border/70 p-4">
+                  <div className="font-medium">Preferencias</div>
+                  {[
+                    ['inAppEnabled', 'Central in-app'],
+                    ['priceDropsEnabled', 'Quedas de preco'],
+                    ['receiptOutcomesEnabled', 'Resultado de notas'],
+                    ['optimizationReadyEnabled', 'Otimizacoes prontas'],
+                  ].map(([key, label]) => (
+                    <label
+                      className="flex items-center justify-between gap-3 text-sm"
+                      key={key}
+                    >
+                      <span>{label}</span>
+                      <Switch
+                        checked={Boolean(
+                          notificationPreferences[
+                            key as keyof NotificationPreferencesResponse
+                          ],
+                        )}
+                        onCheckedChange={async (checked) => {
+                          if (!accessToken) return;
+                          const updated = await updateNotificationPreferences(
+                            accessToken,
+                            { [key]: checked },
+                          );
+                          setNotificationPreferences(updated);
+                        }}
+                      />
+                    </label>
+                  ))}
+                  <div className="text-xs text-muted-foreground">
+                    E-mail e push serao adicionados depois; permanecem
+                    desativados nesta fase.
+                  </div>
+                </div>
+              ) : null}
+            </>
+          )}
+          <DialogFooter>
+            {unreadNotifications > 0 && accessToken ? (
+              <Button
+                onClick={async () => {
+                  await markAllNotificationsRead(accessToken);
+                  setNotifications((current) =>
+                    current.map((item) => ({
+                      ...item,
+                      readAt: item.readAt ?? new Date().toISOString(),
+                    })),
+                  );
+                }}
+                type="button"
+                variant="outline"
+              >
+                Marcar todas como lidas
+              </Button>
+            ) : null}
+            <Button
+              onClick={() => setIsNotificationsDialogOpen(false)}
+              type="button"
+            >
+              Fechar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <Dialog onOpenChange={setIsHelpDialogOpen} open={isHelpDialogOpen}>
         <DialogContent>
           <DialogHeader>
@@ -624,24 +798,21 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
               </div>
             </div>
             <div className="grid gap-2 sm:grid-cols-4">
-              {[
-                'Enviar',
-                'Revisar',
-                'Liberar',
-                'Recomendar',
-              ].map((label, index) => (
-                <div className="grid gap-1" key={label}>
-                  <div className="flex items-center gap-2">
-                    <span className="flex size-6 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
-                      {index + 1}
-                    </span>
-                    {index < 3 ? (
-                      <span className="hidden h-px flex-1 bg-border sm:block" />
-                    ) : null}
+              {['Enviar', 'Revisar', 'Liberar', 'Recomendar'].map(
+                (label, index) => (
+                  <div className="grid gap-1" key={label}>
+                    <div className="flex items-center gap-2">
+                      <span className="flex size-6 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+                        {index + 1}
+                      </span>
+                      {index < 3 ? (
+                        <span className="hidden h-px flex-1 bg-border sm:block" />
+                      ) : null}
+                    </div>
+                    <div className="text-xs font-medium">{label}</div>
                   </div>
-                  <div className="text-xs font-medium">{label}</div>
-                </div>
-              ))}
+                ),
+              )}
             </div>
           </div>
           <div className="grid gap-3 text-sm">


### PR DESCRIPTION
## Summary
- add in-app notification center and per-category preferences
- emit alerts for price drops, receipt outcomes, and optimization results
- document deferred email/push delivery and update the API contract/task roadmap

## Validation
- backend build, lint, and 53 suites / 149 tests
- web build, lint, and 55 tests
- PostgreSQL 17 fresh migration, idempotent redeploy, and drift check
- `git diff --check`

Refs #436