### PR TITLE
Phase 35 T267 notification quiet hours

### DIFF
--- a/backend/prisma/migrations/20260626070000_notification_quiet_hours/migration.sql
+++ b/backend/prisma/migrations/20260626070000_notification_quiet_hours/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "UserNotificationPreference"
+ADD COLUMN "quietHoursEnabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "quietHoursStartMinute" INTEGER,
+ADD COLUMN "quietHoursEndMinute" INTEGER,
+ADD COLUMN "quietHoursTimezone" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -392,6 +392,10 @@ model UserNotificationPreference {
   optimizationReadyEnabled Boolean     @default(true)
   emailEnabled             Boolean     @default(false)
   pushEnabled              Boolean     @default(false)
+  quietHoursEnabled        Boolean     @default(false)
+  quietHoursStartMinute    Int?
+  quietHoursEndMinute      Int?
+  quietHoursTimezone       String?
   createdAt                DateTime    @default(now())
   updatedAt                DateTime    @updatedAt
   user                     UserAccount @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -8,7 +8,17 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { IsBoolean, IsEmail, IsIn, IsOptional, IsString, MinLength } from 'class-validator';
+import {
+  IsBoolean,
+  IsEmail,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  MinLength,
+} from 'class-validator';
 
 import { type JwtUserPayload } from '../auth/auth.types';
 import { CurrentUser } from '../common/auth/current-user.decorator';
@@ -35,6 +45,30 @@ class UpdateNotificationPreferencesDto {
   @IsOptional()
   @IsBoolean()
   emailEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  pushEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  quietHoursEnabled?: boolean;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1439)
+  quietHoursStartMinute?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1439)
+  quietHoursEndMinute?: number;
+
+  @IsOptional()
+  @IsString()
+  quietHoursTimezone?: string;
 }
 
 class RequestEmailDestinationDto {

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -51,6 +51,10 @@ export class NotificationsService {
       optimizationReadyEnabled?: boolean;
       emailEnabled?: boolean;
       pushEnabled?: boolean;
+      quietHoursEnabled?: boolean;
+      quietHoursStartMinute?: number | null;
+      quietHoursEndMinute?: number | null;
+      quietHoursTimezone?: string | null;
     },
   ) {
     const emailEnabled =
@@ -61,17 +65,20 @@ export class NotificationsService {
       input.pushEnabled === true
         ? await this.hasActivePushDevice(userId)
         : input.pushEnabled;
+    const quietHoursPatch = this.normalizeQuietHoursPatch(input);
 
     return this.prisma.userNotificationPreference.upsert({
       where: { userId },
       create: {
         userId,
         ...input,
+        ...quietHoursPatch,
         emailEnabled: emailEnabled ?? false,
         pushEnabled: pushEnabled ?? false,
       },
       update: {
         ...input,
+        ...quietHoursPatch,
         emailEnabled,
         pushEnabled,
       },
@@ -524,6 +531,7 @@ export class NotificationsService {
       userId: notification.userId,
       channel: 'email',
       emailDestinationId: destination.id,
+      nextAttemptAt: this.resolveQuietHoursNextAttemptAt(preferences),
     });
   }
 
@@ -558,9 +566,119 @@ export class NotificationsService {
           userId: notification.userId,
           channel: 'push',
           pushDeviceId: device.id,
+          nextAttemptAt: this.resolveQuietHoursNextAttemptAt(preferences),
         }),
       ),
     );
