### PR TITLE
Phase 36 T270 sandbox notification delivery providers

### DIFF
--- a/backend/src/notifications/notification-delivery-executor.service.ts
+++ b/backend/src/notifications/notification-delivery-executor.service.ts
@@ -1,0 +1,192 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  type UserEmailNotificationDestination,
+  type UserNotification,
+  type UserNotificationDeliveryAttempt,
+  type UserPushDevice,
+} from '@prisma/client';
+
+import { PrismaService } from '../persistence/prisma.service';
+import {
+  NOTIFICATION_DELIVERY_PROVIDER,
+  type NotificationDeliveryProvider,
+  type NotificationDeliveryRequest,
+} from './notification-delivery.provider';
+import { NotificationsService } from './notifications.service';
+
+type DeliveryAttemptWithTargets = UserNotificationDeliveryAttempt & {
+  notification: UserNotification;
+  emailDestination: UserEmailNotificationDestination | null;
+  pushDevice: UserPushDevice | null;
+};
+
+export interface NotificationDeliveryExecutionSummary {
+  processed: number;
+  delivered: number;
+  retrying: number;
+  failed: number;
+  skipped: number;
+}
+
+@Injectable()
+export class NotificationDeliveryExecutorService {
+  private readonly logger = new Logger(NotificationDeliveryExecutorService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly notificationsService: NotificationsService,
+    @Inject(NOTIFICATION_DELIVERY_PROVIDER)
+    private readonly provider: NotificationDeliveryProvider,
+  ) {}
+
+  async processDueAttempts(input: { take?: number; now?: Date } = {}) {
+    const now = input.now ?? new Date();
+    const attempts = await this.prisma.userNotificationDeliveryAttempt.findMany({
+      where: {
+        status: { in: ['queued', 'retrying'] },
+        OR: [{ nextAttemptAt: null }, { nextAttemptAt: { lte: now } }],
+      },
+      include: {
+        notification: true,
+        emailDestination: true,
+        pushDevice: true,
+      },
+      orderBy: [{ nextAttemptAt: 'asc' }, { createdAt: 'asc' }],
+      take: input.take ?? 25,
+    });
+
+    const summary: NotificationDeliveryExecutionSummary = {
+      processed: attempts.length,
+      delivered: 0,
+      retrying: 0,
+      failed: 0,
+      skipped: 0,
+    };
+
+    for (const attempt of attempts) {
+      const result = await this.processAttempt(attempt);
+      summary[result] += 1;
+    }
+
+    this.logger.log({
+      event: 'notification_delivery_batch_processed',
+      ...summary,
+    });
+
+    return summary;
+  }
+
+  async processAttempt(
+    attempt: DeliveryAttemptWithTargets,
+  ): Promise<'delivered' | 'retrying' | 'failed' | 'skipped'> {
+    if (!['queued', 'retrying'].includes(attempt.status)) {
+      return 'skipped';
+    }
+
+    const request = this.toDeliveryRequest(attempt);
+    if (!request) {
+      await this.notificationsService.markDeliveryFailed(attempt.id, {
+        reason: 'notification_delivery_destination_unavailable',
+        retryable: false,
+      });
+      return 'failed';
+    }
+
+    const sendingAttempt =
+      await this.notificationsService.markDeliverySending(attempt.id);
+
+    try {
+      const result = await this.provider.deliver(request);
+      if (!result.failureReason) {
+        await this.notificationsService.markDeliveryDelivered(attempt.id, {
+          providerMessageId: result.providerMessageId,
+        });
+        return 'delivered';
+      }
+
+      const retryable = result.retryable === true;
+      await this.notificationsService.markDeliveryFailed(attempt.id, {
+        reason: result.failureReason,
+        retryable,
+        nextAttemptAt: retryable
+          ? this.nextRetryAt(sendingAttempt.attemptCount)
+          : undefined,
+      });
+      return retryable ? 'retrying' : 'failed';
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'notification_delivery_provider_error';
+      await this.notificationsService.markDeliveryFailed(attempt.id, {
+        reason: message,
+        retryable: true,
+        nextAttemptAt: this.nextRetryAt(sendingAttempt.attemptCount),
+      });
+      return 'retrying';
+    }
+  }
+
+  private toDeliveryRequest(
+    attempt: DeliveryAttemptWithTargets,
+  ): NotificationDeliveryRequest | null {
+    if (attempt.channel === 'email') {
+      if (
+        !attempt.emailDestination ||
+        attempt.emailDestination.status !== 'verified'
+      ) {
+        return null;
+      }
+      return {
+        attemptId: attempt.id,
+        channel: attempt.channel,
+        title: attempt.notification.title,
+        message: attempt.notification.message,
+        destination: {
+          id: attempt.emailDestination.id,
+          label: this.maskEmail(attempt.emailDestination.email),
+          provider: 'sandbox-email',
+        },
+      };
+    }
+
+    if (!attempt.pushDevice || !attempt.pushDevice.isActive) {
+      return null;
+    }
+    return {
+      attemptId: attempt.id,
+      channel: attempt.channel,
+      title: attempt.notification.title,
+      message: attempt.notification.message,
+      destination: {
+        id: attempt.pushDevice.id,
+        label: `${attempt.pushDevice.platform}:${this.redactTail(
+          attempt.pushDevice.deviceTokenTail,
+        )}`,
+        provider: attempt.pushDevice.provider,
+      },
+      metadata: {
+        notificationId: attempt.notificationId,
+        resourceType: attempt.notification.resourceType,
+        resourceId: attempt.notification.resourceId,
+      },
+    };
+  }
+
+  private nextRetryAt(attemptCount: number) {
+    const delayMinutes = Math.min(60, 5 * 2 ** Math.max(attemptCount - 1, 0));
+    return new Date(Date.now() + delayMinutes * 60 * 1000);
+  }
+
+  private maskEmail(email: string) {
+    const [name, domain] = email.split('@');
+    if (!domain) {
+      return '[email]';
+    }
+    return `${name.slice(0, 2)}***@${domain}`;
+  }
+
+  private redactTail(value: string) {
+    return `redacted:${value.slice(-6)}`;
+  }
+}

