### PR TITLE
Phase 35 T269 notification delivery coverage

### DIFF
--- a/backend/test/unit/admin/admin-dashboard.service.spec.ts
+++ b/backend/test/unit/admin/admin-dashboard.service.spec.ts
@@ -543,6 +543,90 @@ describe('AdminDashboardService', () => {
     );
   });
 
+  it('projects push notification delivery diagnostics without raw provider tokens', async () => {
+    const deliveryAttempt = {
+      id: 'attempt-push-1',
+      notificationId: 'notification-1',
+      userId: 'user-1',
+      channel: 'push',
+      status: 'retrying',
+      attemptCount: 2,
+      maxAttempts: 4,
+      providerMessageId: 'projects/pricely/messages/0:push-secret-token-tail',
+      lastFailureReason:
+        'push token abcdefghijklmnopqrstuvwxyz for cliente@pricely.local returned https://fcm.example/error',
+      terminalFailureReason: null,
+      nextAttemptAt: new Date('2026-06-26T11:00:00Z'),
+      lastAttemptAt: new Date('2026-06-26T10:00:00Z'),
+      deliveredAt: null,
+      createdAt: new Date('2026-06-26T09:00:00Z'),
+      updatedAt: new Date('2026-06-26T10:01:00Z'),
+      user: {
+        id: 'user-1',
+        displayName: 'Cliente 1',
+        email: 'cliente@pricely.local',
+      },
+      notification: {
+        id: 'notification-1',
+        type: 'optimization_ready',
+        title: 'Lista pronta',
+        resourceType: 'optimization_run',
+        resourceId: 'run-1',
+        createdAt: new Date('2026-06-26T08:59:00Z'),
+      },
+      emailDestination: null,
+      pushDevice: {
+        id: 'device-1',
+        platform: 'android',
+        provider: 'fcm',
+        deviceTokenTail: 'token-tail-123',
+        isActive: true,
+      },
+    };
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findMany: jest.fn().mockResolvedValue([deliveryAttempt]),
+      },
+    };
+    const service = new AdminDashboardService(
+      prisma as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+    await expect(service.listNotificationDeliveries()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'attempt-push-1',
+        channel: 'push',
+        status: 'retrying',
+        providerMessage: 'redacted:n-tail',
+        lastFailureReason: 'push token [token] for [email] returned [url]',
+        canRetry: true,
+        canCancel: true,
+        destination: {
+          kind: 'push',
+          id: 'device-1',
+          label: 'android redacted:il-123',
+          status: 'active',
+          provider: 'fcm',
+        },
+      }),
+    ]);
+
+    const [projected] = await service.listNotificationDeliveries();
+    expect(JSON.stringify(projected)).not.toContain(
+      'abcdefghijklmnopqrstuvwxyz',
+    );
+    expect(JSON.stringify(projected)).not.toContain('cliente@pricely.local');
+    expect(JSON.stringify(projected)).not.toContain('https://fcm.example');
+  });
+
   it('projects receipt line extraction, maker action, and price comparison for admin review', async () => {
     const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
     const prisma = {

--- a/backend/test/unit/notifications/notifications.service.spec.ts
+++ b/backend/test/unit/notifications/notifications.service.spec.ts
@@ -533,6 +533,60 @@ describe('NotificationsService', () => {
     });
   });
 
+  it('defers push delivery attempts during quiet hours using the same outbound policy as email', async () => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2026-06-26T23:30:00.000Z').getTime());
+    const prisma = {
+      userNotificationPreference: {
+        upsert: jest.fn().mockResolvedValue({
+          inAppEnabled: true,
+          emailEnabled: false,
+          pushEnabled: true,
+          priceDropsEnabled: true,
+          receiptOutcomesEnabled: true,
+          optimizationReadyEnabled: true,
+          quietHoursEnabled: true,
+          quietHoursStartMinute: 22 * 60,
+          quietHoursEndMinute: 7 * 60,
+          quietHoursTimezone: 'UTC',
+        }),
+      },
+      userNotification: {
+        create: jest.fn().mockResolvedValue({
+          id: 'notification-1',
+          userId: 'user-1',
+          type: 'optimization_ready',
+        }),
+      },
+      userPushDevice: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'device-1' }]),
+      },
+      userNotificationDeliveryAttempt: {
+        create: jest.fn().mockResolvedValue({ id: 'attempt-1' }),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await service.create({
+      userId: 'user-1',
+      type: 'optimization_ready',
+      title: 'Otimizacao pronta',
+      message: 'Sua lista foi otimizada.',
+    });
+
+    expect(prisma.userNotificationDeliveryAttempt.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        notificationId: 'notification-1',
+        userId: 'user-1',
+        channel: 'push',
+        pushDeviceId: 'device-1',
+        nextAttemptAt: new Date('2026-06-27T07:00:00.000Z'),
+      }),
+    });
+    jest.useRealTimers();
+  });
+
   it('marks a delivery attempt as sending and increments attempt count', async () => {
     const prisma = {
       userNotificationDeliveryAttempt: {
@@ -643,6 +697,46 @@ describe('NotificationsService', () => {
         nextAttemptAt: expect.any(Date),
       }),
     });
+  });
+
+  it('rejects delivery retry after the attempt budget is exhausted', async () => {
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'attempt-1',
+          status: 'failed',
+          attemptCount: 3,
+          maxAttempts: 3,
+        }),
+        update: jest.fn(),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await expect(service.retryDeliveryAttempt('attempt-1')).rejects.toThrow(
+      'Limite de tentativas ja foi atingido',
+    );
+    expect(prisma.userNotificationDeliveryAttempt.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects cancellation for terminal delivery attempts', async () => {
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'attempt-1',
+          status: 'delivered',
+          attemptCount: 1,
+          maxAttempts: 3,
+        }),
+        update: jest.fn(),
+      },
+    } as any;
+    const service = new NotificationsService(prisma);
+
+    await expect(service.cancelDeliveryAttempt('attempt-1')).rejects.toThrow(
+      'Apenas entregas aguardando envio podem ser canceladas',
+    );
+    expect(prisma.userNotificationDeliveryAttempt.update).not.toHaveBeenCalled();
   });
 
   it('cancels queued delivery attempts with an admin-visible terminal reason', async () => {

--- a/mobile/test/unit/features/receipts/receipt_backend_gateway_test.dart
+++ b/mobile/test/unit/features/receipts/receipt_backend_gateway_test.dart
@@ -105,6 +105,9 @@ void main() {
             expect(body['platform'], 'android');
             expect(body['deviceToken'], 'push-token-value-1234567890');
             expect(body['provider'], 'fcm');
+            expect(body['appVersion'], '1.2.3');
+            expect(body['locale'], 'pt-BR');
+            expect(body['timezone'], 'America/Sao_Paulo');
             return http.Response(
               jsonEncode(<String, dynamic>{
                 'id': 'device-1',
@@ -112,6 +115,9 @@ void main() {
                 'provider': 'fcm',
                 'deviceTokenTail': 'e-1234567890',
                 'isActive': true,
+                'appVersion': '1.2.3',
+                'locale': 'pt-BR',
+                'timezone': 'America/Sao_Paulo',
                 'lastSeenAt': '2026-06-26T12:00:00.000Z',
               }),
               201,
@@ -143,6 +149,9 @@ void main() {
       accessToken: 'token-123',
       platform: 'android',
       deviceToken: 'push-token-value-1234567890',
+      appVersion: '1.2.3',
+      locale: 'pt-BR',
+      timezone: 'America/Sao_Paulo',
     );
     final revoked = await gateway.revokePushDevice(
       accessToken: 'token-123',
@@ -151,11 +160,54 @@ void main() {
 
     expect(registered.id, 'device-1');
     expect(registered.isActive, isTrue);
+    expect(registered.timezone, 'America/Sao_Paulo');
     expect(revoked.isActive, isFalse);
     expect(requestedPaths, <String>[
       '/notification-push-devices',
       '/notification-push-devices/device-1/revoke',
     ]);
+  });
+
+  test('lists authenticated push devices with redacted token tails only', () async {
+    final gateway = PricelyBackendGateway(
+      HttpApiClient(
+        client: MockClient((request) async {
+          expect(request.url.path, '/notification-push-devices');
+          expect(request.headers['authorization'], 'Bearer token-123');
+
+          return http.Response(
+            jsonEncode(<Map<String, dynamic>>[
+              {
+                'id': 'device-1',
+                'platform': 'android',
+                'provider': 'fcm',
+                'deviceTokenTail': 'e-1234567890',
+                'isActive': true,
+                'lastSeenAt': '2026-06-26T12:00:00.000Z',
+              },
+              {
+                'id': 'device-2',
+                'platform': 'ios',
+                'provider': 'apns',
+                'deviceTokenTail': 'ios-token-tail',
+                'isActive': false,
+                'revokedAt': '2026-06-26T12:05:00.000Z',
+                'lastSeenAt': '2026-06-26T11:00:00.000Z',
+              },
+            ]),
+            200,
+          );
+        }),
+      ),
+    );
+
+    final devices = await gateway.fetchPushDevices('token-123');
+
+    expect(devices, hasLength(2));
+    expect(devices.first.deviceTokenTail, 'e-1234567890');
+    expect(devices.first.isActive, isTrue);
+    expect(devices.last.platform, 'ios');
+    expect(devices.last.revokedAt, '2026-06-26T12:05:00.000Z');
   });
 
   test('updates notification quiet-hour preferences', () async {
@@ -200,5 +252,65 @@ void main() {
     expect(capturedBody?['quietHoursStartMinute'], 1320);
     expect(preferences.quietHoursEnabled, isTrue);
     expect(preferences.quietHoursTimezone, 'America/Sao_Paulo');
+  });
+
+  test('fetches notification preferences and sends only changed preference fields', () async {
+    final requestedMethods = <String>[];
+    Map<String, dynamic>? patchBody;
+    final gateway = PricelyBackendGateway(
+      HttpApiClient(
+        client: MockClient((request) async {
+          requestedMethods.add(request.method);
+          expect(request.url.path, '/notification-preferences');
+          expect(request.headers['authorization'], 'Bearer token-123');
+
+          if (request.method == 'GET') {
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'inAppEnabled': true,
+                'priceDropsEnabled': false,
+                'receiptOutcomesEnabled': true,
+                'optimizationReadyEnabled': true,
+                'emailEnabled': false,
+                'pushEnabled': false,
+                'quietHoursEnabled': false,
+                'quietHoursStartMinute': null,
+                'quietHoursEndMinute': null,
+                'quietHoursTimezone': null,
+              }),
+              200,
+            );
+          }
+
+          patchBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode(<String, dynamic>{
+              'inAppEnabled': true,
+              'priceDropsEnabled': false,
+              'receiptOutcomesEnabled': true,
+              'optimizationReadyEnabled': true,
+              'emailEnabled': false,
+              'pushEnabled': false,
+              'quietHoursEnabled': true,
+              'quietHoursStartMinute': 1320,
+              'quietHoursEndMinute': 420,
+              'quietHoursTimezone': 'America/Sao_Paulo',
+            }),
+            200,
+          );
+        }),
+      ),
+    );
+
+    final initial = await gateway.fetchNotificationPreferences('token-123');
+    final updated = await gateway.updateNotificationPreferences(
+      accessToken: 'token-123',
+      quietHoursEnabled: true,
+    );
+
+    expect(initial.priceDropsEnabled, isFalse);
+    expect(patchBody, <String, dynamic>{'quietHoursEnabled': true});
+    expect(updated.quietHoursStartMinute, 1320);
+    expect(requestedMethods, <String>['GET', 'PATCH']);
   });
 }

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -632,7 +632,7 @@ channels without enabling provider sends prematurely.
 - [X] T266 Add mobile push device registration, token refresh/revocation, and authenticated device listing in `backend/src/notifications/` and `mobile/lib/features/`
 - [X] T267 Add quiet-hour preferences with timezone-aware deferral for non-critical notifications in `backend/src/notifications/`, `web/src/components/design-system/`, and `mobile/lib/features/`
 - [X] T268 Add admin notification delivery diagnostics, retry/cancel controls, and provider-error redaction in `web/src/dashboard/` and `backend/src/admin/`
-- [ ] T269 Add backend, web, and mobile coverage for delivery preferences, quiet-hour deferral, device registration, retry policy, and redacted admin diagnostics in `backend/test/`, `web/src/`, and `mobile/test/`
+- [X] T269 Add backend, web, and mobile coverage for delivery preferences, quiet-hour deferral, device registration, retry policy, and redacted admin diagnostics in `backend/test/`, `web/src/`, and `mobile/test/`
 
 **Homolog validation note (2026-06-15)**: Web/admin/backend MVP smoke passed on
 `https://pricely.grmeireles.dev` after deploying `homolog` commit `ed82c6a`.

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -537,8 +537,47 @@ describe('Admin dashboard pages', () => {
           status: 'verified',
         },
       },
+      {
+        id: 'attempt-2',
+        notificationId: 'notification-2',
+        userId: 'user-2',
+        channel: 'push',
+        status: 'queued',
+        attemptCount: 0,
+        maxAttempts: 3,
+        providerMessage: null,
+        lastFailureReason: null,
+        nextAttemptAt: '2026-05-10T04:10:00.000Z',
+        lastAttemptAt: null,
+        deliveredAt: null,
+        createdAt: '2026-05-10T04:01:00.000Z',
+        updatedAt: '2026-05-10T04:01:00.000Z',
+        canRetry: false,
+        canCancel: true,
+        owner: {
+          id: 'user-2',
+          displayName: 'Cliente Push',
+          email: 'pu***@pricely.local',
+        },
+        notification: {
+          id: 'notification-2',
+          type: 'optimization_ready',
+          title: 'Lista pronta',
+          resourceType: 'optimization_run',
+          resourceId: 'run-1',
+          createdAt: '2026-05-10T04:01:00.000Z',
+        },
+        destination: {
+          kind: 'push',
+          id: 'device-1',
+          label: 'android redacted:il-123',
+          status: 'active',
+          provider: 'fcm',
+        },
+      },
     ]);
     retryAdminNotificationDelivery.mockResolvedValue({});