+  }
+
+  private normalizeQuietHoursPatch(input: {
+    quietHoursEnabled?: boolean;
+    quietHoursStartMinute?: number | null;
+    quietHoursEndMinute?: number | null;
+    quietHoursTimezone?: string | null;
+  }) {
+    const patch: {
+      quietHoursEnabled?: boolean;
+      quietHoursStartMinute?: number | null;
+      quietHoursEndMinute?: number | null;
+      quietHoursTimezone?: string | null;
+    } = {};
+
+    if (input.quietHoursEnabled !== undefined) {
+      patch.quietHoursEnabled = input.quietHoursEnabled;
+      if (input.quietHoursEnabled) {
+        patch.quietHoursStartMinute = input.quietHoursStartMinute ?? 22 * 60;
+        patch.quietHoursEndMinute = input.quietHoursEndMinute ?? 7 * 60;
+        patch.quietHoursTimezone =
+          this.normalizeTimezone(input.quietHoursTimezone) ??
+          'America/Sao_Paulo';
+      }
+    }
+    if (input.quietHoursStartMinute !== undefined) {
+      patch.quietHoursStartMinute = input.quietHoursStartMinute;
+    }
+    if (input.quietHoursEndMinute !== undefined) {
+      patch.quietHoursEndMinute = input.quietHoursEndMinute;
+    }
+    if (input.quietHoursTimezone !== undefined) {
+      patch.quietHoursTimezone = this.normalizeTimezone(
+        input.quietHoursTimezone,
+      );
+    }
+
+    return patch;
+  }
+
+  private resolveQuietHoursNextAttemptAt(
+    preferences: Pick<
+      UserNotificationPreference,
+      | 'quietHoursEnabled'
+      | 'quietHoursStartMinute'
+      | 'quietHoursEndMinute'
+      | 'quietHoursTimezone'
+    >,
+    now = new Date(),
+  ) {
+    if (!preferences.quietHoursEnabled) {
+      return undefined;
+    }
+    const startMinute = preferences.quietHoursStartMinute ?? 22 * 60;
+    const endMinute = preferences.quietHoursEndMinute ?? 7 * 60;
+    if (startMinute === endMinute) {
+      return undefined;
+    }
+    const timezone = preferences.quietHoursTimezone ?? 'America/Sao_Paulo';
+    const localMinute = this.localMinuteOfDay(now, timezone);
+    const minutes = this.minutesUntilQuietHoursEnd(
+      startMinute,
+      endMinute,
+      localMinute,
+    );
+    if (minutes <= 0) {
+      return undefined;
+    }
+    return new Date(now.getTime() + minutes * 60 * 1000);
+  }
+
+  private minutesUntilQuietHoursEnd(
+    startMinute: number,
+    endMinute: number,
+    currentMinute: number,
+  ) {
+    if (startMinute < endMinute) {
+      return currentMinute >= startMinute && currentMinute < endMinute
+        ? endMinute - currentMinute
+        : 0;
+    }
+    if (currentMinute >= startMinute) {
+      return 1440 - currentMinute + endMinute;
+    }
+    if (currentMinute < endMinute) {
+      return endMinute - currentMinute;
+    }
+    return 0;
+  }
+
+  private localMinuteOfDay(date: Date, timezone: string) {
+    try {
+      const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: timezone,
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      }).formatToParts(date);
+      const hour = Number(parts.find((part) => part.type === 'hour')?.value);
+      const minute = Number(
+        parts.find((part) => part.type === 'minute')?.value,
+      );
+      if (Number.isFinite(hour) && Number.isFinite(minute)) {
+        return (hour % 24) * 60 + minute;
+      }
+    } catch {
+      return date.getUTCHours() * 60 + date.getUTCMinutes();
+    }
+    return date.getUTCHours() * 60 + date.getUTCMinutes();
   }
 
   private async hasVerifiedEmailDestination(userId: string) {
@@ -615,6 +733,22 @@ export class NotificationsService {
       throw new BadRequestException('Email invalido');
     }
     return normalizedEmail;
+  }
+
+  private normalizeTimezone(timezone?: string | null) {
+    if (timezone === null) {
+      return null;
+    }
+    const normalizedTimezone = timezone?.trim();
+    if (!normalizedTimezone) {
+      return undefined;
+    }
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: normalizedTimezone });
+      return normalizedTimezone;
+    } catch {
+      throw new BadRequestException('Timezone invalido');
+    }
   }
 
   private createToken() {

--- a/backend/test/unit/notifications/notifications.service.spec.ts
+++ b/backend/test/unit/notifications/notifications.service.spec.ts
@@ -303,6 +303,95 @@ describe('NotificationsService', () => {
     });
   });
 
