### PR TITLE
Feat: add mobile push device registration

### DIFF
--- a/backend/prisma/migrations/20260626050000_push_notification_devices/migration.sql
+++ b/backend/prisma/migrations/20260626050000_push_notification_devices/migration.sql
@@ -1,0 +1,47 @@
+CREATE TYPE "UserPushDevicePlatform" AS ENUM (
+  'android',
+  'ios'
+);
+
+CREATE TABLE "UserPushDevice" (
+  "id" UUID NOT NULL,
+  "userId" UUID NOT NULL,
+  "platform" "UserPushDevicePlatform" NOT NULL,
+  "deviceTokenHash" TEXT NOT NULL,
+  "deviceTokenTail" VARCHAR(16) NOT NULL,
+  "provider" TEXT NOT NULL DEFAULT 'fcm',
+  "appVersion" TEXT,
+  "locale" TEXT,
+  "timezone" TEXT,
+  "isActive" BOOLEAN NOT NULL DEFAULT true,
+  "revokedAt" TIMESTAMP(3),
+  "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "UserPushDevice_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "UserNotificationDeliveryAttempt"
+ADD COLUMN "pushDeviceId" UUID;
+
+CREATE UNIQUE INDEX "UserPushDevice_deviceTokenHash_key"
+ON "UserPushDevice"("deviceTokenHash");
+
+CREATE INDEX "UserPushDevice_userId_isActive_lastSeenAt_idx"
+ON "UserPushDevice"("userId", "isActive", "lastSeenAt");
+
+CREATE INDEX "UserPushDevice_platform_isActive_idx"
+ON "UserPushDevice"("platform", "isActive");
+
+CREATE INDEX "notification_delivery_push_device_idx"
+ON "UserNotificationDeliveryAttempt"("pushDeviceId", "status");
+
+ALTER TABLE "UserPushDevice"
+ADD CONSTRAINT "UserPushDevice_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "UserAccount"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "UserNotificationDeliveryAttempt"
+ADD CONSTRAINT "UserNotificationDeliveryAttempt_pushDeviceId_fkey"
+FOREIGN KEY ("pushDeviceId") REFERENCES "UserPushDevice"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -217,6 +217,11 @@ enum UserEmailNotificationStatus {
   unsubscribed
 }
 
+enum UserPushDevicePlatform {
+  android
+  ios
+}
+
 model UserAccount {
   id                      String                            @id @default(uuid()) @db.Uuid
   email                   String                            @unique
@@ -240,6 +245,7 @@ model UserAccount {
   notifications           UserNotification[]
   notificationDeliveries  UserNotificationDeliveryAttempt[]
   emailNotificationTarget UserEmailNotificationDestination?
+  pushDevices             UserPushDevice[]
   notificationPreference  UserNotificationPreference?
   preferredRegion         Region?                           @relation("UserPreferredRegion", fields: [preferredRegionId], references: [id], onDelete: SetNull)
 }
@@ -408,6 +414,28 @@ model UserEmailNotificationDestination {
   @@index([email, status])
 }
 
+model UserPushDevice {
+  id               String                            @id @default(uuid()) @db.Uuid
+  userId           String                            @db.Uuid
+  platform         UserPushDevicePlatform
+  deviceTokenHash  String                            @unique
+  deviceTokenTail  String                            @db.VarChar(16)
+  provider         String                            @default("fcm")
+  appVersion       String?
+  locale           String?
+  timezone         String?
+  isActive         Boolean                           @default(true)
+  revokedAt        DateTime?
+  lastSeenAt       DateTime                          @default(now())
+  createdAt        DateTime                          @default(now())
+  updatedAt        DateTime                          @updatedAt
+  user             UserAccount                       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  deliveryAttempts UserNotificationDeliveryAttempt[]
+
+  @@index([userId, isActive, lastSeenAt])
+  @@index([platform, isActive])
+}
+
 model UserNotification {
   id               String                            @id @default(uuid()) @db.Uuid
   userId           String                            @db.Uuid
@@ -431,6 +459,7 @@ model UserNotificationDeliveryAttempt {
   notificationId        String                            @db.Uuid
   userId                String                            @db.Uuid
   emailDestinationId    String?                           @db.Uuid
+  pushDeviceId          String?                           @db.Uuid
   channel               UserNotificationDeliveryChannel
   status                UserNotificationDeliveryStatus    @default(queued)
   attemptCount          Int                               @default(0)
@@ -446,11 +475,13 @@ model UserNotificationDeliveryAttempt {
   notification          UserNotification                  @relation(fields: [notificationId], references: [id], onDelete: Cascade)
   user                  UserAccount                       @relation(fields: [userId], references: [id], onDelete: Cascade)
   emailDestination      UserEmailNotificationDestination? @relation(fields: [emailDestinationId], references: [id], onDelete: SetNull)
+  pushDevice            UserPushDevice?                   @relation(fields: [pushDeviceId], references: [id], onDelete: SetNull)
 
   @@index([status, nextAttemptAt, createdAt], map: "notification_delivery_status_due_idx")
   @@index([userId, channel, status], map: "notification_delivery_user_channel_status_idx")
   @@index([notificationId, channel, createdAt], map: "notification_delivery_notification_channel_idx")
   @@index([emailDestinationId, status], map: "notification_delivery_email_destination_idx")
+  @@index([pushDeviceId, status], map: "notification_delivery_push_device_idx")
 }
 
 model CatalogProductAlias {

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -8,7 +8,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { IsBoolean, IsEmail, IsIn, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsEmail, IsIn, IsOptional, IsString, MinLength } from 'class-validator';
 
 import { type JwtUserPayload } from '../auth/auth.types';
 import { CurrentUser } from '../common/auth/current-user.decorator';
@@ -54,6 +54,31 @@ class UnsubscribeEmailDto {
   @IsOptional()
   @IsIn(['all', 'price_drop', 'receipt_outcome', 'optimization'])
   category?: 'all' | 'price_drop' | 'receipt_outcome' | 'optimization';
+}
+
+class RegisterPushDeviceDto {
+  @IsIn(['android', 'ios'])
+  platform!: 'android' | 'ios';
+
+  @IsString()
+  @MinLength(16)
+  deviceToken!: string;
+
+  @IsOptional()
+  @IsString()
+  provider?: string;
+
+  @IsOptional()
+  @IsString()
+  appVersion?: string;
+
+  @IsOptional()
+  @IsString()
+  locale?: string;
+
+  @IsOptional()
+  @IsString()
+  timezone?: string;
 }
 
 @Controller()
@@ -122,5 +147,26 @@ export class NotificationsController {
   @Post('notification-email-unsubscribe')
   unsubscribeEmail(@Body() body: UnsubscribeEmailDto) {
     return this.notificationsService.unsubscribeEmail(body);
+  }
+
+  @Get('notification-push-devices')
+  @UseGuards(JwtAuthGuard)
+  pushDevices(@CurrentUser() user: JwtUserPayload) {
+    return this.notificationsService.listPushDevices(user.sub);
+  }
+
+  @Post('notification-push-devices')
+  @UseGuards(JwtAuthGuard)
+  registerPushDevice(
+    @CurrentUser() user: JwtUserPayload,
+    @Body() body: RegisterPushDeviceDto,
+  ) {
+    return this.notificationsService.registerPushDevice(user.sub, body);
+  }
+
+  @Post('notification-push-devices/:id/revoke')
+  @UseGuards(JwtAuthGuard)
+  revokePushDevice(@CurrentUser() user: JwtUserPayload, @Param('id') id: string) {
+    return this.notificationsService.revokePushDevice(user.sub, id);
   }
 }

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -8,6 +8,7 @@ import {
   type UserNotificationDeliveryStatus,
   type UserNotificationPreference,
   type UserNotificationType,
+  type UserPushDevicePlatform,
 } from '@prisma/client';
 
 import { PrismaService } from '../persistence/prisma.service';
@@ -49,12 +50,17 @@ export class NotificationsService {
       receiptOutcomesEnabled?: boolean;
       optimizationReadyEnabled?: boolean;
       emailEnabled?: boolean;
+      pushEnabled?: boolean;
     },
   ) {
     const emailEnabled =
       input.emailEnabled === true
         ? await this.hasVerifiedEmailDestination(userId)
         : input.emailEnabled;
+    const pushEnabled =
+      input.pushEnabled === true
+        ? await this.hasActivePushDevice(userId)
+        : input.pushEnabled;
 
     return this.prisma.userNotificationPreference.upsert({
       where: { userId },
@@ -62,12 +68,12 @@ export class NotificationsService {
         userId,
         ...input,
         emailEnabled: emailEnabled ?? false,
-        pushEnabled: false,
+        pushEnabled: pushEnabled ?? false,
       },
       update: {
         ...input,
         emailEnabled,
-        pushEnabled: false,
+        pushEnabled,
       },
     });
   }
@@ -187,6 +193,98 @@ export class NotificationsService {
     return this.toEmailDestinationResponse(destination);
   }
 
+  async listPushDevices(userId: string) {
+    return this.prisma.userPushDevice.findMany({
+      where: { userId },
+      orderBy: [{ isActive: 'desc' }, { lastSeenAt: 'desc' }],
+      select: {
+        id: true,
+        platform: true,
+        provider: true,
+        deviceTokenTail: true,
+        appVersion: true,
+        locale: true,
+        timezone: true,
+        isActive: true,
+        revokedAt: true,
+        lastSeenAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  async registerPushDevice(
+    userId: string,
+    input: {
+      platform: UserPushDevicePlatform;
+      deviceToken: string;
+      provider?: string;
+      appVersion?: string;
+      locale?: string;
+      timezone?: string;
+    },
+  ) {
+    const deviceToken = input.deviceToken.trim();
+    if (deviceToken.length < 16) {
+      throw new BadRequestException('Token de push invalido');
+    }
+
+    const now = new Date();
+    const device = await this.prisma.userPushDevice.upsert({
+      where: { deviceTokenHash: this.hashToken(deviceToken) },
+      create: {
+        userId,
+        platform: input.platform,
+        deviceTokenHash: this.hashToken(deviceToken),
+        deviceTokenTail: deviceToken.slice(-12),
+        provider: input.provider?.trim() || 'fcm',
+        appVersion: input.appVersion,
+        locale: input.locale,
+        timezone: input.timezone,
+        isActive: true,
+        revokedAt: null,
+        lastSeenAt: now,
+      },
+      update: {
+        userId,
+        platform: input.platform,
+        deviceTokenTail: deviceToken.slice(-12),
+        provider: input.provider?.trim() || 'fcm',
+        appVersion: input.appVersion,
+        locale: input.locale,
+        timezone: input.timezone,
+        isActive: true,
+        revokedAt: null,
+        lastSeenAt: now,
+      },
+    });
+    await this.updatePreferences(userId, { pushEnabled: true });
+    return device;
+  }
+
+  async revokePushDevice(userId: string, deviceId: string) {
+    const device = await this.prisma.userPushDevice.findFirst({
+      where: { id: deviceId, userId },
+    });
+    if (!device) {
+      throw new NotFoundException('Dispositivo de push nao encontrado');
+    }
+
+    const updated = await this.prisma.userPushDevice.update({
+      where: { id: device.id },
+      data: {
+        isActive: false,
+        revokedAt: new Date(),
+      },
+    });
+    const hasActiveDevice = await this.hasActivePushDevice(userId);
+    if (!hasActiveDevice) {
+      await this.updatePreferences(userId, { pushEnabled: false });
+    }
+    return updated;
+  }
+
   async markRead(userId: string, notificationId: string) {
     const notification = await this.prisma.userNotification.findFirst({
       where: { id: notificationId, userId },
@@ -236,6 +334,7 @@ export class NotificationsService {
       },
     });
     await this.queueEmailDeliveryIfEligible(notification, preferences);
+    await this.queuePushDeliveryIfEligible(notification, preferences);
     return notification;
   }
 
@@ -246,6 +345,7 @@ export class NotificationsService {
     maxAttempts?: number;
     nextAttemptAt?: Date;
     emailDestinationId?: string;
+    pushDeviceId?: string;
   }) {
     return this.prisma.userNotificationDeliveryAttempt.create({
       data: {
@@ -255,6 +355,7 @@ export class NotificationsService {
         maxAttempts: input.maxAttempts ?? 3,
         nextAttemptAt: input.nextAttemptAt,
         emailDestinationId: input.emailDestinationId,
+        pushDeviceId: input.pushDeviceId,
       },
     });
   }
@@ -426,9 +527,52 @@ export class NotificationsService {
     });
   }
 
+  private async queuePushDeliveryIfEligible(
+    notification: {
+      id: string;
+      userId: string;
+      type: UserNotificationType;
+    },
+    preferences: UserNotificationPreference,
+  ) {
+    if (
+      !preferences.pushEnabled ||
+      !this.typeEnabled(preferences, notification.type)
+    ) {
+      return;
+    }
+
+    const devices = await this.prisma.userPushDevice.findMany({
+      where: {
+        userId: notification.userId,
+        isActive: true,
+      },
+      take: 10,
+      orderBy: { lastSeenAt: 'desc' },
+    });
+
+    await Promise.all(
+      devices.map((device) =>
+        this.createDeliveryAttempt({
+          notificationId: notification.id,
+          userId: notification.userId,
+          channel: 'push',
+          pushDeviceId: device.id,
+        }),
+      ),
+    );
+  }
+
   private async hasVerifiedEmailDestination(userId: string) {
     const count = await this.prisma.userEmailNotificationDestination.count({
       where: { userId, status: 'verified' },
+    });
+    return count > 0;
+  }
+
+  private async hasActivePushDevice(userId: string) {
+    const count = await this.prisma.userPushDevice.count({
+      where: { userId, isActive: true },
     });
     return count > 0;
   }

--- a/backend/test/unit/notifications/notifications.service.spec.ts
+++ b/backend/test/unit/notifications/notifications.service.spec.ts
@@ -91,6 +91,7 @@ describe('NotificationsService', () => {
         maxAttempts: 5,
         nextAttemptAt: undefined,
         emailDestinationId: undefined,
+        pushDeviceId: undefined,
       },
     });
   });
@@ -112,6 +113,27 @@ describe('NotificationsService', () => {
       expect.objectContaining({
         create: expect.objectContaining({ emailEnabled: false }),
         update: expect.objectContaining({ emailEnabled: false }),
+      }),
+    );
+  });
+
+  it('does not enable push preferences until an active device exists', async () => {
+    const prisma = {
+      userPushDevice: {
+        count: jest.fn().mockResolvedValue(0),
+      },
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({ pushEnabled: false }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.updatePreferences('user-1', { pushEnabled: true });
+
+    expect(prisma.userNotificationPreference.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ pushEnabled: false }),
+        update: expect.objectContaining({ pushEnabled: false }),
       }),
     );
   });