--- a/backend/src/notifications/notification-delivery.provider.ts
+++ b/backend/src/notifications/notification-delivery.provider.ts
@@ -1,0 +1,29 @@
+import { type UserNotificationDeliveryChannel } from '@prisma/client';
+
+export interface NotificationDeliveryRequest {
+  attemptId: string;
+  channel: UserNotificationDeliveryChannel;
+  title: string;
+  message: string;
+  destination: {
+    id: string;
+    label: string;
+    provider?: string;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+export interface NotificationDeliveryResult {
+  providerMessageId?: string;
+  retryable?: boolean;
+  failureReason?: string;
+}
+
+export interface NotificationDeliveryProvider {
+  deliver(
+    request: NotificationDeliveryRequest,
+  ): Promise<NotificationDeliveryResult>;
+}
+
+export const NOTIFICATION_DELIVERY_PROVIDER =
+  'NOTIFICATION_DELIVERY_PROVIDER';

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,14 +1,25 @@
 import { Global, Module } from '@nestjs/common';
 
 import { PrismaModule } from '../persistence/prisma.module';
+import { NotificationDeliveryExecutorService } from './notification-delivery-executor.service';
+import { NOTIFICATION_DELIVERY_PROVIDER } from './notification-delivery.provider';
 import { NotificationsController } from './notifications.controller';
 import { NotificationsService } from './notifications.service';
+import { SandboxNotificationDeliveryProvider } from './sandbox-notification-delivery.provider';
 
 @Global()
 @Module({
   imports: [PrismaModule],
   controllers: [NotificationsController],
-  providers: [NotificationsService],
-  exports: [NotificationsService],
+  providers: [
+    NotificationsService,
+    NotificationDeliveryExecutorService,
+    SandboxNotificationDeliveryProvider,
+    {
+      provide: NOTIFICATION_DELIVERY_PROVIDER,
+      useExisting: SandboxNotificationDeliveryProvider,
+    },
+  ],
+  exports: [NotificationsService, NotificationDeliveryExecutorService],
 })
 export class NotificationsModule {}

--- a/backend/src/notifications/sandbox-notification-delivery.provider.ts
+++ b/backend/src/notifications/sandbox-notification-delivery.provider.ts
@@ -1,0 +1,31 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import {
+  type NotificationDeliveryProvider,
+  type NotificationDeliveryRequest,
+  type NotificationDeliveryResult,
+} from './notification-delivery.provider';
+
+@Injectable()
+export class SandboxNotificationDeliveryProvider
+  implements NotificationDeliveryProvider
+{
+  private readonly logger = new Logger(SandboxNotificationDeliveryProvider.name);
+
+  async deliver(
+    request: NotificationDeliveryRequest,
+  ): Promise<NotificationDeliveryResult> {
+    this.logger.log({
+      event: 'notification_delivery_sandbox_send',
+      attemptId: request.attemptId,
+      channel: request.channel,
+      destinationId: request.destination.id,
+      destinationLabel: request.destination.label,
+      provider: request.destination.provider ?? 'sandbox',
+    });
+
+    return {
+      providerMessageId: `sandbox-${request.channel}-${request.attemptId}`,
+    };
+  }
+}

--- a/backend/test/unit/notifications/notification-delivery-executor.service.spec.ts
+++ b/backend/test/unit/notifications/notification-delivery-executor.service.spec.ts
@@ -1,0 +1,230 @@
+import { Logger } from '@nestjs/common';
+
+import { NotificationDeliveryExecutorService } from '../../../src/notifications/notification-delivery-executor.service';
+import { SandboxNotificationDeliveryProvider } from '../../../src/notifications/sandbox-notification-delivery.provider';
+
+function buildAttempt(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'attempt-1',
+    notificationId: 'notification-1',
+    userId: 'user-1',
+    emailDestinationId: 'destination-1',
+    pushDeviceId: null,
+    channel: 'email',
+    status: 'queued',
+    attemptCount: 0,
+    maxAttempts: 3,
+    providerMessageId: null,
+    lastFailureReason: null,
+    terminalFailureReason: null,
+    nextAttemptAt: null,
+    lastAttemptAt: null,
+    deliveredAt: null,
+    createdAt: new Date('2026-06-26T10:00:00.000Z'),
+    updatedAt: new Date('2026-06-26T10:00:00.000Z'),
+    notification: {
+      id: 'notification-1',
+      userId: 'user-1',
+      type: 'price_drop',
+      title: 'Preco menor',
+      message: 'Arroz caiu de preco.',
+      resourceType: 'product_offer',
+      resourceId: 'offer-1',
+      metadata: null,
+      readAt: null,
+      createdAt: new Date('2026-06-26T09:59:00.000Z'),
+    },
+    emailDestination: {
+      id: 'destination-1',
+      userId: 'user-1',
+      email: 'cliente@pricely.local',
+      status: 'verified',
+      verificationTokenHash: null,
+      unsubscribeTokenHash: 'unsubscribe-hash',
+      verifiedAt: new Date('2026-06-26T09:00:00.000Z'),
+      unsubscribedAt: null,
+      createdAt: new Date('2026-06-26T08:00:00.000Z'),
+      updatedAt: new Date('2026-06-26T09:00:00.000Z'),
+    },
+    pushDevice: null,
+    ...overrides,
+  };
+}
+
+describe('NotificationDeliveryExecutorService', () => {
+  it('delivers due email attempts through the provider and records provider message id', async () => {
+    const attempt = buildAttempt();
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findMany: jest.fn().mockResolvedValue([attempt]),
+      },
+    };
+    const notificationsService = {
+      markDeliverySending: jest
+        .fn()
+        .mockResolvedValue({ ...attempt, attemptCount: 1, status: 'sending' }),
+      markDeliveryDelivered: jest.fn().mockResolvedValue({}),
+      markDeliveryFailed: jest.fn(),
+    };
+    const provider = {
+      deliver: jest.fn().mockResolvedValue({
+        providerMessageId: 'sandbox-email-attempt-1',
+      }),
+    };
+    const service = new NotificationDeliveryExecutorService(
+      prisma as never,
+      notificationsService as never,
+      provider,
+    );
+
+    await expect(service.processDueAttempts()).resolves.toEqual({
+      processed: 1,
+      delivered: 1,
+      retrying: 0,
+      failed: 0,
+      skipped: 0,
+    });
+
+    expect(provider.deliver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attemptId: 'attempt-1',
+        channel: 'email',
+        destination: {
+          id: 'destination-1',
+          label: 'cl***@pricely.local',
+          provider: 'sandbox-email',
+        },
+      }),
+    );
+    expect(notificationsService.markDeliveryDelivered).toHaveBeenCalledWith(
+      'attempt-1',
+      { providerMessageId: 'sandbox-email-attempt-1' },
+    );
+    expect(notificationsService.markDeliveryFailed).not.toHaveBeenCalled();
+  });
+
+  it('fails terminally when a queued email destination is no longer verified', async () => {
+    const attempt = buildAttempt({
+      emailDestination: {
+        ...(buildAttempt().emailDestination as Record<string, unknown>),
+        status: 'unsubscribed',
+      },
+    });
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findMany: jest.fn().mockResolvedValue([attempt]),
+      },
+    };
+    const notificationsService = {
+      markDeliverySending: jest.fn(),
+      markDeliveryDelivered: jest.fn(),
+      markDeliveryFailed: jest.fn().mockResolvedValue({}),
+    };
+    const provider = { deliver: jest.fn() };
+    const service = new NotificationDeliveryExecutorService(
+      prisma as never,
+      notificationsService as never,
+      provider,
+    );
+
+    await expect(service.processDueAttempts()).resolves.toEqual({
+      processed: 1,
+      delivered: 0,
+      retrying: 0,
+      failed: 1,
+      skipped: 0,
+    });
+
+    expect(provider.deliver).not.toHaveBeenCalled();
+    expect(notificationsService.markDeliverySending).not.toHaveBeenCalled();
+    expect(notificationsService.markDeliveryFailed).toHaveBeenCalledWith(
+      'attempt-1',
+      {
+        reason: 'notification_delivery_destination_unavailable',
+        retryable: false,
+      },
+    );
+  });
+
+  it('retries provider failures with bounded backoff', async () => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2026-06-26T12:00:00.000Z').getTime());
+    const attempt = buildAttempt();
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findMany: jest.fn().mockResolvedValue([attempt]),
+      },
+    };
+    const notificationsService = {
+      markDeliverySending: jest
+        .fn()
+        .mockResolvedValue({ ...attempt, attemptCount: 2, status: 'sending' }),
+      markDeliveryDelivered: jest.fn(),
+      markDeliveryFailed: jest.fn().mockResolvedValue({}),
+    };
+    const provider = {
+      deliver: jest.fn().mockResolvedValue({
+        retryable: true,
+        failureReason: 'sandbox_provider_rate_limited',
+      }),
+    };
+    const service = new NotificationDeliveryExecutorService(
+      prisma as never,
+      notificationsService as never,
+      provider,
+    );
+
+    await expect(service.processDueAttempts()).resolves.toEqual({
+      processed: 1,
+      delivered: 0,
+      retrying: 1,
+      failed: 0,
+      skipped: 0,
+    });
+
+    expect(notificationsService.markDeliveryFailed).toHaveBeenCalledWith(
+      'attempt-1',
+      {
+        reason: 'sandbox_provider_rate_limited',
+        retryable: true,
+        nextAttemptAt: new Date('2026-06-26T12:10:00.000Z'),
+      },
+    );
+    jest.useRealTimers();
+  });
+});
+
+describe('SandboxNotificationDeliveryProvider', () => {
+  it('returns deterministic sandbox ids and logs only redacted destination labels', async () => {
+    const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    const provider = new SandboxNotificationDeliveryProvider();
+
+    await expect(
+      provider.deliver({
+        attemptId: 'attempt-1',
+        channel: 'push',
+        title: 'Lista pronta',
+        message: 'Abra o app para conferir.',
+        destination: {
+          id: 'device-1',
+          label: 'android:redacted:il-123',
+          provider: 'fcm',
+        },
+      }),
+    ).resolves.toEqual({
+      providerMessageId: 'sandbox-push-attempt-1',
+    });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'notification_delivery_sandbox_send',
+        attemptId: 'attempt-1',
+        destinationLabel: 'android:redacted:il-123',
+      }),
+    );
+    expect(JSON.stringify(logSpy.mock.calls)).not.toContain(
+      'push-token-value-1234567890',
+    );
+  });
+});