+  it('defers email delivery attempts until quiet hours end in the user timezone', async () => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2026-06-26T23:30:00.000Z').getTime());
+    const prisma = {
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({
+          inAppEnabled: true,
+          emailEnabled: true,
+          priceDropsEnabled: true,
+          receiptOutcomesEnabled: true,
+          optimizationReadyEnabled: true,
+          quietHoursEnabled: true,
+          quietHoursStartMinute: 22 * 60,
+          quietHoursEndMinute: 7 * 60,
+          quietHoursTimezone: 'UTC',
+        }),
+      },
+      userNotification: {
+        create: jest.fn().mockResolvedValue({
+          id: 'notification-1',
+          userId: 'user-1',
+          type: 'price_drop',
+        }),
+      },
+      userEmailNotificationDestination: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'destination-1',
+          userId: 'user-1',
+          status: 'verified',
+        }),
+      },
+      userNotificationDeliveryAttempt: {
+        create: jest.fn().mockResolvedValue({ id: 'attempt-1' }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.create({
+      userId: 'user-1',
+      type: 'price_drop',
+      title: 'Preco menor',
+      message: 'Novo preco disponivel.',
+    });
+
+    expect(prisma.userNotificationDeliveryAttempt.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        notificationId: 'notification-1',
+        userId: 'user-1',
+        channel: 'email',
+        nextAttemptAt: new Date('2026-06-27T07:00:00.000Z'),
+      }),
+    });
+    jest.useRealTimers();
+  });
+
+  it('persists quiet-hour preferences with default window when enabled', async () => {
+    const prisma = {
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({
+          quietHoursEnabled: true,
+          quietHoursStartMinute: 1320,
+          quietHoursEndMinute: 420,
+          quietHoursTimezone: 'America/Sao_Paulo',
+        }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.updatePreferences('user-1', { quietHoursEnabled: true });
+
+    expect(prisma.userNotificationPreference.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          quietHoursEnabled: true,
+          quietHoursStartMinute: 1320,
+          quietHoursEndMinute: 420,
+          quietHoursTimezone: 'America/Sao_Paulo',
+        }),
+        update: expect.objectContaining({
+          quietHoursEnabled: true,
+          quietHoursStartMinute: 1320,
+          quietHoursEndMinute: 420,
+          quietHoursTimezone: 'America/Sao_Paulo',
+        }),
+      }),
+    );
+  });
+
   it('registers push devices with hashed token and enables push preferences', async () => {
     const prisma = {
       userPushDevice: {

--- a/docs/product/notification-center.md
+++ b/docs/product/notification-center.md
@@ -13,12 +13,13 @@ The current engagement channel is the authenticated in-app notification center.
 Users can disable all in-app notifications or control price, receipt, and
 optimization categories independently.
 
-## Deferred channels
+## Outbound channels
 
-Email and push fields are persisted as disabled capabilities. Enabling either
-channel requires provider configuration, verified destination ownership,
-delivery/retry tracking, unsubscribe handling, and quiet-hour policy. No
-external delivery is attempted in this phase.
+Email and push delivery are modeled as queued delivery attempts. Email requires
+a verified destination and push requires an active mobile device. Provider sends
+remain gated by the delivery worker/provider configuration, while the product
+surface can already persist preferences, delivery attempts, unsubscribe state,
+device registration, and quiet-hour deferral.
 
 ## Phase 35 delivery plan
 
@@ -47,8 +48,12 @@ as a controlled fan-out layer.
 ### Quiet hours and retries
 
 - Add a per-user quiet-hour window with timezone.
-- Defer non-critical notifications during quiet hours; allow critical account or
-  receipt-result notifications only if product policy explicitly allows them.
+- Defer non-critical email and push delivery attempts during quiet hours by
+  setting `nextAttemptAt` to the end of the user-local quiet window.
+- Keep in-app notifications immediate so users can still see account activity
+  after signing in.
+- Allow critical account or receipt-result notifications only if product policy
+  explicitly allows them.
 - Use bounded exponential retry for provider failures and stop retrying after a
   terminal provider response.
 - Expose delivery state in admin diagnostics before enabling automatic external

--- a/mobile/lib/features/shared/data/pricely_backend_gateway.dart
+++ b/mobile/lib/features/shared/data/pricely_backend_gateway.dart
@@ -158,6 +158,55 @@ class PricelyBackendGateway {
     return PushDeviceSummary.fromJson(response);
   }
 
+  Future<NotificationPreferencesSummary> fetchNotificationPreferences(
+    String accessToken,
+  ) async {
+    final response = await _apiClient.get<Map<String, dynamic>>(
+      '/notification-preferences',
+      accessToken: accessToken,
+    );
+    return NotificationPreferencesSummary.fromJson(response);
+  }
+
+  Future<NotificationPreferencesSummary> updateNotificationPreferences({
+    required String accessToken,
+    bool? inAppEnabled,
+    bool? priceDropsEnabled,
+    bool? receiptOutcomesEnabled,
+    bool? optimizationReadyEnabled,
+    bool? emailEnabled,
+    bool? pushEnabled,
+    bool? quietHoursEnabled,
+    int? quietHoursStartMinute,
+    int? quietHoursEndMinute,
+    String? quietHoursTimezone,
+  }) async {
+    final response = await _apiClient.patch<Map<String, dynamic>>(
+      '/notification-preferences',
+      accessToken: accessToken,
+      body: <String, dynamic>{
+        if (inAppEnabled != null) 'inAppEnabled': inAppEnabled,
+        if (priceDropsEnabled != null)
+          'priceDropsEnabled': priceDropsEnabled,
+        if (receiptOutcomesEnabled != null)
+          'receiptOutcomesEnabled': receiptOutcomesEnabled,
+        if (optimizationReadyEnabled != null)
+          'optimizationReadyEnabled': optimizationReadyEnabled,
+        if (emailEnabled != null) 'emailEnabled': emailEnabled,
+        if (pushEnabled != null) 'pushEnabled': pushEnabled,
+        if (quietHoursEnabled != null)
+          'quietHoursEnabled': quietHoursEnabled,
+        if (quietHoursStartMinute != null)
+          'quietHoursStartMinute': quietHoursStartMinute,
+        if (quietHoursEndMinute != null)
+          'quietHoursEndMinute': quietHoursEndMinute,
+        if (quietHoursTimezone != null)
+          'quietHoursTimezone': quietHoursTimezone,
+      },
+    );
+    return NotificationPreferencesSummary.fromJson(response);
+  }
+
   List<Map<String, dynamic>> _parseManualReceiptItems(String? rawReceipt) {
     if (rawReceipt == null || rawReceipt.trim().isEmpty) {
       return <Map<String, dynamic>>[];
@@ -827,6 +876,52 @@ class PushDeviceSummary {
       locale: json['locale'] as String?,
       timezone: json['timezone'] as String?,
       revokedAt: json['revokedAt'] as String?,
+    );
+  }
+}
+
+class NotificationPreferencesSummary {
+  NotificationPreferencesSummary({
+    required this.inAppEnabled,
+    required this.priceDropsEnabled,
+    required this.receiptOutcomesEnabled,
+    required this.optimizationReadyEnabled,
+    required this.emailEnabled,
+    required this.pushEnabled,
+    required this.quietHoursEnabled,
+    this.quietHoursStartMinute,
+    this.quietHoursEndMinute,
+    this.quietHoursTimezone,
+  });
+
+  final bool inAppEnabled;
+  final bool priceDropsEnabled;
+  final bool receiptOutcomesEnabled;
+  final bool optimizationReadyEnabled;
+  final bool emailEnabled;
+  final bool pushEnabled;
+  final bool quietHoursEnabled;
+  final int? quietHoursStartMinute;
+  final int? quietHoursEndMinute;
+  final String? quietHoursTimezone;
+
+  factory NotificationPreferencesSummary.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return NotificationPreferencesSummary(
+      inAppEnabled: json['inAppEnabled'] as bool? ?? true,
+      priceDropsEnabled: json['priceDropsEnabled'] as bool? ?? true,
+      receiptOutcomesEnabled:
+          json['receiptOutcomesEnabled'] as bool? ?? true,
+      optimizationReadyEnabled:
+          json['optimizationReadyEnabled'] as bool? ?? true,
+      emailEnabled: json['emailEnabled'] as bool? ?? false,
+      pushEnabled: json['pushEnabled'] as bool? ?? false,
+      quietHoursEnabled: json['quietHoursEnabled'] as bool? ?? false,
+      quietHoursStartMinute:
+          (json['quietHoursStartMinute'] as num?)?.toInt(),
+      quietHoursEndMinute: (json['quietHoursEndMinute'] as num?)?.toInt(),
+      quietHoursTimezone: json['quietHoursTimezone'] as String?,
     );
   }
 }

--- a/mobile/test/unit/features/receipts/receipt_backend_gateway_test.dart
+++ b/mobile/test/unit/features/receipts/receipt_backend_gateway_test.dart
@@ -157,4 +157,48 @@ void main() {
       '/notification-push-devices/device-1/revoke',
     ]);
   });