@@ -277,6 +299,147 @@ describe('NotificationsService', () => {
         userId: 'user-1',
         channel: 'email',
         emailDestinationId: 'destination-1',
+      }),
+    });
+  });
+
+  it('registers push devices with hashed token and enables push preferences', async () => {
+    const prisma = {
+      userPushDevice: {
+        upsert: jest.fn().mockResolvedValue({
+          id: 'device-1',
+          userId: 'user-1',
+          platform: 'android',
+          deviceTokenTail: 'token-tail-1',
+          isActive: true,
+        }),
+        count: jest.fn().mockResolvedValue(1),
+      },
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({ pushEnabled: true }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.registerPushDevice('user-1', {
+      platform: 'android',
+      deviceToken: 'push-token-value-1234567890',
+      appVersion: '1.0.0',
+      locale: 'pt-BR',
+      timezone: 'America/Sao_Paulo',
+    });
+
+    expect(prisma.userPushDevice.upsert).toHaveBeenCalledWith({
+      where: { deviceTokenHash: expect.any(String) },
+      create: expect.objectContaining({
+        userId: 'user-1',
+        platform: 'android',
+        deviceTokenHash: expect.any(String),
+        deviceTokenTail: 'e-1234567890',
+        provider: 'fcm',
+        appVersion: '1.0.0',
+        locale: 'pt-BR',
+        timezone: 'America/Sao_Paulo',
+        isActive: true,
+        revokedAt: null,
+        lastSeenAt: expect.any(Date),
+      }),
+      update: expect.objectContaining({
+        userId: 'user-1',
+        isActive: true,
+        revokedAt: null,
+        lastSeenAt: expect.any(Date),
+      }),
+    });
+    expect(prisma.userNotificationPreference.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ pushEnabled: true }),
+      }),
+    );
+  });
+
+  it('revokes push devices and disables push when no active device remains', async () => {
+    const prisma = {
+      userPushDevice: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'device-1',
+          userId: 'user-1',
+        }),
+        update: jest.fn().mockResolvedValue({
+          id: 'device-1',
+          isActive: false,
+        }),
+        count: jest.fn().mockResolvedValue(0),
+      },
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({ pushEnabled: false }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.revokePushDevice('user-1', 'device-1');
+
+    expect(prisma.userPushDevice.update).toHaveBeenCalledWith({
+      where: { id: 'device-1' },
+      data: {
+        isActive: false,
+        revokedAt: expect.any(Date),
+      },
+    });
+    expect(prisma.userNotificationPreference.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ pushEnabled: false }),
+      }),
+    );
+  });
+
+  it('queues push delivery attempts for each active device', async () => {
+    const prisma = {
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({
+          inAppEnabled: true,
+          emailEnabled: false,
+          pushEnabled: true,
+          priceDropsEnabled: true,
+          receiptOutcomesEnabled: true,
+          optimizationReadyEnabled: true,
+        }),
+      },
+      userNotification: {
+        create: jest.fn().mockResolvedValue({
+          id: 'notification-1',
+          userId: 'user-1',
+          type: 'optimization_ready',
+        }),
+      },
+      userPushDevice: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: 'device-1' },
+          { id: 'device-2' },
+        ]),
+      },
+      userNotificationDeliveryAttempt: {
+        create: jest.fn().mockResolvedValue({ id: 'attempt-1' }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.create({
+      userId: 'user-1',
+      type: 'optimization_ready',
+      title: 'Otimizacao pronta',
+      message: 'Sua lista foi otimizada.',
+    });
+
+    expect(prisma.userNotificationDeliveryAttempt.create).toHaveBeenCalledTimes(
+      2,
+    );
+    expect(prisma.userNotificationDeliveryAttempt.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        notificationId: 'notification-1',
+        userId: 'user-1',
+        channel: 'push',
+        pushDeviceId: 'device-1',
       }),
     });
   });