--- a/docs/product/notification-center.md
+++ b/docs/product/notification-center.md
@@ -91,3 +91,28 @@ turning on broad sends immediately:
 If product priority shifts back to UX, the alternate next phase is mobile/web
 parity polish for notification preferences, device management, and admin delivery
 diagnostics.
+
+## Phase 36 delivery hardening
+
+**Status (2026-06-26)**: Started with provider-neutral delivery contracts and
+sandbox adapters. Sandbox delivery can exercise email and push state transitions
+without sending to external providers or storing raw provider payloads.
+
+### Provider gating
+
+- Sandbox is the only implemented adapter.
+- Email delivery receives a masked destination label and verified destination id.
+- Push delivery receives a redacted device-token tail, device id, platform, and
+  provider label; raw push tokens are never available to the delivery adapter.
+- Provider responses update the delivery attempt as `delivered`, `retrying`, or
+  `failed`; in-app notifications remain the canonical record.
+
+### Remaining Phase 36 work
+
+- Add a bounded worker or scheduler that calls the delivery executor for due
+  attempts and can be disabled per environment.
+- Add admin filters/search for delivery diagnostics before volume grows.
+- Extend release readiness with provider credential checks, unsubscribe rollback,
+  quiet-hour validation, sandbox smoke, and incident response.
+- Add broader release coverage for sandbox success, retryable provider failure,
+  terminal provider failure, and quiet-hour deferral.

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -655,6 +655,20 @@ external sends are enabled.
 
 ---
 
