### PR TITLE
Phase 35 T268 notification delivery admin diagnostics

### DIFF
--- a/backend/prisma/migrations/20260626080000_notification_delivery_admin_controls/migration.sql
+++ b/backend/prisma/migrations/20260626080000_notification_delivery_admin_controls/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "UserNotificationDeliveryStatus" ADD VALUE IF NOT EXISTS 'cancelled';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -209,6 +209,7 @@ enum UserNotificationDeliveryStatus {
   retrying
   delivered
   failed
+  cancelled
 }
 
 enum UserEmailNotificationStatus {

--- a/backend/src/admin/api/admin-dashboard.controller.ts
+++ b/backend/src/admin/api/admin-dashboard.controller.ts
@@ -409,6 +409,13 @@ class CancelProcessingJobDto {
   reason?: string;
 }
 
+class CancelNotificationDeliveryDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}
+
 class ConvertMissingProductRequestDto {
   @IsOptional()
   @IsString()
@@ -545,6 +552,27 @@ export class AdminDashboardController {
   @Get('queue-health')
   async queueHealth() {
     return this.adminDashboardService.getQueueHealth();
+  }
+
+  @Get('notification-deliveries')
+  async listNotificationDeliveries() {
+    return this.adminDashboardService.listNotificationDeliveries();
+  }
+
+  @Post('notification-deliveries/:id/retry')
+  retryNotificationDelivery(@Param('id') id: string) {
+    return this.adminDashboardService.retryNotificationDelivery(id);
+  }
+
+  @Post('notification-deliveries/:id/cancel')
+  cancelNotificationDelivery(
+    @Param('id') id: string,
+    @Body() body: CancelNotificationDeliveryDto,
+  ) {
+    return this.adminDashboardService.cancelNotificationDelivery(
+      id,
+      body.reason,
+    );
   }
 
   @Get('shopping-lists')

--- a/backend/src/admin/application/admin-dashboard.service.ts
+++ b/backend/src/admin/application/admin-dashboard.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  InternalServerErrorException,
   Logger,
   NotFoundException,
   Optional,
@@ -929,6 +930,258 @@ export class AdminDashboardService {
     );
 
     return summary;
+  }
+
+  async listNotificationDeliveries() {
+    const attempts =
+      await this.prisma.userNotificationDeliveryAttempt.findMany({
+        orderBy: [{ updatedAt: 'desc' }, { createdAt: 'desc' }],
+        take: 100,
+        include: {
+          user: {
+            select: {
+              id: true,
+              displayName: true,
+              email: true,
+            },
+          },
+          notification: {
+            select: {
+              id: true,
+              type: true,
+              title: true,
+              resourceType: true,
+              resourceId: true,
+              createdAt: true,
+            },
+          },
+          emailDestination: {
+            select: {
+              id: true,
+              email: true,
+              status: true,
+            },
+          },
+          pushDevice: {
+            select: {
+              id: true,
+              platform: true,
+              provider: true,
+              deviceTokenTail: true,
+              isActive: true,
+            },
+          },
+        },
+      });
+
+    const projected = attempts.map((attempt) =>
+      this.projectNotificationDelivery(attempt),
+    );
+
+    this.logger.log(
+      `Admin notification delivery diagnostics requested: ${projected.length} attempts returned`,
+    );
+
+    return projected;
+  }
+
+  async retryNotificationDelivery(attemptId: string) {
+    await this.requireNotificationsService().retryDeliveryAttempt(attemptId);
+    const [attempt] = await this.listNotificationDeliveriesByIds([attemptId]);
+    if (!attempt) {
+      throw new NotFoundException(
+        `Notification delivery attempt ${attemptId} was not found`,
+      );
+    }
+    return attempt;
+  }
+
+  async cancelNotificationDelivery(attemptId: string, reason?: string) {
+    await this.requireNotificationsService().cancelDeliveryAttempt(
+      attemptId,
+      reason,
+    );
+    const [attempt] = await this.listNotificationDeliveriesByIds([attemptId]);
+    if (!attempt) {
+      throw new NotFoundException(
+        `Notification delivery attempt ${attemptId} was not found`,
+      );
+    }
+    return attempt;
+  }
+
+  private async listNotificationDeliveriesByIds(attemptIds: string[]) {
+    const attempts =
+      await this.prisma.userNotificationDeliveryAttempt.findMany({
+        where: { id: { in: attemptIds } },
+        include: {
+          user: {
+            select: {
+              id: true,
+              displayName: true,
+              email: true,
+            },
+          },
+          notification: {
+            select: {
+              id: true,
+              type: true,
+              title: true,
+              resourceType: true,
+              resourceId: true,
+              createdAt: true,
+            },
+          },
+          emailDestination: {
+            select: {
+              id: true,
+              email: true,
+              status: true,
+            },
+          },
+          pushDevice: {
+            select: {
+              id: true,
+              platform: true,
+              provider: true,
+              deviceTokenTail: true,
+              isActive: true,
+            },
+          },
+        },
+      });
+    return attempts.map((attempt) =>
+      this.projectNotificationDelivery(attempt),
+    );
+  }
+
+  private projectNotificationDelivery(attempt: {
+    id: string;
+    notificationId: string;
+    userId: string;
+    channel: string;
+    status: string;
+    attemptCount: number;
+    maxAttempts: number;
+    providerMessageId: string | null;
+    lastFailureReason: string | null;
+    terminalFailureReason: string | null;
+    nextAttemptAt: Date | null;
+    lastAttemptAt: Date | null;
+    deliveredAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+    user: { id: string; displayName: string; email: string };
+    notification: {
+      id: string;
+      type: string;
+      title: string;
+      resourceType: string | null;
+      resourceId: string | null;
+      createdAt: Date;
+    };
+    emailDestination: {
+      id: string;
+      email: string;
+      status: string;
+    } | null;
+    pushDevice: {
+      id: string;
+      platform: string;
+      provider: string;
+      deviceTokenTail: string;
+      isActive: boolean;
+    } | null;
+  }) {
+    return {
+      id: attempt.id,
+      notificationId: attempt.notificationId,
+      userId: attempt.userId,
+      channel: attempt.channel,
+      status: attempt.status,
+      attemptCount: attempt.attemptCount,
+      maxAttempts: attempt.maxAttempts,
+      providerMessage: this.redactSecret(attempt.providerMessageId),
+      lastFailureReason: this.redactProviderError(
+        attempt.lastFailureReason ?? attempt.terminalFailureReason,
+      ),
+      nextAttemptAt: attempt.nextAttemptAt?.toISOString() ?? null,
+      lastAttemptAt: attempt.lastAttemptAt?.toISOString() ?? null,
+      deliveredAt: attempt.deliveredAt?.toISOString() ?? null,
+      createdAt: attempt.createdAt.toISOString(),
+      updatedAt: attempt.updatedAt.toISOString(),
+      canRetry:
+        ['failed', 'retrying'].includes(attempt.status) &&
+        attempt.attemptCount < attempt.maxAttempts,
+      canCancel: ['queued', 'retrying'].includes(attempt.status),
+      owner: {
+        id: attempt.user.id,
+        displayName: attempt.user.displayName,
+        email: this.maskEmail(attempt.user.email),
+      },
+      notification: {
+        id: attempt.notification.id,
+        type: attempt.notification.type,
+        title: attempt.notification.title,
+        resourceType: attempt.notification.resourceType,
+        resourceId: attempt.notification.resourceId,
+        createdAt: attempt.notification.createdAt.toISOString(),
+      },
+      destination: attempt.emailDestination
+        ? {
+            kind: 'email',
+            id: attempt.emailDestination.id,
+            label: this.maskEmail(attempt.emailDestination.email),
+            status: attempt.emailDestination.status,
+          }
+        : attempt.pushDevice
+          ? {
+              kind: 'push',
+              id: attempt.pushDevice.id,
+              label: `${attempt.pushDevice.platform} ${this.redactSecret(
+                attempt.pushDevice.deviceTokenTail,
+              )}`,
+              status: attempt.pushDevice.isActive ? 'active' : 'revoked',
+              provider: attempt.pushDevice.provider,
+            }
+          : null,
+    };
+  }
+
+  private redactProviderError(reason?: string | null) {
+    if (!reason) {
+      return null;
+    }
+    return reason
+      .slice(0, 500)
+      .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[email]')
+      .replace(/https?:\/\/\S+/gi, '[url]')
+      .replace(/[A-Za-z0-9_-]{24,}/g, '[token]');
+  }
+
+  private redactSecret(value?: string | null) {
+    if (!value) {
+      return null;
+    }
+    const visibleTail = value.slice(-6);
+    return `redacted:${visibleTail}`;
+  }
+
+  private maskEmail(email: string) {
+    const [name, domain] = email.split('@');
+    if (!domain) {
+      return '[email]';
+    }
+    return `${name.slice(0, 2)}***@${domain}`;
+  }
+
+  private requireNotificationsService() {
+    if (!this.notificationsService) {
+      throw new InternalServerErrorException(
+        'Notification delivery service is not available',
+      );
+    }
+    return this.notificationsService;
   }
 
   async listShoppingListAudits() {

--- a/backend/src/common/contracts/admin.contract.ts
+++ b/backend/src/common/contracts/admin.contract.ts
@@ -24,6 +24,55 @@ export interface AdminQueueHealthContract {
   }>;
 }
 
+export interface AdminNotificationDeliveryContract {
+  id: string;
+  notificationId: string;
+  userId: string;
+  channel: 'email' | 'push';
+  status:
+    | 'queued'
+    | 'sending'
+    | 'retrying'
+    | 'delivered'
+    | 'failed'
+    | 'cancelled';
+  attemptCount: number;
+  maxAttempts: number;
+  providerMessage: string | null;
+  lastFailureReason: string | null;
+  nextAttemptAt: string | null;
+  lastAttemptAt: string | null;
+  deliveredAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  canRetry: boolean;
+  canCancel: boolean;
+  owner: {
+    id: string;
+    displayName: string;
+    email: string;
+  };
+  notification: {
+    id: string;
+    type:
+      | 'price_drop'
+      | 'receipt_outcome'
+      | 'optimization_ready'
+      | 'optimization_failed';
+    title: string;
+    resourceType: string | null;
+    resourceId: string | null;
+    createdAt: string;
+  };
+  destination: {
+    kind: 'email' | 'push';
+    id: string;
+    label: string;
+    status: string;
+    provider?: string;
+  } | null;
+}
+
 export interface AdminShoppingListAuditContract {
   id: string;
   name: string;

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,6 +1,10 @@
 import { randomBytes, createHash } from 'node:crypto';
 
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import {
   type Prisma,
   type UserEmailNotificationDestination,
@@ -442,6 +446,44 @@ export class NotificationsService {
           ? null
           : input.reason.slice(0, 500),
         nextAttemptAt: shouldRetry ? input.nextAttemptAt : null,
+      },
+    });
+  }
+
+  async retryDeliveryAttempt(attemptId: string) {
+    const attempt = await this.findDeliveryAttempt(attemptId);
+    if (!['failed', 'retrying'].includes(attempt.status)) {
+      throw new BadRequestException(
+        'Apenas entregas com falha ou retry podem ser reenfileiradas',
+      );
+    }
+    if (attempt.attemptCount >= attempt.maxAttempts) {
+      throw new BadRequestException('Limite de tentativas ja foi atingido');
+    }
+    return this.prisma.userNotificationDeliveryAttempt.update({
+      where: { id: attempt.id },
+      data: {
+        status: 'queued',
+        lastFailureReason: null,
+        terminalFailureReason: null,
+        nextAttemptAt: new Date(),
+      },
+    });
+  }
+
+  async cancelDeliveryAttempt(attemptId: string, reason?: string) {
+    const attempt = await this.findDeliveryAttempt(attemptId);
+    if (!['queued', 'retrying'].includes(attempt.status)) {
+      throw new BadRequestException(
+        'Apenas entregas aguardando envio podem ser canceladas',
+      );
+    }
+    return this.prisma.userNotificationDeliveryAttempt.update({
+      where: { id: attempt.id },
+      data: {
+        status: 'cancelled',
+        nextAttemptAt: null,
+        terminalFailureReason: (reason ?? 'admin_cancelled').slice(0, 500),
       },
     });
   }