--- a/mobile/lib/features/shared/data/pricely_backend_gateway.dart
+++ b/mobile/lib/features/shared/data/pricely_backend_gateway.dart
@@ -111,6 +111,52 @@ class PricelyBackendGateway {
     return LocationCoveragePreviewSummary.fromJson(response);
   }
 
+  Future<List<PushDeviceSummary>> fetchPushDevices(String accessToken) async {
+    final response = await _apiClient.get<List<dynamic>>(
+      '/notification-push-devices',
+      accessToken: accessToken,
+    );
+    return response
+        .map(
+          (entry) => PushDeviceSummary.fromJson(entry as Map<String, dynamic>),
+        )
+        .toList();
+  }
+
+  Future<PushDeviceSummary> registerPushDevice({
+    required String accessToken,
+    required String platform,
+    required String deviceToken,
+    String provider = 'fcm',
+    String? appVersion,
+    String? locale,
+    String? timezone,
+  }) async {
+    final response = await _apiClient.post<Map<String, dynamic>>(
+      '/notification-push-devices',
+      accessToken: accessToken,
+      body: <String, dynamic>{
+        'platform': platform,
+        'deviceToken': deviceToken,
+        'provider': provider,
+        if (appVersion != null) 'appVersion': appVersion,
+        if (locale != null) 'locale': locale,
+        if (timezone != null) 'timezone': timezone,
+      },
+    );
+    return PushDeviceSummary.fromJson(response);
+  }
+
+  Future<PushDeviceSummary> revokePushDevice({
+    required String accessToken,
+    required String deviceId,
+  }) async {
+    final response = await _apiClient.post<Map<String, dynamic>>(
+      '/notification-push-devices/$deviceId/revoke',
+      accessToken: accessToken,
+    );
+    return PushDeviceSummary.fromJson(response);
+  }
 
   List<Map<String, dynamic>> _parseManualReceiptItems(String? rawReceipt) {
     if (rawReceipt == null || rawReceipt.trim().isEmpty) {
@@ -740,6 +786,47 @@ class LocationCoveragePreviewSummary {
       activeEstablishmentCount:
           (json['activeEstablishmentCount'] as num? ?? 0).toInt(),
       fallbackUsed: json['fallbackUsed'] as bool? ?? false,
+    );
+  }
+}
+
+class PushDeviceSummary {
+  PushDeviceSummary({
+    required this.id,
+    required this.platform,
+    required this.provider,
+    required this.deviceTokenTail,
+    required this.isActive,
+    required this.lastSeenAt,
+    this.appVersion,
+    this.locale,
+    this.timezone,
+    this.revokedAt,
+  });
+
+  final String id;
+  final String platform;
+  final String provider;
+  final String deviceTokenTail;
+  final bool isActive;
+  final String lastSeenAt;
+  final String? appVersion;
+  final String? locale;
+  final String? timezone;
+  final String? revokedAt;
+
+  factory PushDeviceSummary.fromJson(Map<String, dynamic> json) {
+    return PushDeviceSummary(
+      id: json['id'] as String,
+      platform: json['platform'] as String? ?? 'android',
+      provider: json['provider'] as String? ?? 'fcm',
+      deviceTokenTail: json['deviceTokenTail'] as String? ?? '',
+      isActive: json['isActive'] as bool? ?? false,
+      lastSeenAt: json['lastSeenAt'] as String? ?? '',
+      appVersion: json['appVersion'] as String?,
+      locale: json['locale'] as String?,
+      timezone: json['timezone'] as String?,
+      revokedAt: json['revokedAt'] as String?,
     );
   }
 }

