### PR TITLE
Phase 36 T271 notification delivery scheduler

### DIFF
--- a/backend/src/jobs/notification-delivery-scheduler.service.ts
+++ b/backend/src/jobs/notification-delivery-scheduler.service.ts
@@ -1,0 +1,164 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+
+import {
+  NotificationDeliveryExecutorService,
+  type NotificationDeliveryExecutionSummary,
+} from '../notifications/notification-delivery-executor.service';
+
+const DEFAULT_BATCH_SIZE = 25;
+const MAX_BATCH_SIZE = 100;
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const MIN_POLL_INTERVAL_MS = 1_000;
+
+@Injectable()
+export class NotificationDeliverySchedulerService
+  implements OnModuleInit, OnModuleDestroy
+{
+  private readonly logger = new Logger(NotificationDeliverySchedulerService.name);
+  private interval: NodeJS.Timeout | null = null;
+  private inFlight = false;
+  private batchSize = DEFAULT_BATCH_SIZE;
+  private pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+
+  constructor(
+    private readonly deliveryExecutor: NotificationDeliveryExecutorService,
+  ) {}
+
+  onModuleInit() {
+    const config = this.resolveConfig();
+
+    if (config.disabledReason) {
+      this.logger.log({
+        event: 'notification_delivery_scheduler_skipped',
+        reason: config.disabledReason,
+      });
+      return;
+    }
+
+    this.batchSize = config.batchSize;
+    this.pollIntervalMs = config.pollIntervalMs;
+    this.logger.log({
+      event: 'notification_delivery_scheduler_started',
+      batchSize: this.batchSize,
+      pollIntervalMs: this.pollIntervalMs,
+    });
+
+    void this.runOnce('startup');
+    this.interval = setInterval(
+      () => void this.runOnce('interval'),
+      this.pollIntervalMs,
+    );
+  }
+
+  onModuleDestroy() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  async runOnce(
+    trigger = 'manual',
+  ): Promise<NotificationDeliveryExecutionSummary | null> {
+    if (this.inFlight) {
+      this.logger.warn({
+        event: 'notification_delivery_scheduler_tick_skipped',
+        reason: 'previous_tick_in_flight',
+        trigger,
+      });
+      return null;
+    }
+
+    const startedAt = Date.now();
+    this.inFlight = true;
+
+    try {
+      const summary = await this.deliveryExecutor.processDueAttempts({
+        take: this.batchSize,
+      });
+      this.logger.log({
+        event: 'notification_delivery_scheduler_tick_completed',
+        trigger,
+        batchSize: this.batchSize,
+        durationMs: Date.now() - startedAt,
+        ...summary,
+      });
+      return summary;
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'notification_delivery_scheduler_failed';
+      this.logger.error({
+        event: 'notification_delivery_scheduler_tick_failed',
+        trigger,
+        batchSize: this.batchSize,
+        durationMs: Date.now() - startedAt,
+        message,
+      });
+      return null;
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  private resolveConfig() {
+    if (process.env.JEST_WORKER_ID) {
+      return {
+        disabledReason: 'test_environment',
+        batchSize: DEFAULT_BATCH_SIZE,
+        pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+      };
+    }
+
+    if (process.env.QUEUE_WORKERS_ENABLED === 'false') {
+      return {
+        disabledReason: 'queue_workers_disabled',
+        batchSize: DEFAULT_BATCH_SIZE,
+        pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+      };
+    }
+
+    if (process.env.NOTIFICATION_DELIVERY_WORKER_ENABLED === 'false') {
+      return {
+        disabledReason: 'notification_delivery_worker_disabled',
+        batchSize: DEFAULT_BATCH_SIZE,
+        pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+      };
+    }
+
+    return {
+      disabledReason: null,
+      batchSize: boundedNumber(
+        process.env.NOTIFICATION_DELIVERY_BATCH_SIZE,
+        DEFAULT_BATCH_SIZE,
+        1,
+        MAX_BATCH_SIZE,
+      ),
+      pollIntervalMs: boundedNumber(
+        process.env.NOTIFICATION_DELIVERY_POLL_INTERVAL_MS,
+        DEFAULT_POLL_INTERVAL_MS,
+        MIN_POLL_INTERVAL_MS,
+        Number.MAX_SAFE_INTEGER,
+      ),
+    };
+  }
+}
+
+function boundedNumber(
+  value: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, Math.trunc(parsed)));
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,5 +1,6 @@
 import { Global, Module } from '@nestjs/common';
 
+import { NotificationDeliverySchedulerService } from '../jobs/notification-delivery-scheduler.service';
 import { PrismaModule } from '../persistence/prisma.module';
 import { NotificationDeliveryExecutorService } from './notification-delivery-executor.service';
 import { NOTIFICATION_DELIVERY_PROVIDER } from './notification-delivery.provider';
@@ -14,6 +15,7 @@ import { SandboxNotificationDeliveryProvider } from './sandbox-notification-deli
   providers: [
     NotificationsService,
     NotificationDeliveryExecutorService,
+    NotificationDeliverySchedulerService,
     SandboxNotificationDeliveryProvider,
     {
       provide: NOTIFICATION_DELIVERY_PROVIDER,

--- a/backend/test/unit/jobs/notification-delivery-scheduler.service.spec.ts
+++ b/backend/test/unit/jobs/notification-delivery-scheduler.service.spec.ts
@@ -1,0 +1,142 @@
+import { Logger } from '@nestjs/common';
+
+import { NotificationDeliverySchedulerService } from '../../../src/jobs/notification-delivery-scheduler.service';
+
+describe('NotificationDeliverySchedulerService', () => {
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    delete process.env.JEST_WORKER_ID;
+    delete process.env.QUEUE_WORKERS_ENABLED;
+    delete process.env.NOTIFICATION_DELIVERY_WORKER_ENABLED;
+    delete process.env.NOTIFICATION_DELIVERY_BATCH_SIZE;
+    delete process.env.NOTIFICATION_DELIVERY_POLL_INTERVAL_MS;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('skips bootstrap when delivery workers are disabled', () => {
+    process.env.NOTIFICATION_DELIVERY_WORKER_ENABLED = 'false';
+    const executor = {
+      processDueAttempts: jest.fn(),
+    };
+    const service = new NotificationDeliverySchedulerService(
+      executor as never,
+    );
+
+    service.onModuleInit();
+
+    expect(executor.processDueAttempts).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith({
+      event: 'notification_delivery_scheduler_skipped',
+      reason: 'notification_delivery_worker_disabled',
+    });
+  });
+
+  it('processes startup and interval ticks with bounded batch size', async () => {
+    process.env.NOTIFICATION_DELIVERY_BATCH_SIZE = '250';
+    process.env.NOTIFICATION_DELIVERY_POLL_INTERVAL_MS = '500';
+    const executor = {
+      processDueAttempts: jest.fn().mockResolvedValue({
+        processed: 1,
+        delivered: 1,
+        retrying: 0,
+        failed: 0,
+        skipped: 0,
+      }),
+    };
+    const service = new NotificationDeliverySchedulerService(
+      executor as never,
+    );
+
+    service.onModuleInit();
+    await Promise.resolve();
+
+    expect(executor.processDueAttempts).toHaveBeenCalledWith({ take: 100 });
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'notification_delivery_scheduler_started',
+        batchSize: 100,
+        pollIntervalMs: 1000,
+      }),
+    );
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(executor.processDueAttempts).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'notification_delivery_scheduler_tick_completed',
+        trigger: 'interval',
+        batchSize: 100,
+        processed: 1,
+        delivered: 1,
+      }),
+    );
+
+    service.onModuleDestroy();
+  });
+
+  it('does not overlap ticks when the previous batch is still running', async () => {
+    let releaseBatch: () => void = () => undefined;
+    const pendingBatch = new Promise((resolve) => {
+      releaseBatch = () =>
+        resolve({
+          processed: 0,
+          delivered: 0,
+          retrying: 0,
+          failed: 0,
+          skipped: 0,
+        });
+    });
+    const executor = {
+      processDueAttempts: jest.fn().mockReturnValue(pendingBatch),
+    };
+    const service = new NotificationDeliverySchedulerService(
+      executor as never,
+    );
+
+    const firstRun = service.runOnce('manual');
+    await Promise.resolve();
+    await expect(service.runOnce('manual')).resolves.toBeNull();
+
+    expect(executor.processDueAttempts).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith({
+      event: 'notification_delivery_scheduler_tick_skipped',
+      reason: 'previous_tick_in_flight',
+      trigger: 'manual',
+    });
+
+    releaseBatch();
+    await firstRun;
+  });
+
+  it('logs failed ticks without throwing to the interval loop', async () => {
+    const executor = {
+      processDueAttempts: jest.fn().mockRejectedValue(new Error('provider down')),
+    };
+    const service = new NotificationDeliverySchedulerService(
+      executor as never,
+    );
+
+    await expect(service.runOnce('manual')).resolves.toBeNull();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'notification_delivery_scheduler_tick_failed',
+        trigger: 'manual',
+        message: 'provider down',
+      }),
+    );
+  });
+});

