### PR TITLE
Test: stabilize checklist smoke in WebKit

### DIFF
--- a/web/e2e/mvp-smoke.spec.ts
+++ b/web/e2e/mvp-smoke.spec.ts
@@ -724,7 +724,16 @@ test('MVP shopper flow covers sign-in, city, list, optimization, checklist, and 
   await expect(
     page.getByRole('heading', { name: 'Checklist de compra' }),
   ).toBeVisible();
-  await page.getByRole('checkbox').click();
+  await Promise.all([
+    page.waitForResponse((response) =>
+      response.url().includes('/shopping-lists/list-1/items/item-1/purchase-status'),
+    ),
+    page
+      .getByRole('checkbox', {
+        name: 'Marcar Arroz tipo 1 1kg como comprado',
+      })
+      .click(),
+  ]);
   await expect(page.getByText('Comprado', { exact: true })).toBeVisible();
 });
 


### PR DESCRIPTION
## Summary
- Stabilizes the MVP shopper smoke checklist step in WebKit.
- Targets the named checklist checkbox instead of the first checkbox on the page.
- Waits for the purchase-status API response before asserting the `Comprado` badge.

## Validation
- `npx playwright test e2e/mvp-smoke.spec.ts --project=webkit --grep MVP-shopper-flow`
- `npx playwright test e2e/mvp-smoke.spec.ts --project=chromium --grep MVP-shopper-flow`
- `npm run lint`
- `git diff --check`

Closes #445