### PR TITLE
Feat: add email notification destination flow

### DIFF
--- a/backend/prisma/migrations/20260626040000_email_notification_destination/migration.sql
+++ b/backend/prisma/migrations/20260626040000_email_notification_destination/migration.sql
@@ -1,0 +1,47 @@
+CREATE TYPE "UserEmailNotificationStatus" AS ENUM (
+  'pending',
+  'verified',
+  'unsubscribed'
+);
+
+CREATE TABLE "UserEmailNotificationDestination" (
+  "id" UUID NOT NULL,
+  "userId" UUID NOT NULL,
+  "email" TEXT NOT NULL,
+  "status" "UserEmailNotificationStatus" NOT NULL DEFAULT 'pending',
+  "verificationTokenHash" TEXT,
+  "unsubscribeTokenHash" TEXT NOT NULL,
+  "verifiedAt" TIMESTAMP(3),
+  "unsubscribedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "UserEmailNotificationDestination_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "UserNotificationDeliveryAttempt"
+ADD COLUMN "emailDestinationId" UUID;
+
+CREATE UNIQUE INDEX "UserEmailNotificationDestination_userId_key"
+ON "UserEmailNotificationDestination"("userId");
+
+CREATE UNIQUE INDEX "UserEmailNotificationDestination_verificationTokenHash_key"
+ON "UserEmailNotificationDestination"("verificationTokenHash");
+
+CREATE UNIQUE INDEX "UserEmailNotificationDestination_unsubscribeTokenHash_key"
+ON "UserEmailNotificationDestination"("unsubscribeTokenHash");
+
+CREATE INDEX "UserEmailNotificationDestination_email_status_idx"
+ON "UserEmailNotificationDestination"("email", "status");
+
+CREATE INDEX "notification_delivery_email_destination_idx"
+ON "UserNotificationDeliveryAttempt"("emailDestinationId", "status");
+
+ALTER TABLE "UserEmailNotificationDestination"
+ADD CONSTRAINT "UserEmailNotificationDestination_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "UserAccount"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "UserNotificationDeliveryAttempt"
+ADD CONSTRAINT "UserNotificationDeliveryAttempt_emailDestinationId_fkey"
+FOREIGN KEY ("emailDestinationId") REFERENCES "UserEmailNotificationDestination"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -211,6 +211,12 @@ enum UserNotificationDeliveryStatus {
   failed
 }
 
+enum UserEmailNotificationStatus {
+  pending
+  verified
+  unsubscribed
+}
+
 model UserAccount {
   id                      String                            @id @default(uuid()) @db.Uuid
   email                   String                            @unique
@@ -233,6 +239,7 @@ model UserAccount {
   missingProductRequests  MissingProductRequest[]
   notifications           UserNotification[]
   notificationDeliveries  UserNotificationDeliveryAttempt[]
+  emailNotificationTarget UserEmailNotificationDestination?
   notificationPreference  UserNotificationPreference?
   preferredRegion         Region?                           @relation("UserPreferredRegion", fields: [preferredRegionId], references: [id], onDelete: SetNull)
 }
@@ -384,6 +391,23 @@ model UserNotificationPreference {
   user                     UserAccount @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
+model UserEmailNotificationDestination {
+  id                    String                            @id @default(uuid()) @db.Uuid
+  userId                String                            @unique @db.Uuid
+  email                 String
+  status                UserEmailNotificationStatus       @default(pending)
+  verificationTokenHash String?                           @unique
+  unsubscribeTokenHash  String                            @unique
+  verifiedAt            DateTime?
+  unsubscribedAt        DateTime?
+  createdAt             DateTime                          @default(now())
+  updatedAt             DateTime                          @updatedAt
+  user                  UserAccount                       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  deliveryAttempts      UserNotificationDeliveryAttempt[]
+
+  @@index([email, status])
+}
+
 model UserNotification {
   id               String                            @id @default(uuid()) @db.Uuid
   userId           String                            @db.Uuid
@@ -403,27 +427,30 @@ model UserNotification {
 }
 
 model UserNotificationDeliveryAttempt {
-  id                    String                          @id @default(uuid()) @db.Uuid
-  notificationId        String                          @db.Uuid
-  userId                String                          @db.Uuid
+  id                    String                            @id @default(uuid()) @db.Uuid
+  notificationId        String                            @db.Uuid
+  userId                String                            @db.Uuid
+  emailDestinationId    String?                           @db.Uuid
   channel               UserNotificationDeliveryChannel
-  status                UserNotificationDeliveryStatus  @default(queued)
-  attemptCount          Int                             @default(0)
-  maxAttempts           Int                             @default(3)
+  status                UserNotificationDeliveryStatus    @default(queued)
+  attemptCount          Int                               @default(0)
+  maxAttempts           Int                               @default(3)
   providerMessageId     String?
   lastFailureReason     String?
   terminalFailureReason String?
   nextAttemptAt         DateTime?
   lastAttemptAt         DateTime?
   deliveredAt           DateTime?
-  createdAt             DateTime                        @default(now())
-  updatedAt             DateTime                        @updatedAt
-  notification          UserNotification                @relation(fields: [notificationId], references: [id], onDelete: Cascade)
-  user                  UserAccount                     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt             DateTime                          @default(now())
+  updatedAt             DateTime                          @updatedAt
+  notification          UserNotification                  @relation(fields: [notificationId], references: [id], onDelete: Cascade)
+  user                  UserAccount                       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  emailDestination      UserEmailNotificationDestination? @relation(fields: [emailDestinationId], references: [id], onDelete: SetNull)
 
   @@index([status, nextAttemptAt, createdAt], map: "notification_delivery_status_due_idx")
   @@index([userId, channel, status], map: "notification_delivery_user_channel_status_idx")
   @@index([notificationId, channel, createdAt], map: "notification_delivery_notification_channel_idx")
+  @@index([emailDestinationId, status], map: "notification_delivery_email_destination_idx")
 }
 
 model CatalogProductAlias {

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -8,7 +8,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { IsBoolean, IsOptional } from 'class-validator';
+import { IsBoolean, IsEmail, IsIn, IsOptional, IsString } from 'class-validator';
 
 import { type JwtUserPayload } from '../auth/auth.types';
 import { CurrentUser } from '../common/auth/current-user.decorator';
@@ -31,14 +31,37 @@ class UpdateNotificationPreferencesDto {
   @IsOptional()
   @IsBoolean()
   optimizationReadyEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  emailEnabled?: boolean;
+}
+
+class RequestEmailDestinationDto {
+  @IsEmail()
+  email!: string;
+}
+
+class ConfirmEmailDestinationDto {
+  @IsString()
+  token!: string;
+}
+
+class UnsubscribeEmailDto {
+  @IsString()
+  token!: string;
+
+  @IsOptional()
+  @IsIn(['all', 'price_drop', 'receipt_outcome', 'optimization'])
+  category?: 'all' | 'price_drop' | 'receipt_outcome' | 'optimization';
 }
 
 @Controller()
-@UseGuards(JwtAuthGuard)
 export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}
 
   @Get('notifications')
+  @UseGuards(JwtAuthGuard)
   list(
     @CurrentUser() user: JwtUserPayload,
     @Query('unreadOnly') unreadOnly?: string,
@@ -47,25 +70,57 @@ export class NotificationsController {
   }
 
   @Patch('notifications/:id/read')
+  @UseGuards(JwtAuthGuard)
   markRead(@CurrentUser() user: JwtUserPayload, @Param('id') id: string) {
     return this.notificationsService.markRead(user.sub, id);
   }
 
   @Post('notifications/read-all')
+  @UseGuards(JwtAuthGuard)
   markAllRead(@CurrentUser() user: JwtUserPayload) {
     return this.notificationsService.markAllRead(user.sub);
   }
 
   @Get('notification-preferences')
+  @UseGuards(JwtAuthGuard)
   preferences(@CurrentUser() user: JwtUserPayload) {
     return this.notificationsService.getPreferences(user.sub);
   }
 
   @Patch('notification-preferences')
+  @UseGuards(JwtAuthGuard)
   updatePreferences(
     @CurrentUser() user: JwtUserPayload,
     @Body() body: UpdateNotificationPreferencesDto,
   ) {
     return this.notificationsService.updatePreferences(user.sub, body);
+  }
+
+  @Get('notification-email-destination')
+  @UseGuards(JwtAuthGuard)
+  emailDestination(@CurrentUser() user: JwtUserPayload) {
+    return this.notificationsService.getEmailDestination(user.sub);
+  }
+
+  @Post('notification-email-destination')
+  @UseGuards(JwtAuthGuard)
+  requestEmailDestination(
+    @CurrentUser() user: JwtUserPayload,
+    @Body() body: RequestEmailDestinationDto,
+  ) {
+    return this.notificationsService.requestEmailDestination(
+      user.sub,
+      body.email,
+    );
+  }
+
+  @Post('notification-email-destination/confirm')
+  confirmEmailDestination(@Body() body: ConfirmEmailDestinationDto) {
+    return this.notificationsService.confirmEmailDestination(body.token);
+  }
+
+  @Post('notification-email-unsubscribe')
+  unsubscribeEmail(@Body() body: UnsubscribeEmailDto) {
+    return this.notificationsService.unsubscribeEmail(body);
   }
 }

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,12 +1,22 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { randomBytes, createHash } from 'node:crypto';
+
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import {
   type Prisma,
+  type UserEmailNotificationDestination,
   type UserNotificationDeliveryChannel,
   type UserNotificationDeliveryStatus,
+  type UserNotificationPreference,
   type UserNotificationType,
 } from '@prisma/client';
 
 import { PrismaService } from '../persistence/prisma.service';
+
+type EmailUnsubscribeCategory =
+  | 'all'
+  | 'price_drop'
+  | 'receipt_outcome'
+  | 'optimization';
 
 @Injectable()
 export class NotificationsService {
@@ -38,22 +48,143 @@ export class NotificationsService {
       priceDropsEnabled?: boolean;
       receiptOutcomesEnabled?: boolean;
       optimizationReadyEnabled?: boolean;
+      emailEnabled?: boolean;
     },
   ) {
+    const emailEnabled =
+      input.emailEnabled === true
+        ? await this.hasVerifiedEmailDestination(userId)
+        : input.emailEnabled;
+
     return this.prisma.userNotificationPreference.upsert({
       where: { userId },
       create: {
         userId,
         ...input,
-        emailEnabled: false,
+        emailEnabled: emailEnabled ?? false,
         pushEnabled: false,
       },
       update: {
         ...input,
-        emailEnabled: false,
+        emailEnabled,
         pushEnabled: false,
       },
     });
+  }
+
+  async getEmailDestination(userId: string) {
+    return this.prisma.userEmailNotificationDestination.findUnique({
+      where: { userId },
+      select: {
+        id: true,
+        email: true,
+        status: true,
+        verifiedAt: true,
+        unsubscribedAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  async requestEmailDestination(userId: string, email: string) {
+    const normalizedEmail = this.normalizeEmail(email);
+    const verificationToken = this.createToken();
+    const unsubscribeToken = this.createToken();
+    const existing =
+      await this.prisma.userEmailNotificationDestination.findUnique({
+        where: { userId },
+      });
+
+    const destination = existing
+      ? await this.prisma.userEmailNotificationDestination.update({
+          where: { userId },
+          data: {
+            email: normalizedEmail,
+            status: 'pending',
+            verificationTokenHash: this.hashToken(verificationToken),
+            verifiedAt: null,
+            unsubscribedAt: null,
+          },
+        })
+      : await this.prisma.userEmailNotificationDestination.create({
+          data: {
+            userId,
+            email: normalizedEmail,
+            status: 'pending',
+            verificationTokenHash: this.hashToken(verificationToken),
+            unsubscribeTokenHash: this.hashToken(unsubscribeToken),
+          },
+        });
+
+    await this.updatePreferences(userId, { emailEnabled: false });
+
+    return this.toEmailDestinationResponse(destination, {
+      verificationToken,
+      unsubscribeToken: existing ? undefined : unsubscribeToken,
+    });
+  }
+
+  async confirmEmailDestination(token: string) {
+    const destination =
+      await this.prisma.userEmailNotificationDestination.findFirst({
+        where: {
+          verificationTokenHash: this.hashToken(token),
+          status: 'pending',
+        },
+      });
+    if (!destination) {
+      throw new NotFoundException('Destino de email nao encontrado');
+    }
+
+    const updated = await this.prisma.userEmailNotificationDestination.update({
+      where: { id: destination.id },
+      data: {
+        status: 'verified',
+        verificationTokenHash: null,
+        verifiedAt: new Date(),
+        unsubscribedAt: null,
+      },
+    });
+    await this.updatePreferences(updated.userId, { emailEnabled: true });
+
+    return this.toEmailDestinationResponse(updated);
+  }
+
+  async unsubscribeEmail(input: {
+    token: string;
+    category?: EmailUnsubscribeCategory;
+  }) {
+    const destination =
+      await this.prisma.userEmailNotificationDestination.findFirst({
+        where: { unsubscribeTokenHash: this.hashToken(input.token) },
+      });
+    if (!destination) {
+      throw new NotFoundException('Destino de email nao encontrado');
+    }
+
+    const category = input.category ?? 'all';
+    await this.prisma.userNotificationPreference.upsert({
+      where: { userId: destination.userId },
+      create: {
+        userId: destination.userId,
+        ...this.unsubscribePreferencePatch(category),
+      },
+      update: this.unsubscribePreferencePatch(category),
+    });
+
+    if (category === 'all') {
+      const updated = await this.prisma.userEmailNotificationDestination.update({
+        where: { id: destination.id },
+        data: {
+          status: 'unsubscribed',
+          unsubscribedAt: new Date(),
+        },
+      });
+      return this.toEmailDestinationResponse(updated);
+    }
+
+    return this.toEmailDestinationResponse(destination);
   }
 
   async markRead(userId: string, notificationId: string) {
@@ -93,7 +224,7 @@ export class NotificationsService {
     ) {
       return null;
     }
-    return this.prisma.userNotification.create({
+    const notification = await this.prisma.userNotification.create({
       data: {
         userId: input.userId,
         type: input.type,
@@ -104,6 +235,8 @@ export class NotificationsService {
         metadata: input.metadata,
       },
     });
+    await this.queueEmailDeliveryIfEligible(notification, preferences);
+    return notification;
   }
 
   async createDeliveryAttempt(input: {
@@ -112,6 +245,7 @@ export class NotificationsService {
     channel: UserNotificationDeliveryChannel;
     maxAttempts?: number;
     nextAttemptAt?: Date;
+    emailDestinationId?: string;
   }) {
     return this.prisma.userNotificationDeliveryAttempt.create({
       data: {
@@ -120,6 +254,7 @@ export class NotificationsService {
         channel: input.channel,
         maxAttempts: input.maxAttempts ?? 3,
         nextAttemptAt: input.nextAttemptAt,
+        emailDestinationId: input.emailDestinationId,
       },
     });
   }
@@ -257,6 +392,93 @@ export class NotificationsService {
       return preferences.receiptOutcomesEnabled;
     }
     return preferences.optimizationReadyEnabled;
+  }
+
+  private async queueEmailDeliveryIfEligible(
+    notification: {
+      id: string;
+      userId: string;
+      type: UserNotificationType;
+    },
+    preferences: UserNotificationPreference,
+  ) {
+    if (
+      !preferences.emailEnabled ||
+      !this.typeEnabled(preferences, notification.type)
+    ) {
+      return;
+    }
+    const destination =
+      await this.prisma.userEmailNotificationDestination.findFirst({
+        where: {
+          userId: notification.userId,
+          status: 'verified',
+        },
+      });
+    if (!destination) {
+      return;
+    }
+    await this.createDeliveryAttempt({
+      notificationId: notification.id,
+      userId: notification.userId,
+      channel: 'email',
+      emailDestinationId: destination.id,
+    });
+  }
+
+  private async hasVerifiedEmailDestination(userId: string) {
+    const count = await this.prisma.userEmailNotificationDestination.count({
+      where: { userId, status: 'verified' },
+    });
+    return count > 0;
+  }
+
+  private unsubscribePreferencePatch(category: EmailUnsubscribeCategory) {
+    if (category === 'all') {
+      return { emailEnabled: false };
+    }
+    if (category === 'price_drop') {
+      return { priceDropsEnabled: false };
+    }
+    if (category === 'receipt_outcome') {
+      return { receiptOutcomesEnabled: false };
+    }
+    return { optimizationReadyEnabled: false };
+  }
+
+  private toEmailDestinationResponse(
+    destination: UserEmailNotificationDestination,
+    tokens: { verificationToken?: string; unsubscribeToken?: string } = {},
+  ) {
+    return {
+      id: destination.id,
+      email: destination.email,
+      status: destination.status,
+      verifiedAt: destination.verifiedAt,
+      unsubscribedAt: destination.unsubscribedAt,
+      verificationToken:
+        process.env.NODE_ENV === 'production'
+          ? undefined
+          : tokens.verificationToken,
+      unsubscribeToken:
+        process.env.NODE_ENV === 'production' ? undefined : tokens.unsubscribeToken,
+    };
+  }
+
+  private normalizeEmail(email: string) {
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail.includes('@')) {
+      throw new BadRequestException('Email invalido');
+    }
+    return normalizedEmail;
+  }
+
+  private createToken() {
+    return randomBytes(32).toString('base64url');
+  }
+
+  private hashToken(token: string) {
+    return createHash('sha256').update(token.trim()).digest('hex');
   }
 
   private async findDeliveryAttempt(attemptId: string) {

--- a/backend/test/unit/notifications/notifications.service.spec.ts
+++ b/backend/test/unit/notifications/notifications.service.spec.ts
@@ -90,7 +90,194 @@ describe('NotificationsService', () => {
         channel: 'email',
         maxAttempts: 5,
         nextAttemptAt: undefined,
+        emailDestinationId: undefined,
       },
+    });
+  });
+
+  it('does not enable email preferences until the destination is verified', async () => {
+    const prisma = {
+      userEmailNotificationDestination: {
+        count: jest.fn().mockResolvedValue(0),
+      },
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({ emailEnabled: false }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.updatePreferences('user-1', { emailEnabled: true });
+
+    expect(prisma.userNotificationPreference.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ emailEnabled: false }),
+        update: expect.objectContaining({ emailEnabled: false }),
+      }),
+    );
+  });
+
+  it('requests email destination verification with normalized email tokens', async () => {
+    const prisma = {
+      userEmailNotificationDestination: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({
+          id: 'destination-1',
+          userId: 'user-1',
+          email: 'cliente@pricely.local',
+          status: 'pending',
+          verifiedAt: null,
+          unsubscribedAt: null,
+        }),
+      },
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({ emailEnabled: false }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    const result = await service.requestEmailDestination(
+      'user-1',
+      ' Cliente@Pricely.Local ',
+    );
+
+    expect(prisma.userEmailNotificationDestination.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'user-1',
+        email: 'cliente@pricely.local',
+        status: 'pending',
+        verificationTokenHash: expect.any(String),
+        unsubscribeTokenHash: expect.any(String),
+      }),
+    });
+    expect(result.verificationToken).toEqual(expect.any(String));
+    expect(result.unsubscribeToken).toEqual(expect.any(String));
+  });
+
+  it('confirms email destination and enables email preferences', async () => {
+    const prisma = {
+      userEmailNotificationDestination: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'destination-1',
+          userId: 'user-1',
+          email: 'cliente@pricely.local',
+          status: 'pending',
+        }),
+        update: jest.fn().mockResolvedValue({
+          id: 'destination-1',
+          userId: 'user-1',
+          email: 'cliente@pricely.local',
+          status: 'verified',
+          verifiedAt: new Date('2026-06-26T04:00:00.000Z'),
+          unsubscribedAt: null,
+        }),
+        count: jest.fn().mockResolvedValue(1),
+      },
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({ emailEnabled: true }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.confirmEmailDestination('verification-token');
+
+    expect(prisma.userEmailNotificationDestination.update).toHaveBeenCalledWith({
+      where: { id: 'destination-1' },
+      data: expect.objectContaining({
+        status: 'verified',
+        verificationTokenHash: null,
+        verifiedAt: expect.any(Date),
+        unsubscribedAt: null,
+      }),
+    });
+    expect(prisma.userNotificationPreference.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ emailEnabled: true }),
+      }),
+    );
+  });
+
+  it('maps email unsubscribe category to notification preferences', async () => {
+    const prisma = {
+      userEmailNotificationDestination: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'destination-1',
+          userId: 'user-1',
+          email: 'cliente@pricely.local',
+          status: 'verified',
+          verifiedAt: new Date('2026-06-26T04:00:00.000Z'),
+          unsubscribedAt: null,
+        }),
+      },
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({
+          receiptOutcomesEnabled: false,
+        }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.unsubscribeEmail({
+      token: 'unsubscribe-token',
+      category: 'receipt_outcome',
+    });
+
+    expect(prisma.userNotificationPreference.upsert).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      create: {
+        userId: 'user-1',
+        receiptOutcomesEnabled: false,
+      },
+      update: {
+        receiptOutcomesEnabled: false,
+      },
+    });
+  });
+
+  it('queues email delivery attempts for verified destinations and enabled categories', async () => {
+    const prisma = {
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({
+          inAppEnabled: true,
+          emailEnabled: true,
+          priceDropsEnabled: true,
+          receiptOutcomesEnabled: true,
+          optimizationReadyEnabled: true,
+        }),
+      },
+      userNotification: {
+        create: jest.fn().mockResolvedValue({
+          id: 'notification-1',
+          userId: 'user-1',
+          type: 'price_drop',
+        }),
+      },
+      userEmailNotificationDestination: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'destination-1',
+          userId: 'user-1',
+          status: 'verified',
+        }),
+      },
+      userNotificationDeliveryAttempt: {
+        create: jest.fn().mockResolvedValue({ id: 'attempt-1' }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.create({
+      userId: 'user-1',
+      type: 'price_drop',
+      title: 'Preco menor',
+      message: 'Novo preco disponivel.',
+    });
+
+    expect(prisma.userNotificationDeliveryAttempt.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        notificationId: 'notification-1',
+        userId: 'user-1',
+        channel: 'email',
+        emailDestinationId: 'destination-1',
+      }),
     });
   });
 