+
+  test('updates notification quiet-hour preferences', () async {
+    Map<String, dynamic>? capturedBody;
+    final gateway = PricelyBackendGateway(
+      HttpApiClient(
+        client: MockClient((request) async {
+          expect(request.url.path, '/notification-preferences');
+          expect(request.headers['authorization'], 'Bearer token-123');
+          capturedBody = jsonDecode(request.body) as Map<String, dynamic>;
+
+          return http.Response(
+            jsonEncode(<String, dynamic>{
+              'inAppEnabled': true,
+              'priceDropsEnabled': true,
+              'receiptOutcomesEnabled': true,
+              'optimizationReadyEnabled': true,
+              'emailEnabled': false,
+              'pushEnabled': true,
+              'quietHoursEnabled': true,
+              'quietHoursStartMinute': 1320,
+              'quietHoursEndMinute': 420,
+              'quietHoursTimezone': 'America/Sao_Paulo',
+            }),
+            200,
+          );
+        }),
+      ),
+    );
+
+    final preferences = await gateway.updateNotificationPreferences(
+      accessToken: 'token-123',
+      pushEnabled: true,
+      quietHoursEnabled: true,
+      quietHoursStartMinute: 1320,
+      quietHoursEndMinute: 420,
+      quietHoursTimezone: 'America/Sao_Paulo',
+    );
+
+    expect(capturedBody?['pushEnabled'], isTrue);
+    expect(capturedBody?['quietHoursEnabled'], isTrue);
+    expect(capturedBody?['quietHoursStartMinute'], 1320);
+    expect(preferences.quietHoursEnabled, isTrue);
+    expect(preferences.quietHoursTimezone, 'America/Sao_Paulo');
+  });
 }