--- a/backend/test/unit/admin/admin-dashboard.service.spec.ts
+++ b/backend/test/unit/admin/admin-dashboard.service.spec.ts
@@ -445,6 +445,104 @@ describe('AdminDashboardService', () => {
     expect(logSpy).toHaveBeenCalledWith('Admin updated region region-1');
   });
 
+  it('projects notification delivery diagnostics with redacted provider data and delegates admin actions', async () => {
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    const deliveryAttempt = {
+      id: 'attempt-1',
+      notificationId: 'notification-1',
+      userId: 'user-1',
+      channel: 'email',
+      status: 'failed',
+      attemptCount: 1,
+      maxAttempts: 3,
+      providerMessageId: 'provider-message-secret-1234567890',
+      lastFailureReason:
+        'provider rejected cliente@pricely.local token abcdefghijklmnopqrstuvwxyz url https://provider.example/error',
+      terminalFailureReason: null,
+      nextAttemptAt: null,
+      lastAttemptAt: new Date('2026-06-26T10:00:00Z'),
+      deliveredAt: null,
+      createdAt: new Date('2026-06-26T09:00:00Z'),
+      updatedAt: new Date('2026-06-26T10:01:00Z'),
+      user: {
+        id: 'user-1',
+        displayName: 'Cliente 1',
+        email: 'cliente@pricely.local',
+      },
+      notification: {
+        id: 'notification-1',
+        type: 'price_drop',
+        title: 'Preco menor',
+        resourceType: 'product_offer',
+        resourceId: 'offer-1',
+        createdAt: new Date('2026-06-26T08:59:00Z'),
+      },
+      emailDestination: {
+        id: 'destination-1',
+        email: 'cliente@pricely.local',
+        status: 'verified',
+      },
+      pushDevice: null,
+    };
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findMany: jest.fn().mockResolvedValue([deliveryAttempt]),
+      },
+    };
+    const notificationsService = {
+      retryDeliveryAttempt: jest.fn().mockResolvedValue(null),
+      cancelDeliveryAttempt: jest.fn().mockResolvedValue(null),
+    };
+    const service = new AdminDashboardService(
+      prisma as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      notificationsService as never,
+    );
+
+    await expect(service.listNotificationDeliveries()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'attempt-1',
+        status: 'failed',
+        providerMessage: 'redacted:567890',
+        lastFailureReason:
+          'provider rejected [email] token [token] url [url]',
+        canRetry: true,
+        canCancel: false,
+        owner: {
+          id: 'user-1',
+          displayName: 'Cliente 1',
+          email: 'cl***@pricely.local',
+        },
+        destination: {
+          kind: 'email',
+          id: 'destination-1',
+          label: 'cl***@pricely.local',
+          status: 'verified',
+        },
+      }),
+    ]);
+
+    await service.retryNotificationDelivery('attempt-1');
+    await service.cancelNotificationDelivery('attempt-1', 'admin cancel');
+
+    expect(notificationsService.retryDeliveryAttempt).toHaveBeenCalledWith(
+      'attempt-1',
+    );
+    expect(notificationsService.cancelDeliveryAttempt).toHaveBeenCalledWith(
+      'attempt-1',
+      'admin cancel',
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Admin notification delivery diagnostics'),
+    );
+  });
+
   it('projects receipt line extraction, maker action, and price comparison for admin review', async () => {
     const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
     const prisma = {

--- a/backend/test/unit/notifications/notifications.service.spec.ts
+++ b/backend/test/unit/notifications/notifications.service.spec.ts
@@ -618,6 +618,59 @@ describe('NotificationsService', () => {
     });
   });
 
+  it('requeues retryable delivery attempts without clearing attempt history', async () => {
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'attempt-1',
+          status: 'failed',
+          attemptCount: 1,
+          maxAttempts: 3,
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'attempt-1' }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.retryDeliveryAttempt('attempt-1');
+
+    expect(prisma.userNotificationDeliveryAttempt.update).toHaveBeenCalledWith({
+      where: { id: 'attempt-1' },
+      data: expect.objectContaining({
+        status: 'queued',
+        lastFailureReason: null,
+        terminalFailureReason: null,
+        nextAttemptAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it('cancels queued delivery attempts with an admin-visible terminal reason', async () => {
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'attempt-1',
+          status: 'queued',
+          attemptCount: 0,
+          maxAttempts: 3,
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'attempt-1' }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.cancelDeliveryAttempt('attempt-1', 'cancelado pelo admin');
+
+    expect(prisma.userNotificationDeliveryAttempt.update).toHaveBeenCalledWith({
+      where: { id: 'attempt-1' },
+      data: {
+        status: 'cancelled',
+        nextAttemptAt: null,
+        terminalFailureReason: 'cancelado pelo admin',
+      },
+    });
+  });
+
   it('marks delivery success with provider message id', async () => {
     const prisma = {
       userNotificationDeliveryAttempt: {

--- a/docs/product/notification-center.md
+++ b/docs/product/notification-center.md
@@ -35,6 +35,9 @@ as a controlled fan-out layer.
   preferences.
 - Track delivery attempts, provider message id, terminal failure, and retryable
   failure reason without storing provider payloads that may contain personal data.
+- Expose admin diagnostics with masked destinations, redacted provider errors,
+  manual retry for retryable attempts, and cancellation for queued/retrying
+  attempts.
 
 ### Push
 
@@ -57,7 +60,8 @@ as a controlled fan-out layer.
 - Use bounded exponential retry for provider failures and stop retrying after a
   terminal provider response.
 - Expose delivery state in admin diagnostics before enabling automatic external
-  sends broadly.
+  sends broadly; provider message ids, emails, push token tails, URLs, and long
+  tokens must not be shown raw in the dashboard.
 
 ### Release validation
 

--- a/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
+++ b/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
@@ -355,6 +355,30 @@ paths:
       responses:
         '201':
           description: Job removed from the waiting queue and audit retained
+  /admin/notification-deliveries:
+    get:
+      summary: List redacted notification delivery attempts for admin diagnostics
+      responses:
+        '200':
+          description: Notification delivery attempts returned newest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminNotificationDelivery'
+  /admin/notification-deliveries/{attemptId}/retry:
+    post:
+      summary: Requeue a failed or retrying notification delivery attempt
+      responses:
+        '201':
+          description: Delivery attempt requeued when retry budget remains
+  /admin/notification-deliveries/{attemptId}/cancel:
+    post:
+      summary: Cancel a queued or retrying notification delivery attempt
+      responses:
+        '201':
+          description: Delivery attempt cancelled with audit reason
   /admin/missing-product-requests:
     get:
       summary: List shopper missing-product requests for catalog triage
@@ -997,6 +1021,125 @@ components:
         lastSeenAt:
           type: string
           format: date-time
+    AdminNotificationDelivery:
+      type: object
+      required:
+        [
+          id,
+          notificationId,
+          userId,
+          channel,
+          status,
+          attemptCount,
+          maxAttempts,
+          createdAt,
+          updatedAt,
+          canRetry,
+          canCancel,
+          owner,
+          notification,
+        ]
+      properties:
+        id:
+          type: string
+        notificationId:
+          type: string
+        userId:
+          type: string
+        channel:
+          type: string
+          enum: [email, push]
+        status:
+          type: string
+          enum: [queued, sending, retrying, delivered, failed, cancelled]
+        attemptCount:
+          type: integer
+        maxAttempts:
+          type: integer
+        providerMessage:
+          type: string
+          nullable: true
+          description: Redacted provider id, never the raw provider message id
+        lastFailureReason:
+          type: string
+          nullable: true
+          description: Provider/user-sensitive values are redacted
+        nextAttemptAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastAttemptAt:
+          type: string
+          format: date-time
+          nullable: true
+        deliveredAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        canRetry:
+          type: boolean
+        canCancel:
+          type: boolean
+        owner:
+          type: object
+          required: [id, displayName, email]
+          properties:
+            id:
+              type: string
+            displayName:
+              type: string
+            email:
+              type: string
+              description: Masked email
+        notification:
+          type: object
+          required: [id, type, title, createdAt]
+          properties:
+            id:
+              type: string
+            type:
+              type: string
+              enum:
+                [
+                  price_drop,
+                  receipt_outcome,
+                  optimization_ready,
+                  optimization_failed,
+                ]
+            title:
+              type: string
+            resourceType:
+              type: string
+              nullable: true
+            resourceId:
+              type: string
+              nullable: true
+            createdAt:
+              type: string
+              format: date-time
+        destination:
+          type: object
+          nullable: true
+          required: [kind, id, label, status]
+          properties:
+            kind:
+              type: string
+              enum: [email, push]
+            id:
+              type: string
+            label:
+              type: string
+              description: Masked destination label
+            status:
+              type: string
+            provider:
+              type: string
     AuthSession:
       type: object
       required: [accessToken, user]

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -631,7 +631,7 @@ channels without enabling provider sends prematurely.
 - [X] T265 Add user email destination verification, unsubscribe/category mapping, and email delivery queue integration in `backend/src/notifications/` and `backend/src/users/`
 - [X] T266 Add mobile push device registration, token refresh/revocation, and authenticated device listing in `backend/src/notifications/` and `mobile/lib/features/`
 - [X] T267 Add quiet-hour preferences with timezone-aware deferral for non-critical notifications in `backend/src/notifications/`, `web/src/components/design-system/`, and `mobile/lib/features/`
-- [ ] T268 Add admin notification delivery diagnostics, retry/cancel controls, and provider-error redaction in `web/src/dashboard/` and `backend/src/admin/`
+- [X] T268 Add admin notification delivery diagnostics, retry/cancel controls, and provider-error redaction in `web/src/dashboard/` and `backend/src/admin/`
 - [ ] T269 Add backend, web, and mobile coverage for delivery preferences, quiet-hour deferral, device registration, retry policy, and redacted admin diagnostics in `backend/test/`, `web/src/`, and `mobile/test/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -460,6 +460,55 @@ type AdminProcessingJobResponse = {
   } | null;
 };
 
+type AdminNotificationDeliveryResponse = {
+  id: string;
+  notificationId: string;
+  userId: string;
+  channel: 'email' | 'push';
+  status:
+    | 'queued'
+    | 'sending'
+    | 'retrying'
+    | 'delivered'
+    | 'failed'
+    | 'cancelled';
+  attemptCount: number;
+  maxAttempts: number;
+  providerMessage?: string | null;
+  lastFailureReason?: string | null;
+  nextAttemptAt?: string | null;
+  lastAttemptAt?: string | null;
+  deliveredAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  canRetry: boolean;
+  canCancel: boolean;
+  owner: {
+    id: string;
+    displayName: string;
+    email: string;
+  };
+  notification: {
+    id: string;
+    type:
+      | 'price_drop'
+      | 'receipt_outcome'
+      | 'optimization_ready'
+      | 'optimization_failed';
+    title: string;
+    resourceType?: string | null;
+    resourceId?: string | null;
+    createdAt: string;
+  };
+  destination?: {
+    kind: 'email' | 'push';
+    id: string;
+    label: string;
+    status: string;
+    provider?: string;
+  } | null;
+};
+
 type AdminProcessingJobDetailResponse = AdminProcessingJobResponse & {
   optimizationRun?:
     | (NonNullable<AdminProcessingJobResponse['optimizationRun']> & {
@@ -1414,6 +1463,40 @@ export async function cancelAdminProcessingJob(
   );
 }
 
+export async function fetchAdminNotificationDeliveries(token: string) {
+  return apiFetch<AdminNotificationDeliveryResponse[]>(
+    '/admin/notification-deliveries',
+    {},
+    token,
+  );
+}
+
+export async function retryAdminNotificationDelivery(
+  token: string,
+  id: string,
+) {
+  return apiFetch<AdminNotificationDeliveryResponse>(
+    `/admin/notification-deliveries/${id}/retry`,
+    { method: 'POST' },
+    token,
+  );
+}
+
+export async function cancelAdminNotificationDelivery(
+  token: string,
+  id: string,
+  reason?: string,
+) {
+  return apiFetch<AdminNotificationDeliveryResponse>(
+    `/admin/notification-deliveries/${id}/cancel`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ reason }),
+    },
+    token,
+  );
+}
+
 export async function fetchAdminMissingProductRequests(token: string) {
   return apiFetch<MissingProductRequestResponse[]>(
     '/admin/missing-product-requests',
@@ -1867,6 +1950,7 @@ export type {
   AdminMetricsResponse,
   AdminPublicSearchMetricsResponse,
   AdminOfferResponse,
+  AdminNotificationDeliveryResponse,
   AdminProductResponse,
   AdminProductVariantResponse,
   AdminProcessingJobResponse,

--- a/web/src/components/design-system/status-badge.tsx
+++ b/web/src/components/design-system/status-badge.tsx
@@ -69,9 +69,12 @@ const statusPresets = {
   },
   queue: {
     queued: { icon: Clock3Icon, label: 'Na fila', tone: 'location' },
+    sending: { icon: Clock3Icon, label: 'Enviando', tone: 'primary' },
     running: { icon: Clock3Icon, label: 'Executando', tone: 'primary' },
     retrying: { icon: AlertTriangleIcon, label: 'Tentando novamente', tone: 'warning' },
     failed: { icon: XCircleIcon, label: 'Falhou', tone: 'critical' },
+    cancelled: { icon: CircleIcon, label: 'Cancelado', tone: 'neutral' },
+    delivered: { icon: CheckCircle2Icon, label: 'Entregue', tone: 'savings' },
     completed: { icon: CheckCircle2Icon, label: 'Concluido', tone: 'savings' },
   },
   receipt: {

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -34,6 +34,7 @@ const fetchAdminMetrics = vi.fn();
 const fetchAdminPublicSearchMetrics = vi.fn();
 const fetchAdminQueueHealth = vi.fn();
 const fetchAdminProcessingJobs = vi.fn();
+const fetchAdminNotificationDeliveries = vi.fn();
 const fetchAdminProcessingJobDetail = vi.fn();
 const fetchAdminReceiptProcessing = vi.fn();
 const fetchAdminReceiptProcessingDetail = vi.fn();
@@ -51,6 +52,8 @@ const rejectAdminMissingProductRequest = vi.fn();
 const retryAdminProcessingJob = vi.fn();
 const reviewAdminProcessingJob = vi.fn();
 const cancelAdminProcessingJob = vi.fn();
+const retryAdminNotificationDelivery = vi.fn();
+const cancelAdminNotificationDelivery = vi.fn();
 const createAdminOffer = vi.fn();
 const updateAdminOffer = vi.fn();
 const deleteAdminProduct = vi.fn();
@@ -90,6 +93,8 @@ vi.mock('@/app/api', () => ({
   fetchAdminQueueHealth: (...args: unknown[]) => fetchAdminQueueHealth(...args),
   fetchAdminProcessingJobs: (...args: unknown[]) =>
     fetchAdminProcessingJobs(...args),
+  fetchAdminNotificationDeliveries: (...args: unknown[]) =>
+    fetchAdminNotificationDeliveries(...args),
   fetchAdminProcessingJobDetail: (...args: unknown[]) =>
     fetchAdminProcessingJobDetail(...args),
   fetchAdminReceiptProcessing: (...args: unknown[]) =>
@@ -129,6 +134,10 @@ vi.mock('@/app/api', () => ({
     reviewAdminProcessingJob(...args),
   cancelAdminProcessingJob: (...args: unknown[]) =>
     cancelAdminProcessingJob(...args),
+  retryAdminNotificationDelivery: (...args: unknown[]) =>
+    retryAdminNotificationDelivery(...args),
+  cancelAdminNotificationDelivery: (...args: unknown[]) =>
+    cancelAdminNotificationDelivery(...args),
   createAdminOffer: (...args: unknown[]) => createAdminOffer(...args),
   createAdminProduct: vi.fn(),
   createAdminProductVariant: vi.fn(),
@@ -302,6 +311,7 @@ describe('Admin dashboard pages', () => {
     fetchAdminPublicSearchMetrics.mockReset();
     fetchAdminQueueHealth.mockReset();
     fetchAdminProcessingJobs.mockReset();
+    fetchAdminNotificationDeliveries.mockReset();
     fetchAdminProcessingJobDetail.mockReset();
     fetchAdminReceiptProcessing.mockReset();
     fetchAdminReceiptProcessingDetail.mockReset();
@@ -319,7 +329,10 @@ describe('Admin dashboard pages', () => {
     retryAdminProcessingJob.mockReset();
     reviewAdminProcessingJob.mockReset();
     cancelAdminProcessingJob.mockReset();
+    retryAdminNotificationDelivery.mockReset();
+    cancelAdminNotificationDelivery.mockReset();
     fetchAdminMissingProductRequests.mockResolvedValue([]);
+    fetchAdminNotificationDeliveries.mockResolvedValue([]);
     createAdminOffer.mockReset();
     updateAdminOffer.mockReset();
     deleteAdminProduct.mockReset();
@@ -486,6 +499,46 @@ describe('Admin dashboard pages', () => {
         },
       },
     ]);
+    fetchAdminNotificationDeliveries.mockResolvedValue([
+      {
+        id: 'attempt-1',
+        notificationId: 'notification-1',
+        userId: 'user-1',
+        channel: 'email',
+        status: 'failed',
+        attemptCount: 1,
+        maxAttempts: 3,
+        providerMessage: 'redacted:123456',
+        lastFailureReason: 'provider rejected [email] token [token]',
+        nextAttemptAt: null,
+        lastAttemptAt: '2026-05-10T04:02:00.000Z',
+        deliveredAt: null,
+        createdAt: '2026-05-10T04:00:00.000Z',
+        updatedAt: '2026-05-10T04:03:00.000Z',
+        canRetry: true,
+        canCancel: false,
+        owner: {
+          id: 'user-1',
+          displayName: 'Cliente Teste',
+          email: 'cl***@pricely.local',
+        },
+        notification: {
+          id: 'notification-1',
+          type: 'price_drop',
+          title: 'Preco menor para arroz',
+          resourceType: 'product_offer',
+          resourceId: 'offer-1',
+          createdAt: '2026-05-10T04:00:00.000Z',
+        },
+        destination: {
+          kind: 'email',
+          id: 'destination-1',
+          label: 'cl***@pricely.local',
+          status: 'verified',
+        },
+      },
+    ]);
+    retryAdminNotificationDelivery.mockResolvedValue({});
 
     render(<AdminQueuePage />);
 
@@ -496,6 +549,19 @@ describe('Admin dashboard pages', () => {
     expect(screen.getByText('Lista: Compra da semana')).toBeTruthy();
     expect(screen.getByText(/Menor total na cidade/)).toBeTruthy();
     expect(screen.getByLabelText('Abrir detalhe do job job-1')).toBeTruthy();
+    expect(await screen.findByText('Entregas de notificações')).toBeTruthy();
+    expect(screen.getByText('Preco menor para arroz')).toBeTruthy();
+    expect(screen.getAllByText(/cl\*\*\*@pricely.local/).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByText(/provider rejected \[email\]/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    await waitFor(() =>
+      expect(retryAdminNotificationDelivery).toHaveBeenCalledWith(
+        'token',
+        'attempt-1',
+      ),
+    );
     expect(screen.queryByText('Go to link')).toBeNull();
   });
 

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -23,6 +23,7 @@ import {
   type AdminEstablishmentResponse,
   type AdminMetricsResponse,
   type MissingProductRequestResponse,
+  type AdminNotificationDeliveryResponse,
   type AdminOfferResponse,
   type AdminPublicSearchMetricsResponse,
   type AdminProcessingJobDetailResponse,
@@ -40,11 +41,13 @@ import {
   createAdminProductVariant,
   createAdminRegion,
   convertAdminMissingProductRequest,
+  cancelAdminNotificationDelivery,
   deleteAdminProduct,
   deleteAdminProductVariant,
   fetchAdminEstablishments,
   fetchAdminMetrics,
   fetchAdminMissingProductRequests,
+  fetchAdminNotificationDeliveries,
   fetchAdminOffers,
   fetchAdminProcessingJobDetail,
   fetchAdminProcessingJobs,
@@ -63,6 +66,7 @@ import {
   rejectAdminReceiptProcessing,
   rejectAdminMissingProductRequest,
   reprocessAdminReceiptProcessing,
+  retryAdminNotificationDelivery,
   retryAdminProcessingJob,
   reviewAdminProcessingJob,
   setAdminUserPremium,
@@ -299,6 +303,36 @@ function jobSeverity(status: AdminProcessingJobResponse['status']) {
     return 'healthy' as const;
   }
 
+  return 'info' as const;
+}
+
+function notificationDeliveryStatusLabel(
+  status: AdminNotificationDeliveryResponse['status'],
+) {
+  const labels: Record<AdminNotificationDeliveryResponse['status'], string> = {
+    cancelled: 'Cancelada',
+    delivered: 'Entregue',
+    failed: 'Falhou',
+    queued: 'Em fila',
+    retrying: 'Tentando novamente',
+    sending: 'Enviando',
+  };
+
+  return labels[status];
+}
+
+function notificationDeliverySeverity(
+  status: AdminNotificationDeliveryResponse['status'],
+) {
+  if (status === 'failed') {
+    return 'critical' as const;
+  }
+  if (status === 'queued' || status === 'retrying' || status === 'sending') {
+    return 'warning' as const;
+  }
+  if (status === 'delivered') {
+    return 'healthy' as const;
+  }
   return 'info' as const;
 }
 
@@ -5217,6 +5251,7 @@ export function AdminReceiptAuditPage() {
 }
 
 export function AdminQueuePage() {
+  const { accessToken } = usePricely();
   const { data: metrics } = useAdminData<AdminMetricsResponse | null>(
     fetchAdminMetrics,
     null,
@@ -5229,6 +5264,51 @@ export function AdminQueuePage() {
     fetchAdminQueueHealth,
     null,
   );
+  const {
+    data: notificationDeliveries,
+    error: notificationDeliveriesError,
+    reload: reloadNotificationDeliveries,
+  } = useAdminData<AdminNotificationDeliveryResponse[]>(
+    fetchAdminNotificationDeliveries,
+    [],
+  );
+  const [deliveryActionError, setDeliveryActionError] = useState<string | null>(
+    null,
+  );
+  const [activeDeliveryAction, setActiveDeliveryAction] = useState<
+    string | null
+  >(null);
+
+  const runDeliveryAction = async (
+    delivery: AdminNotificationDeliveryResponse,
+    action: 'retry' | 'cancel',
+  ) => {
+    if (!accessToken) {
+      return;
+    }
+    setDeliveryActionError(null);
+    setActiveDeliveryAction(`${action}:${delivery.id}`);
+    try {
+      if (action === 'retry') {
+        await retryAdminNotificationDelivery(accessToken, delivery.id);
+      } else {
+        await cancelAdminNotificationDelivery(
+          accessToken,
+          delivery.id,
+          'Cancelada pelo painel administrativo.',
+        );
+      }
+      await reloadNotificationDeliveries();
+    } catch (error) {
+      setDeliveryActionError(
+        error instanceof Error
+          ? error.message
+          : 'Nao foi possivel alterar a entrega.',
+      );
+    } finally {
+      setActiveDeliveryAction(null);
+    }
+  };
 
   return (
     <div className="grid gap-4 lg:grid-cols-[0.72fr_1.28fr]">
@@ -5377,6 +5457,130 @@ export function AdminQueuePage() {
                       >
                         <ExternalLinkIcon className="size-4" />
                       </a>
+                    </Button>
+                  </WithTooltip>
+                </div>
+              }
+            />
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card className="border-border/70 bg-card/90 shadow-sm lg:col-span-2">
+        <CardHeader>
+          <CardTitle>Entregas de notificações</CardTitle>
+          <CardDescription>
+            Diagnóstico de email e push com dados sensíveis redigidos antes de
+            aparecer no painel.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3">
+          {notificationDeliveriesError ? (
+            <Alert variant="destructive">
+              <AlertTitle>Falha ao carregar entregas</AlertTitle>
+              <AlertDescription>{notificationDeliveriesError}</AlertDescription>
+            </Alert>
+          ) : null}
+          {deliveryActionError ? (
+            <Alert variant="destructive">
+              <AlertTitle>Ação não executada</AlertTitle>
+              <AlertDescription>{deliveryActionError}</AlertDescription>
+            </Alert>
+          ) : null}
+          {notificationDeliveries.length === 0 ? (
+            <ActionPlaceholder
+              icon={<BellRingIcon className="size-5" />}
+              title="Nenhuma entrega de notificação"
+              description="Email e push aparecerão aqui quando notificações gerarem tentativas de entrega. A central in-app continua registrada separadamente."
+              primaryAction={<a href="/dashboard">Ver overview</a>}
+              secondaryAction={<a href="/dashboard/fila">Ver jobs</a>}
+            />
+          ) : null}
+          {notificationDeliveries.slice(0, 12).map((delivery) => (
+            <AdminActionQueueItem
+              key={delivery.id}
+              severity={notificationDeliverySeverity(delivery.status)}
+              severityTooltip={`Entrega ${notificationDeliveryStatusLabel(
+                delivery.status,
+              ).toLowerCase()} para ${delivery.channel}.`}
+              title={
+                <span className="inline-flex min-w-0 items-center gap-2">
+                  <span className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/70 bg-card text-muted-foreground">
+                    <BellRingIcon className="size-4" />
+                  </span>
+                  <span className="truncate">
+                    {delivery.notification.title}
+                  </span>
+                </span>
+              }
+              description={
+                <>
+                  {delivery.owner.displayName} · {delivery.owner.email} ·{' '}
+                  {delivery.destination?.label ?? 'Destino não vinculado'}
+                  {delivery.lastFailureReason ? (
+                    <span className="mt-2 block rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-destructive">
+                      {delivery.lastFailureReason}
+                    </span>
+                  ) : null}
+                </>
+              }
+              age={`Atualizada ${formatFreshnessLabel(delivery.updatedAt)}`}
+              context={
+                <>
+                  {delivery.channel} · tentativa {delivery.attemptCount}/
+                  {delivery.maxAttempts}
+                  {delivery.nextAttemptAt
+                    ? ` · próxima ${formatFreshnessLabel(delivery.nextAttemptAt)}`
+                    : ''}
+                </>
+              }
+              meta={
+                <>
+                  ID técnico: entrega {delivery.id} · notificação{' '}
+                  {delivery.notificationId}
+                  {delivery.providerMessage
+                    ? ` · provider ${delivery.providerMessage}`
+                    : ''}
+                </>
+              }
+              action={
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  <StatusBadge
+                    family="queue"
+                    status={delivery.status}
+                    tooltip={`Status de entrega ${delivery.channel}.`}
+                  >
+                    {notificationDeliveryStatusLabel(delivery.status)}
+                  </StatusBadge>
+                  <WithTooltip label="Reenfileira a entrega quando ainda há tentativas disponíveis.">
+                    <Button
+                      disabled={
+                        !delivery.canRetry || activeDeliveryAction !== null
+                      }
+                      onClick={() => void runDeliveryAction(delivery, 'retry')}
+                      size="sm"
+                      type="button"
+                      variant="outline"
+                    >
+                      {activeDeliveryAction === `retry:${delivery.id}`
+                        ? 'Reenfileirando...'
+                        : 'Retry'}
+                    </Button>
+                  </WithTooltip>
+                  <WithTooltip label="Cancela entregas ainda em fila ou retry, preservando o histórico.">
+                    <Button
+                      className="border-destructive/40 text-destructive hover:bg-destructive/10"
+                      disabled={
+                        !delivery.canCancel || activeDeliveryAction !== null
+                      }
+                      onClick={() => void runDeliveryAction(delivery, 'cancel')}
+                      size="sm"
+                      type="button"
+                      variant="outline"
+                    >
+                      {activeDeliveryAction === `cancel:${delivery.id}`
+                        ? 'Cancelando...'
+                        : 'Cancelar'}
                     </Button>
                   </WithTooltip>
                 </div>


### PR DESCRIPTION
## Summary
- Add admin notification delivery diagnostics with masked owner/destination labels and redacted provider errors.
- Add notification delivery retry and cancel controls, including `cancelled` delivery status persistence.
- Surface email/push delivery attempts in `/dashboard/fila` with retry/cancel actions wired to admin APIs.
- Update OpenAPI/backend contracts, notification delivery docs, and mark T268 complete.

## Validation
- `npm run db:generate` (backend)
- `npx prisma format` (backend)
- `npm run db:migrate:policy` (backend)
- `npm run test -- notifications.service.spec.ts admin-dashboard.service.spec.ts` (backend)
- `npm run build` (backend)
- `npm run lint` (backend)
- `npm test` (backend)
- `npm run test -- dashboard-pages.spec.tsx` (web)
- `npm run build` (web)
- `npm run lint` (web)
- `npm test` (web)
- `npm run e2e -- --project=chromium` (web, 11 passed / 1 skipped)

Refs #453