--- a/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
+++ b/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
@@ -393,15 +393,56 @@ paths:
           description: Unread notifications updated
   /notification-preferences:
     get:
-      summary: Fetch in-app notification category preferences
+      summary: Fetch notification channel and category preferences
       responses:
         '200':
           description: Preferences returned
     patch:
-      summary: Update in-app notification category preferences
+      summary: Update notification channel and category preferences
       responses:
         '200':
-          description: Preferences updated; email and push remain disabled
+          description: Preferences updated; email can be enabled after destination verification
+  /notification-email-destination:
+    get:
+      summary: Fetch the authenticated user's email notification destination
+      responses:
+        '200':
+          description: Email destination returned when configured
+    post:
+      summary: Request verification for an email notification destination
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailDestinationRequest'
+      responses:
+        '201':
+          description: Verification request recorded; external email delivery remains provider-gated
+  /notification-email-destination/confirm:
+    post:
+      summary: Confirm an email notification destination by verification token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailTokenRequest'
+      responses:
+        '201':
+          description: Destination verified and email notifications enabled
+  /notification-email-unsubscribe:
+    post:
+      summary: Disable all email notifications or one mapped category by unsubscribe token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailUnsubscribeRequest'
+      responses:
+        '201':
+          description: Email preference updated
   /receipts:
     post:
       summary: Submit a receipt contribution from manual items or an NFC-e QR URL