--- a/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
+++ b/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
@@ -397,11 +397,25 @@ paths:
       responses:
         '200':
           description: Preferences returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPreferences'
     patch:
       summary: Update notification channel and category preferences
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationPreferencesUpdate'
       responses:
         '200':
-          description: Preferences updated; email can be enabled after destination verification
+          description: Preferences updated; outbound channels can be deferred by quiet hours
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPreferences'
   /notification-email-destination:
     get:
       summary: Fetch the authenticated user's email notification destination
@@ -838,6 +852,73 @@ components:
         email:
           type: string
           format: email
+    NotificationPreferences:
+      type: object
+      required:
+        [
+          inAppEnabled,
+          priceDropsEnabled,
+          receiptOutcomesEnabled,
+          optimizationReadyEnabled,
+          emailEnabled,
+          pushEnabled,
+          quietHoursEnabled,
+        ]
+      properties:
+        inAppEnabled:
+          type: boolean
+        priceDropsEnabled:
+          type: boolean
+        receiptOutcomesEnabled:
+          type: boolean
+        optimizationReadyEnabled:
+          type: boolean
+        emailEnabled:
+          type: boolean
+        pushEnabled:
+          type: boolean
+        quietHoursEnabled:
+          type: boolean
+        quietHoursStartMinute:
+          type: integer
+          minimum: 0
+          maximum: 1439
+          nullable: true
+        quietHoursEndMinute:
+          type: integer
+          minimum: 0
+          maximum: 1439
+          nullable: true
+        quietHoursTimezone:
+          type: string
+          nullable: true
+    NotificationPreferencesUpdate:
+      type: object
+      properties:
+        inAppEnabled:
+          type: boolean
+        priceDropsEnabled:
+          type: boolean
+        receiptOutcomesEnabled:
+          type: boolean
+        optimizationReadyEnabled:
+          type: boolean
+        emailEnabled:
+          type: boolean
+        pushEnabled:
+          type: boolean
+        quietHoursEnabled:
+          type: boolean
+        quietHoursStartMinute:
+          type: integer
+          minimum: 0
+          maximum: 1439
+        quietHoursEndMinute:
+          type: integer
+          minimum: 0
+          maximum: 1439
+        quietHoursTimezone:
+          type: string
     EmailTokenRequest:
       type: object
       required: [token]

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -630,7 +630,7 @@ channels without enabling provider sends prematurely.
 - [X] T264 Add notification delivery persistence for channel attempts, provider message ids, retry state, and terminal failure reasons in `backend/prisma/` and `backend/src/notifications/`
 - [X] T265 Add user email destination verification, unsubscribe/category mapping, and email delivery queue integration in `backend/src/notifications/` and `backend/src/users/`
 - [X] T266 Add mobile push device registration, token refresh/revocation, and authenticated device listing in `backend/src/notifications/` and `mobile/lib/features/`
