### PR TITLE
Feat: persist notification delivery attempts

### DIFF
--- a/backend/prisma/migrations/20260626030000_notification_delivery_attempts/migration.sql
+++ b/backend/prisma/migrations/20260626030000_notification_delivery_attempts/migration.sql
@@ -1,0 +1,50 @@
+CREATE TYPE "UserNotificationDeliveryChannel" AS ENUM (
+  'email',
+  'push'
+);
+
+CREATE TYPE "UserNotificationDeliveryStatus" AS ENUM (
+  'queued',
+  'sending',
+  'retrying',
+  'delivered',
+  'failed'
+);
+
+CREATE TABLE "UserNotificationDeliveryAttempt" (
+  "id" UUID NOT NULL,
+  "notificationId" UUID NOT NULL,
+  "userId" UUID NOT NULL,
+  "channel" "UserNotificationDeliveryChannel" NOT NULL,
+  "status" "UserNotificationDeliveryStatus" NOT NULL DEFAULT 'queued',
+  "attemptCount" INTEGER NOT NULL DEFAULT 0,
+  "maxAttempts" INTEGER NOT NULL DEFAULT 3,
+  "providerMessageId" TEXT,
+  "lastFailureReason" TEXT,
+  "terminalFailureReason" TEXT,
+  "nextAttemptAt" TIMESTAMP(3),
+  "lastAttemptAt" TIMESTAMP(3),
+  "deliveredAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "UserNotificationDeliveryAttempt_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "notification_delivery_status_due_idx"
+ON "UserNotificationDeliveryAttempt"("status", "nextAttemptAt", "createdAt");
+
+CREATE INDEX "notification_delivery_user_channel_status_idx"
+ON "UserNotificationDeliveryAttempt"("userId", "channel", "status");
+
+CREATE INDEX "notification_delivery_notification_channel_idx"
+ON "UserNotificationDeliveryAttempt"("notificationId", "channel", "createdAt");
+
+ALTER TABLE "UserNotificationDeliveryAttempt"
+ADD CONSTRAINT "UserNotificationDeliveryAttempt_notificationId_fkey"
+FOREIGN KEY ("notificationId") REFERENCES "UserNotification"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "UserNotificationDeliveryAttempt"
+ADD CONSTRAINT "UserNotificationDeliveryAttempt_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "UserAccount"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -198,17 +198,30 @@ enum UserNotificationType {
   optimization_failed
 }
 