+## Phase 36: Provider-Gated Notification Delivery Hardening
+
+**Purpose**: Keep notification delivery disabled for broad external sends until
+provider adapters, worker observability, admin triage, and rollback controls are
+validated with sandbox behavior.
+
+- [X] T270 Add provider-neutral notification delivery contracts, sandbox email/push adapters, and backend coverage for provider-gated execution in `backend/src/notifications/` and `backend/test/unit/notifications/`
+- [ ] T271 Add a notification delivery worker or scheduler with bounded batch size, structured logs, and safe disable flags in `backend/src/jobs/` and `backend/src/notifications/`
+- [ ] T272 Add admin delivery filters/search for channel, status, destination, notification type, and retryability in `backend/src/admin/` and `web/src/dashboard/`
+- [ ] T273 Add release and rollback checklist entries for provider credentials, unsubscribe safety, quiet-hour policy, sandbox smoke, and incident response in `docs/release/`
+- [ ] T274 Add end-to-end release coverage for sandbox delivery attempts, deferred quiet-hour attempts, retryable provider failure, and terminal provider failure across backend/web/mobile where applicable
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies


### PR DESCRIPTION
Closes #459 when merged to the default branch.\n\n## Summary\n- Start Phase 36 in the roadmap with T270 complete and T271-T274 queued.\n- Add provider-neutral notification delivery contracts and a sandbox email/push provider.\n- Add a backend delivery executor that processes due queued/retrying attempts, marks sending, delivered, retrying, or failed, and keeps destinations redacted.\n- Document provider gating and remaining Phase 36 hardening work.\n\n## Validation\n- backend: npm run test -- notification-delivery-executor.service.spec.ts notifications.service.spec.ts\n- backend: npm test\n- backend: npm run lint\n- backend: npm run build\n- git diff --check