-- [ ] T267 Add quiet-hour preferences with timezone-aware deferral for non-critical notifications in `backend/src/notifications/`, `web/src/components/design-system/`, and `mobile/lib/features/`
+- [X] T267 Add quiet-hour preferences with timezone-aware deferral for non-critical notifications in `backend/src/notifications/`, `web/src/components/design-system/`, and `mobile/lib/features/`
 - [ ] T268 Add admin notification delivery diagnostics, retry/cancel controls, and provider-error redaction in `web/src/dashboard/` and `backend/src/admin/`
 - [ ] T269 Add backend, web, and mobile coverage for delivery preferences, quiet-hour deferral, device registration, retry policy, and redacted admin diagnostics in `backend/test/`, `web/src/`, and `mobile/test/`
 

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -194,8 +194,12 @@ export type NotificationPreferencesResponse = {
   priceDropsEnabled: boolean;
   receiptOutcomesEnabled: boolean;
   optimizationReadyEnabled: boolean;
-  emailEnabled: false;
-  pushEnabled: false;
+  emailEnabled: boolean;
+  pushEnabled: boolean;
+  quietHoursEnabled: boolean;
+  quietHoursStartMinute?: number | null;
+  quietHoursEndMinute?: number | null;
+  quietHoursTimezone?: string | null;
 };
 
 type RegionOffersApiResponse = {
@@ -1033,6 +1037,12 @@ export async function updateNotificationPreferences(
       | 'priceDropsEnabled'
       | 'receiptOutcomesEnabled'
       | 'optimizationReadyEnabled'
+      | 'emailEnabled'
+      | 'pushEnabled'
+      | 'quietHoursEnabled'
+      | 'quietHoursStartMinute'
+      | 'quietHoursEndMinute'
+      | 'quietHoursTimezone'
     >
   >,
 ) {

--- a/web/src/components/design-system/app-sidebar-shell.tsx
+++ b/web/src/components/design-system/app-sidebar-shell.tsx
@@ -115,6 +115,17 @@ function SidebarLogo() {
   );
 }
 
+function formatQuietHour(minute?: number | null) {
+  if (minute === undefined || minute === null) {
+    return '--:--';
+  }
+  const hour = Math.floor(minute / 60)
+    .toString()
+    .padStart(2, '0');
+  const normalizedMinute = (minute % 60).toString().padStart(2, '0');
+  return `${hour}:${normalizedMinute}`;
+}
+
 export function PublicSidebarShell({ children }: PropsWithChildren) {
   const {
     cityId,
@@ -712,6 +723,8 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
                     ['priceDropsEnabled', 'Quedas de preco'],
                     ['receiptOutcomesEnabled', 'Resultado de notas'],
                     ['optimizationReadyEnabled', 'Otimizacoes prontas'],
+                    ['emailEnabled', 'Email verificado'],
+                    ['pushEnabled', 'Push no celular'],
                   ].map(([key, label]) => (
                     <label
                       className="flex items-center justify-between gap-3 text-sm"
@@ -735,9 +748,113 @@ export function PublicSidebarShell({ children }: PropsWithChildren) {
                       />
                     </label>
                   ))}
-                  <div className="text-xs text-muted-foreground">
-                    E-mail e push serao adicionados depois; permanecem
-                    desativados nesta fase.
+                  <div className="grid gap-3 rounded-lg border border-border/70 bg-card p-3">
+                    <label className="flex items-center justify-between gap-3 text-sm">
+                      <span>
+                        <span className="block font-medium">
+                          Horario silencioso
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          Segura email e push ate o fim da janela configurada.
+                        </span>
+                      </span>
+                      <Switch
+                        checked={notificationPreferences.quietHoursEnabled}
+                        onCheckedChange={async (checked) => {
+                          if (!accessToken) return;
+                          const updated = await updateNotificationPreferences(
+                            accessToken,
+                            {
+                              quietHoursEnabled: checked,
+                              quietHoursStartMinute:
+                                notificationPreferences.quietHoursStartMinute ??
+                                22 * 60,
+                              quietHoursEndMinute:
+                                notificationPreferences.quietHoursEndMinute ??
+                                7 * 60,
+                              quietHoursTimezone:
+                                notificationPreferences.quietHoursTimezone ??
+                                Intl.DateTimeFormat().resolvedOptions()
+                                  .timeZone ??
+                                'America/Sao_Paulo',
+                            },
+                          );
+                          setNotificationPreferences(updated);
+                        }}
+                      />
+                    </label>
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      <Select
+                        disabled={!notificationPreferences.quietHoursEnabled}
+                        onValueChange={async (value) => {
+                          if (!accessToken) return;
+                          const [start, end] = value.split('-').map(Number);
+                          const updated = await updateNotificationPreferences(
+                            accessToken,
+                            {
+                              quietHoursStartMinute: start,
+                              quietHoursEndMinute: end,
+                            },
+                          );
+                          setNotificationPreferences(updated);
+                        }}
+                        value={`${notificationPreferences.quietHoursStartMinute ?? 22 * 60}-${notificationPreferences.quietHoursEndMinute ?? 7 * 60}`}
+                      >
+                        <SelectTrigger>
+                          <MoonStarIcon />
+                          <SelectValue placeholder="Janela" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="1320-420">
+                            22:00 ate 07:00
+                          </SelectItem>
+                          <SelectItem value="1260-480">
+                            21:00 ate 08:00
+                          </SelectItem>
+                          <SelectItem value="0-420">
+                            00:00 ate 07:00
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <Select
+                        disabled={!notificationPreferences.quietHoursEnabled}
+                        onValueChange={async (timezone) => {
+                          if (!accessToken) return;
+                          const updated = await updateNotificationPreferences(
+                            accessToken,
+                            { quietHoursTimezone: timezone },
+                          );
+                          setNotificationPreferences(updated);
+                        }}
+                        value={
+                          notificationPreferences.quietHoursTimezone ??
+                          'America/Sao_Paulo'
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Timezone" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="America/Sao_Paulo">
+                            Sao Paulo
+                          </SelectItem>
+                          <SelectItem value="America/Manaus">Manaus</SelectItem>
+                          <SelectItem value="America/Recife">Recife</SelectItem>
+                          <SelectItem value="UTC">UTC</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Janela atual:{' '}
+                      {formatQuietHour(
+                        notificationPreferences.quietHoursStartMinute ?? 22 * 60,
+                      )}{' '}
+                      ate{' '}
+                      {formatQuietHour(
+                        notificationPreferences.quietHoursEndMinute ?? 7 * 60,
+                      )}
+                      .
+                    </div>
                   </div>
                 </div>
               ) : null}


### PR DESCRIPTION
## Summary
- Add persisted notification quiet-hour preferences with timezone, start/end minutes, and migration.
- Defer non-critical email/push delivery attempts by setting `nextAttemptAt` to the end of the user-local quiet window.
- Expose quiet-hour preferences through web sidebar controls, web API types, mobile gateway methods, and the OpenAPI contract.
- Update notification-center docs and mark T267 complete.

## Validation
- `npm run db:generate` (backend)
- `npx prisma format` (backend)
- `npm run db:migrate:policy` (backend)
- `npm run lint` (backend)
- `npm run build` (backend)
- `npm run test -- notifications.service.spec.ts` (backend)
- `npm test` (backend)
- `npm run lint` (web)
- `npm run build` (web)
- `npm run e2e -- --project=chromium` (web, 11 passed / 1 skipped)

## Notes
- Local mobile validation could not run because `dart`/`flutter` is not installed in this environment; mobile gateway test coverage was added for CI.

Refs #451