--- a/mobile/test/unit/features/receipts/receipt_backend_gateway_test.dart
+++ b/mobile/test/unit/features/receipts/receipt_backend_gateway_test.dart
@@ -91,4 +91,70 @@ void main() {
     expect(summary.rewardPoints, 100);
     expect(summary.rewardOptimizationTokens, 1);
   });
+
+  test('registers and revokes authenticated push devices', () async {
+    final requestedPaths = <String>[];
+    final gateway = PricelyBackendGateway(
+      HttpApiClient(
+        client: MockClient((request) async {
+          requestedPaths.add(request.url.path);
+          expect(request.headers['authorization'], 'Bearer token-123');
+
+          if (request.url.path == '/notification-push-devices') {
+            final body = jsonDecode(request.body) as Map<String, dynamic>;
+            expect(body['platform'], 'android');
+            expect(body['deviceToken'], 'push-token-value-1234567890');
+            expect(body['provider'], 'fcm');
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'id': 'device-1',
+                'platform': 'android',
+                'provider': 'fcm',
+                'deviceTokenTail': 'e-1234567890',
+                'isActive': true,
+                'lastSeenAt': '2026-06-26T12:00:00.000Z',
+              }),
+              201,
+            );
+          }
+
+          if (request.url.path ==
+              '/notification-push-devices/device-1/revoke') {
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'id': 'device-1',
+                'platform': 'android',
+                'provider': 'fcm',
+                'deviceTokenTail': 'e-1234567890',
+                'isActive': false,
+                'revokedAt': '2026-06-26T12:05:00.000Z',
+                'lastSeenAt': '2026-06-26T12:00:00.000Z',
+              }),
+              201,
+            );
+          }
+
+          return http.Response('not found', 404);
+        }),
+      ),
+    );
+
+    final registered = await gateway.registerPushDevice(
+      accessToken: 'token-123',
+      platform: 'android',
+      deviceToken: 'push-token-value-1234567890',
+    );
+    final revoked = await gateway.revokePushDevice(
+      accessToken: 'token-123',
+      deviceId: registered.id,
+    );
+
+    expect(registered.id, 'device-1');
+    expect(registered.isActive, isTrue);
+    expect(revoked.isActive, isFalse);
+    expect(requestedPaths, <String>[
+      '/notification-push-devices',
+      '/notification-push-devices/device-1/revoke',
+    ]);
+  });
 }