+enum UserNotificationDeliveryChannel {
+  email
+  push
+}
+
+enum UserNotificationDeliveryStatus {
+  queued
+  sending
+  retrying
+  delivered
+  failed
+}
+
 model UserAccount {
-  id                      String                         @id @default(uuid()) @db.Uuid
-  email                   String                         @unique
+  id                      String                            @id @default(uuid()) @db.Uuid
+  email                   String                            @unique
   passwordHash            String
   displayName             String
-  role                    UserRole                       @default(customer)
-  status                  UserStatus                     @default(active)
-  preferredRegionId       String?                        @db.Uuid
+  role                    UserRole                          @default(customer)
+  status                  UserStatus                        @default(active)
+  preferredRegionId       String?                           @db.Uuid
   lastLoginAt             DateTime?
-  createdAt               DateTime                       @default(now())
-  updatedAt               DateTime                       @updatedAt
+  createdAt               DateTime                          @default(now())
+  updatedAt               DateTime                          @updatedAt
   shoppingLists           ShoppingList[]
   optimizationRuns        OptimizationRun[]
   receiptRecords          ReceiptRecord[]
@@ -219,8 +232,9 @@ model UserAccount {
   sessions                UserSession[]
   missingProductRequests  MissingProductRequest[]
   notifications           UserNotification[]
+  notificationDeliveries  UserNotificationDeliveryAttempt[]
   notificationPreference  UserNotificationPreference?
-  preferredRegion         Region?                        @relation("UserPreferredRegion", fields: [preferredRegionId], references: [id], onDelete: SetNull)
+  preferredRegion         Region?                           @relation("UserPreferredRegion", fields: [preferredRegionId], references: [id], onDelete: SetNull)
 }
 
 model UserSession {
@@ -371,20 +385,45 @@ model UserNotificationPreference {
 }
 
 model UserNotification {
-  id           String               @id @default(uuid()) @db.Uuid
-  userId       String               @db.Uuid
-  type         UserNotificationType
-  title        String
-  message      String
-  resourceType String?
-  resourceId   String?
-  metadata     Json?
-  readAt       DateTime?
-  createdAt    DateTime             @default(now())
-  user         UserAccount          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id               String                            @id @default(uuid()) @db.Uuid
+  userId           String                            @db.Uuid
+  type             UserNotificationType
+  title            String
+  message          String
+  resourceType     String?
+  resourceId       String?
+  metadata         Json?
+  readAt           DateTime?
+  createdAt        DateTime                          @default(now())
+  user             UserAccount                       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  deliveryAttempts UserNotificationDeliveryAttempt[]
 
   @@index([userId, readAt, createdAt])
   @@index([type, createdAt])
+}
+
+model UserNotificationDeliveryAttempt {
+  id                    String                          @id @default(uuid()) @db.Uuid
+  notificationId        String                          @db.Uuid
+  userId                String                          @db.Uuid
+  channel               UserNotificationDeliveryChannel
+  status                UserNotificationDeliveryStatus  @default(queued)
+  attemptCount          Int                             @default(0)
+  maxAttempts           Int                             @default(3)
+  providerMessageId     String?
+  lastFailureReason     String?
+  terminalFailureReason String?
+  nextAttemptAt         DateTime?
+  lastAttemptAt         DateTime?
+  deliveredAt           DateTime?
+  createdAt             DateTime                        @default(now())
+  updatedAt             DateTime                        @updatedAt
+  notification          UserNotification                @relation(fields: [notificationId], references: [id], onDelete: Cascade)
+  user                  UserAccount                     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([status, nextAttemptAt, createdAt], map: "notification_delivery_status_due_idx")
+  @@index([userId, channel, status], map: "notification_delivery_user_channel_status_idx")
+  @@index([notificationId, channel, createdAt], map: "notification_delivery_notification_channel_idx")
 }
 
 model CatalogProductAlias {

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,5 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { type Prisma, type UserNotificationType } from '@prisma/client';
+import {
+  type Prisma,
+  type UserNotificationDeliveryChannel,
+  type UserNotificationDeliveryStatus,
+  type UserNotificationType,
+} from '@prisma/client';
 
 import { PrismaService } from '../persistence/prisma.service';
 
@@ -101,6 +106,103 @@ export class NotificationsService {
     });
   }
 
+  async createDeliveryAttempt(input: {
+    notificationId: string;
+    userId: string;
+    channel: UserNotificationDeliveryChannel;
+    maxAttempts?: number;
+    nextAttemptAt?: Date;
+  }) {
+    return this.prisma.userNotificationDeliveryAttempt.create({
+      data: {
+        notificationId: input.notificationId,
+        userId: input.userId,
+        channel: input.channel,
+        maxAttempts: input.maxAttempts ?? 3,
+        nextAttemptAt: input.nextAttemptAt,
+      },
+    });
+  }
+
+  async listDeliveryAttempts(input: {
+    userId?: string;
+    notificationId?: string;
+    channel?: UserNotificationDeliveryChannel;
+    status?: UserNotificationDeliveryStatus;
+    dueOnly?: boolean;
+    take?: number;
+  }) {
+    return this.prisma.userNotificationDeliveryAttempt.findMany({
+      where: {
+        userId: input.userId,
+        notificationId: input.notificationId,
+        channel: input.channel,
+        status: input.status,
+        ...(input.dueOnly
+          ? {
+              OR: [{ nextAttemptAt: null }, { nextAttemptAt: { lte: new Date() } }],
+            }
+          : {}),
+      },
+      orderBy: [{ nextAttemptAt: 'asc' }, { createdAt: 'asc' }],
+      take: input.take ?? 100,
+    });
+  }
+
+  async markDeliverySending(attemptId: string) {
+    const attempt = await this.findDeliveryAttempt(attemptId);
+    return this.prisma.userNotificationDeliveryAttempt.update({
+      where: { id: attempt.id },
+      data: {
+        status: 'sending',
+        attemptCount: { increment: 1 },
+        lastAttemptAt: new Date(),
+      },
+    });
+  }
+
+  async markDeliveryDelivered(
+    attemptId: string,
+    input: { providerMessageId?: string } = {},
+  ) {
+    const attempt = await this.findDeliveryAttempt(attemptId);
+    return this.prisma.userNotificationDeliveryAttempt.update({
+      where: { id: attempt.id },
+      data: {
+        status: 'delivered',
+        providerMessageId: input.providerMessageId,
+        lastFailureReason: null,
+        terminalFailureReason: null,
+        nextAttemptAt: null,
+        deliveredAt: new Date(),
+      },
+    });
+  }
+
+  async markDeliveryFailed(
+    attemptId: string,
+    input: {
+      reason: string;
+      retryable: boolean;
+      nextAttemptAt?: Date;
+    },
+  ) {
+    const attempt = await this.findDeliveryAttempt(attemptId);
+    const shouldRetry =
+      input.retryable && attempt.attemptCount < attempt.maxAttempts;
+    return this.prisma.userNotificationDeliveryAttempt.update({
+      where: { id: attempt.id },
+      data: {
+        status: shouldRetry ? 'retrying' : 'failed',
+        lastFailureReason: input.reason.slice(0, 500),
+        terminalFailureReason: shouldRetry
+          ? null
+          : input.reason.slice(0, 500),
+        nextAttemptAt: shouldRetry ? input.nextAttemptAt : null,
+      },
+    });
+  }
+
   async notifyPriceDropForProduct(input: {
     catalogProductId: string;
     productName: string;
@@ -155,5 +257,15 @@ export class NotificationsService {
       return preferences.receiptOutcomesEnabled;
     }
     return preferences.optimizationReadyEnabled;
+  }
+
+  private async findDeliveryAttempt(attemptId: string) {
+    const attempt = await this.prisma.userNotificationDeliveryAttempt.findUnique({
+      where: { id: attemptId },
+    });
+    if (!attempt) {
+      throw new NotFoundException('Tentativa de entrega nao encontrada');
+    }
+    return attempt;
   }
 }

--- a/backend/test/unit/notifications/notifications.service.spec.ts
+++ b/backend/test/unit/notifications/notifications.service.spec.ts
@@ -62,4 +62,150 @@ describe('NotificationsService', () => {
 
     expect(prisma.userNotification.create).toHaveBeenCalledTimes(2);
   });
+
+  it('creates queued delivery attempts without sending to external providers', async () => {
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        create: jest.fn().mockResolvedValue({
+          id: 'attempt-1',
+          notificationId: 'notification-1',
+          channel: 'email',
+          status: 'queued',
+        }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.createDeliveryAttempt({
+      notificationId: 'notification-1',
+      userId: 'user-1',
+      channel: 'email',
+      maxAttempts: 5,
+    });
+
+    expect(prisma.userNotificationDeliveryAttempt.create).toHaveBeenCalledWith({
+      data: {
+        notificationId: 'notification-1',
+        userId: 'user-1',
+        channel: 'email',
+        maxAttempts: 5,
+        nextAttemptAt: undefined,
+      },
+    });
+  });
+
+  it('marks a delivery attempt as sending and increments attempt count', async () => {
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'attempt-1',
+          attemptCount: 0,
+          maxAttempts: 3,
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'attempt-1' }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.markDeliverySending('attempt-1');
+
+    expect(prisma.userNotificationDeliveryAttempt.update).toHaveBeenCalledWith({
+      where: { id: 'attempt-1' },
+      data: expect.objectContaining({
+        status: 'sending',
+        attemptCount: { increment: 1 },
+        lastAttemptAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it('marks retryable delivery failure as retrying while attempts remain', async () => {
+    const nextAttemptAt = new Date('2026-06-26T03:15:00.000Z');
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'attempt-1',
+          attemptCount: 1,
+          maxAttempts: 3,
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'attempt-1' }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.markDeliveryFailed('attempt-1', {
+      reason: 'provider_rate_limited',
+      retryable: true,
+      nextAttemptAt,
+    });
+
+    expect(prisma.userNotificationDeliveryAttempt.update).toHaveBeenCalledWith({
+      where: { id: 'attempt-1' },
+      data: {
+        status: 'retrying',
+        lastFailureReason: 'provider_rate_limited',
+        terminalFailureReason: null,
+        nextAttemptAt,
+      },
+    });
+  });
+
+  it('marks non-retryable delivery failure as terminal failed', async () => {
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'attempt-1',
+          attemptCount: 2,
+          maxAttempts: 3,
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'attempt-1' }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.markDeliveryFailed('attempt-1', {
+      reason: 'email_unsubscribed',
+      retryable: false,
+    });
+
+    expect(prisma.userNotificationDeliveryAttempt.update).toHaveBeenCalledWith({
+      where: { id: 'attempt-1' },
+      data: {
+        status: 'failed',
+        lastFailureReason: 'email_unsubscribed',
+        terminalFailureReason: 'email_unsubscribed',
+        nextAttemptAt: null,
+      },
+    });
+  });
+
+  it('marks delivery success with provider message id', async () => {
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'attempt-1',
+          attemptCount: 1,
+          maxAttempts: 3,
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'attempt-1' }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.markDeliveryDelivered('attempt-1', {
+      providerMessageId: 'provider-message-1',
+    });
+
+    expect(prisma.userNotificationDeliveryAttempt.update).toHaveBeenCalledWith({
+      where: { id: 'attempt-1' },
+      data: expect.objectContaining({
+        status: 'delivered',
+        providerMessageId: 'provider-message-1',
+        lastFailureReason: null,
+        terminalFailureReason: null,
+        nextAttemptAt: null,
+        deliveredAt: expect.any(Date),
+      }),
+    });
+  });
 });

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -627,7 +627,7 @@ channels without enabling provider sends prematurely.
 
 - [X] T262 Add `master` validation triggers for CI and Release Readiness while keeping Deploy Homolog Server scoped to `homolog` or manual dispatch in `.github/workflows/`
 - [X] T263 Document the Phase 35 email, push, quiet-hours, retry, and release-validation plan in `docs/product/notification-center.md`
-- [ ] T264 Add notification delivery persistence for channel attempts, provider message ids, retry state, and terminal failure reasons in `backend/prisma/` and `backend/src/notifications/`
+- [X] T264 Add notification delivery persistence for channel attempts, provider message ids, retry state, and terminal failure reasons in `backend/prisma/` and `backend/src/notifications/`
 - [ ] T265 Add user email destination verification, unsubscribe/category mapping, and email delivery queue integration in `backend/src/notifications/` and `backend/src/users/`
 - [ ] T266 Add mobile push device registration, token refresh/revocation, and authenticated device listing in `backend/src/notifications/` and `mobile/lib/features/`
 - [ ] T267 Add quiet-hour preferences with timezone-aware deferral for non-critical notifications in `backend/src/notifications/`, `web/src/components/design-system/`, and `mobile/lib/features/`


### PR DESCRIPTION
## Summary
- Adds Prisma enums/table for notification delivery attempts by email/push channel.
- Tracks delivery status, attempt counts, provider message ids, retry scheduling, and terminal failure reasons.
- Adds notification service methods for queueing attempts, marking sending, delivered, retryable failure, and terminal failure.
- Marks Spec Kit T264 complete.

## Validation
- `npm run db:generate`
- `npx prisma format`
- `npm run test -- notifications.service.spec.ts`
- `npm run build`
- `npm run lint`
- `npm run db:migrate:policy`
- `npm run test`
- `DATABASE_URL=postgresql://pricely:pricely@localhost:5432/pricely_validate npx prisma validate`
- `git diff --check`

Closes #443