@@ -761,6 +802,46 @@ components:
           format: email
         password:
           type: string
+    EmailDestinationRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+    EmailTokenRequest:
+      type: object
+      required: [token]
+      properties:
+        token:
+          type: string
+    EmailUnsubscribeRequest:
+      type: object
+      required: [token]
+      properties:
+        token:
+          type: string
+        category:
+          type: string
+          enum: [all, price_drop, receipt_outcome, optimization]
+    EmailNotificationDestination:
+      type: object
+      required: [id, email, status]
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+          format: email
+        status:
+          type: string
+          enum: [pending, verified, unsubscribed]
+        verifiedAt:
+          type: string
+          format: date-time
+        unsubscribedAt:
+          type: string
+          format: date-time
     AuthSession:
       type: object
       required: [accessToken, user]

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -628,7 +628,7 @@ channels without enabling provider sends prematurely.
 - [X] T262 Add `master` validation triggers for CI and Release Readiness while keeping Deploy Homolog Server scoped to `homolog` or manual dispatch in `.github/workflows/`
 - [X] T263 Document the Phase 35 email, push, quiet-hours, retry, and release-validation plan in `docs/product/notification-center.md`
 - [X] T264 Add notification delivery persistence for channel attempts, provider message ids, retry state, and terminal failure reasons in `backend/prisma/` and `backend/src/notifications/`