--- a/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
+++ b/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
@@ -443,6 +443,35 @@ paths:
       responses:
         '201':
           description: Email preference updated
+  /notification-push-devices:
+    get:
+      summary: List authenticated mobile push devices
+      responses:
+        '200':
+          description: Push devices returned newest active first
+    post:
+      summary: Register or refresh an authenticated mobile push device token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PushDeviceRegistrationRequest'
+      responses:
+        '201':
+          description: Push device registered or refreshed
+  /notification-push-devices/{deviceId}/revoke:
+    post:
+      summary: Revoke an authenticated mobile push device
+      parameters:
+        - name: deviceId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: Push device revoked
   /receipts:
     post:
       summary: Submit a receipt contribution from manual items or an NFC-e QR URL
@@ -840,6 +869,51 @@ components:
           type: string
           format: date-time
         unsubscribedAt:
+          type: string
+          format: date-time
+    PushDeviceRegistrationRequest:
+      type: object
+      required: [platform, deviceToken]
+      properties:
+        platform:
+          type: string
+          enum: [android, ios]
+        deviceToken:
+          type: string
+        provider:
+          type: string
+          default: fcm
+        appVersion:
+          type: string
+        locale:
+          type: string
+        timezone:
+          type: string
+    PushDevice:
+      type: object
+      required: [id, platform, provider, deviceTokenTail, isActive, lastSeenAt]
+      properties:
+        id:
+          type: string
+        platform:
+          type: string
+          enum: [android, ios]
+        provider:
+          type: string
+        deviceTokenTail:
+          type: string
+        appVersion:
+          type: string
+        locale:
+          type: string
+        timezone:
+          type: string
+        isActive:
+          type: boolean
+        revokedAt:
+          type: string
+          format: date-time
+        lastSeenAt:
           type: string
           format: date-time
     AuthSession:

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -629,7 +629,7 @@ channels without enabling provider sends prematurely.
 - [X] T263 Document the Phase 35 email, push, quiet-hours, retry, and release-validation plan in `docs/product/notification-center.md`
 - [X] T264 Add notification delivery persistence for channel attempts, provider message ids, retry state, and terminal failure reasons in `backend/prisma/` and `backend/src/notifications/`
 - [X] T265 Add user email destination verification, unsubscribe/category mapping, and email delivery queue integration in `backend/src/notifications/` and `backend/src/users/`