--- a/docs/product/notification-center.md
+++ b/docs/product/notification-center.md
@@ -109,10 +109,22 @@ without sending to external providers or storing raw provider payloads.
 
 ### Remaining Phase 36 work
 
-- Add a bounded worker or scheduler that calls the delivery executor for due
-  attempts and can be disabled per environment.
+- Bounded scheduler is implemented for due delivery attempts with startup and
+  interval ticks, structured logs, no overlapping batches, capped batch size,
+  and environment kill switches.
 - Add admin filters/search for delivery diagnostics before volume grows.
 - Extend release readiness with provider credential checks, unsubscribe rollback,
   quiet-hour validation, sandbox smoke, and incident response.
 - Add broader release coverage for sandbox success, retryable provider failure,
   terminal provider failure, and quiet-hour deferral.
+
+### Worker controls
+
+- `QUEUE_WORKERS_ENABLED=false` disables queue workers and notification delivery
+  scheduling in shared worker environments.
+- `NOTIFICATION_DELIVERY_WORKER_ENABLED=false` disables only outbound notification
+  delivery scheduling.
+- `NOTIFICATION_DELIVERY_BATCH_SIZE` controls each due-attempt batch and is capped
+  at 100 attempts.
+- `NOTIFICATION_DELIVERY_POLL_INTERVAL_MS` controls scheduler cadence and is
+  floored at 1000 ms.

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -662,7 +662,7 @@ provider adapters, worker observability, admin triage, and rollback controls are
 validated with sandbox behavior.
 
 - [X] T270 Add provider-neutral notification delivery contracts, sandbox email/push adapters, and backend coverage for provider-gated execution in `backend/src/notifications/` and `backend/test/unit/notifications/`
