### PR TITLE
Chore: plan notification delivery validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
+      - master
       - homolog
       - phase/**
   push:
     branches:
+      - master
       - homolog
       - phase/**
 

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -3,6 +3,7 @@ name: Release Readiness
 on:
   push:
     branches:
+      - master
       - homolog
   workflow_dispatch:
     inputs:

--- a/docs/product/notification-center.md
+++ b/docs/product/notification-center.md
@@ -19,3 +19,42 @@ Email and push fields are persisted as disabled capabilities. Enabling either
 channel requires provider configuration, verified destination ownership,
 delivery/retry tracking, unsubscribe handling, and quiet-hour policy. No
 external delivery is attempted in this phase.
+
+## Phase 35 delivery plan
+
+Phase 35 keeps the in-app center as the source of truth and adds outbound delivery
+as a controlled fan-out layer.
+
+### Email
+
+- Store a verified email destination per user before delivery is enabled.
+- Queue email delivery from the persisted notification record instead of sending
+  inline from business flows.
+- Include unsubscribe/category controls that map back to existing notification
+  preferences.
+- Track delivery attempts, provider message id, terminal failure, and retryable
+  failure reason without storing provider payloads that may contain personal data.
+
+### Push
+
+- Register mobile device tokens per authenticated user and platform.
+- Allow multiple active devices per user, with last-seen timestamps and explicit
+  revocation on logout or token refresh.
+- Send only compact notification metadata to the push provider; fetch sensitive
+  details from the authenticated API after the app opens.
+- Respect category preferences and future quiet-hour windows before enqueueing.
+
+### Quiet hours and retries
+
+- Add a per-user quiet-hour window with timezone.
+- Defer non-critical notifications during quiet hours; allow critical account or
+  receipt-result notifications only if product policy explicitly allows them.
+- Use bounded exponential retry for provider failures and stop retrying after a
+  terminal provider response.
+- Expose delivery state in admin diagnostics before enabling automatic external
+  sends broadly.
+
+### Release validation
+
+- CI and Release Readiness should validate both `homolog` and `master`.
+- Deploy Homolog Server remains scoped to `homolog` and manual dispatch only.

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -619,6 +619,21 @@ sensitive monetary values across web surfaces.
 - [X] T260 Complete mobile parity validation for auth, city, lists, optimization evidence, receipts, and monetary privacy before production promotion
 - [X] T261 Execute a restore drill and migration rollback rehearsal on an isolated production-like database
 
+## Phase 35: Notification Delivery and Default-Branch Validation
+
+**Purpose**: Keep the in-app notification center as the canonical record while adding
+safe release validation on the default branch and preparing real outbound delivery
+channels without enabling provider sends prematurely.
+
+- [X] T262 Add `master` validation triggers for CI and Release Readiness while keeping Deploy Homolog Server scoped to `homolog` or manual dispatch in `.github/workflows/`
+- [X] T263 Document the Phase 35 email, push, quiet-hours, retry, and release-validation plan in `docs/product/notification-center.md`
+- [ ] T264 Add notification delivery persistence for channel attempts, provider message ids, retry state, and terminal failure reasons in `backend/prisma/` and `backend/src/notifications/`
+- [ ] T265 Add user email destination verification, unsubscribe/category mapping, and email delivery queue integration in `backend/src/notifications/` and `backend/src/users/`
+- [ ] T266 Add mobile push device registration, token refresh/revocation, and authenticated device listing in `backend/src/notifications/` and `mobile/lib/features/`
+- [ ] T267 Add quiet-hour preferences with timezone-aware deferral for non-critical notifications in `backend/src/notifications/`, `web/src/components/design-system/`, and `mobile/lib/features/`
+- [ ] T268 Add admin notification delivery diagnostics, retry/cancel controls, and provider-error redaction in `web/src/dashboard/` and `backend/src/admin/`
+- [ ] T269 Add backend, web, and mobile coverage for delivery preferences, quiet-hour deferral, device registration, retry policy, and redacted admin diagnostics in `backend/test/`, `web/src/`, and `mobile/test/`
+
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.
 Validated public bundle load, customer login, receipt submission with


### PR DESCRIPTION
## Summary
- Adds `master` to CI and Release Readiness validation triggers.
- Keeps Deploy Homolog Server scoped to `homolog` and manual dispatch only.
- Documents Phase 35 notification delivery plan for email, push, device registration, quiet hours, retries, and admin diagnostics.
- Adds Spec Kit tasks T262-T269 so the next notification delivery work is tracked.

## Validation
- Parsed CI, Release Readiness, and Deploy Homolog Server workflow YAML locally.
- Ran `git diff --check`.
- Verified Deploy Homolog Server does not include a `master` branch trigger.

Closes #441