-- [ ] T266 Add mobile push device registration, token refresh/revocation, and authenticated device listing in `backend/src/notifications/` and `mobile/lib/features/`
+- [X] T266 Add mobile push device registration, token refresh/revocation, and authenticated device listing in `backend/src/notifications/` and `mobile/lib/features/`
 - [ ] T267 Add quiet-hour preferences with timezone-aware deferral for non-critical notifications in `backend/src/notifications/`, `web/src/components/design-system/`, and `mobile/lib/features/`
 - [ ] T268 Add admin notification delivery diagnostics, retry/cancel controls, and provider-error redaction in `web/src/dashboard/` and `backend/src/admin/`
 - [ ] T269 Add backend, web, and mobile coverage for delivery preferences, quiet-hour deferral, device registration, retry policy, and redacted admin diagnostics in `backend/test/`, `web/src/`, and `mobile/test/`


### PR DESCRIPTION
## Summary
- Adds push device persistence for Android/iOS with hashed token storage, token tail, last-seen, and revocation state.
- Adds authenticated backend APIs to list, register/refresh, and revoke push devices.
- Allows `pushEnabled` only when an active push device exists and queues push delivery attempts for active devices.
- Adds mobile gateway support for registering and revoking push devices.
- Updates OpenAPI and marks T266 complete.

## Validation
- `npm run db:generate`
- `npx prisma format`
- `npm run test -- notifications.service.spec.ts`
- `npm run build`
- `npm run lint`
- `npm run db:migrate:policy`
- `DATABASE_URL=postgresql://pricely:pricely@localhost:5432/pricely_validate npx prisma validate`
- `npm run test`
- `git diff --check`

## Notes
- Local Flutter/Dart binaries were not available in this shell, so the mobile gateway test is left for CI mobile validation.
- No external push provider send is enabled in this task.

Closes #449