-- [ ] T271 Add a notification delivery worker or scheduler with bounded batch size, structured logs, and safe disable flags in `backend/src/jobs/` and `backend/src/notifications/`
+- [X] T271 Add a notification delivery worker or scheduler with bounded batch size, structured logs, and safe disable flags in `backend/src/jobs/` and `backend/src/notifications/`
 - [ ] T272 Add admin delivery filters/search for channel, status, destination, notification type, and retryability in `backend/src/admin/` and `web/src/dashboard/`
 - [ ] T273 Add release and rollback checklist entries for provider credentials, unsubscribe safety, quiet-hour policy, sandbox smoke, and incident response in `docs/release/`
 - [ ] T274 Add end-to-end release coverage for sandbox delivery attempts, deferred quiet-hour attempts, retryable provider failure, and terminal provider failure across backend/web/mobile where applicable


### PR DESCRIPTION
## Summary
- Add a bounded notification delivery scheduler that runs due delivery attempts on startup and interval ticks.
- Add safe disable flags and clamped batch/cadence env controls.
- Add scheduler unit coverage and document worker controls in the notification center plan.

## Validation
- npm run test -- notification-delivery-scheduler.service.spec.ts notification-delivery-executor.service.spec.ts
- npm run build
- npm run lint
- npm test
- git diff --check

Issue: #461