-- [ ] T265 Add user email destination verification, unsubscribe/category mapping, and email delivery queue integration in `backend/src/notifications/` and `backend/src/users/`
+- [X] T265 Add user email destination verification, unsubscribe/category mapping, and email delivery queue integration in `backend/src/notifications/` and `backend/src/users/`
 - [ ] T266 Add mobile push device registration, token refresh/revocation, and authenticated device listing in `backend/src/notifications/` and `mobile/lib/features/`
 - [ ] T267 Add quiet-hour preferences with timezone-aware deferral for non-critical notifications in `backend/src/notifications/`, `web/src/components/design-system/`, and `mobile/lib/features/`
 - [ ] T268 Add admin notification delivery diagnostics, retry/cancel controls, and provider-error redaction in `web/src/dashboard/` and `backend/src/admin/`


### PR DESCRIPTION
## Summary
- Adds verified email notification destinations with verification and unsubscribe token storage.
- Adds authenticated email destination endpoints plus public confirm/unsubscribe endpoints.
- Allows `emailEnabled` only after a verified destination exists.
- Queues `email` delivery attempts for verified destinations when notification categories are enabled.
- Updates OpenAPI and marks T265 complete.

## Validation
- `npm run db:generate`
- `npx prisma format`
- `npm run test -- notifications.service.spec.ts`
- `npm run build`
- `npm run lint`
- `npm run db:migrate:policy`
- `DATABASE_URL=postgresql://pricely:pricely@localhost:5432/pricely_validate npx prisma validate`
- `git diff --check`
- `npm run test`

Closes #447