+    cancelAdminNotificationDelivery.mockResolvedValue({});
 
     render(<AdminQueuePage />);
 
@@ -554,12 +593,32 @@ describe('Admin dashboard pages', () => {
     expect(screen.getAllByText(/cl\*\*\*@pricely.local/).length).toBeGreaterThan(
       0,
     );
+    expect(screen.getByText('Lista pronta')).toBeTruthy();
+    expect(screen.getByText(/android redacted:il-123/)).toBeTruthy();
     expect(screen.getByText(/provider rejected \[email\]/)).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(screen.queryByText(/cliente@pricely.local/)).toBeNull();
+    expect(screen.queryByText(/provider-message-secret/)).toBeNull();
+    const enabledRetryButton = screen
+      .getAllByRole('button', { name: 'Retry' })
+      .find((button) => !button.hasAttribute('disabled'));
+    expect(enabledRetryButton).toBeTruthy();
+    fireEvent.click(enabledRetryButton!);
     await waitFor(() =>
       expect(retryAdminNotificationDelivery).toHaveBeenCalledWith(
         'token',
         'attempt-1',
+      ),
+    );
+    const enabledCancelButton = screen
+      .getAllByRole('button', { name: 'Cancelar' })
+      .find((button) => !button.hasAttribute('disabled'));
+    expect(enabledCancelButton).toBeTruthy();
+    fireEvent.click(enabledCancelButton!);
+    await waitFor(() =>
+      expect(cancelAdminNotificationDelivery).toHaveBeenCalledWith(
+        'token',
+        'attempt-2',
+        'Cancelada pelo painel administrativo.',
       ),
     );
     expect(screen.queryByText('Go to link')).toBeNull();


### PR DESCRIPTION
Closes #455 when merged to the default branch.\n\n## Summary\n- Add backend coverage for push quiet-hour deferral, retry budget enforcement, cancellation policy, and push diagnostic redaction.\n- Extend admin web coverage for redacted notification delivery diagnostics plus retry/cancel actions.\n- Extend mobile gateway coverage for push device listing, device metadata registration, and notification preference payloads.\n- Mark T269 complete in the grocery optimizer task plan.\n\n## Validation\n- backend: npm run test -- notifications.service.spec.ts admin-dashboard.service.spec.ts\n- backend: npm run lint\n- backend: npm test\n- backend: npm run build\n- web: npm run test -- dashboard-pages.spec.tsx\n- web: npm run lint\n- web: npm test\n- web: npm run build\n\n## Note\n- Mobile Flutter tests were not runnable in this local shell because neither flutter nor dart is available on PATH.