### PR TITLE
Phase 36 T272 admin notification delivery filters

### DIFF
--- a/backend/src/admin/api/admin-dashboard.controller.ts
+++ b/backend/src/admin/api/admin-dashboard.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UploadedFile,
   UseGuards,
@@ -416,6 +417,52 @@ class CancelNotificationDeliveryDto {
   reason?: string;
 }
 
+class ListNotificationDeliveriesQueryDto {
+  @IsOptional()
+  @IsIn(['email', 'push'])
+  channel?: 'email' | 'push';
+
+  @IsOptional()
+  @IsIn(['all', 'queued', 'sending', 'retrying', 'delivered', 'failed', 'cancelled'])
+  status?:
+    | 'all'
+    | 'queued'
+    | 'sending'
+    | 'retrying'
+    | 'delivered'
+    | 'failed'
+    | 'cancelled';
+
+  @IsOptional()
+  @IsIn([
+    'all',
+    'price_drop',
+    'receipt_outcome',
+    'optimization_ready',
+    'optimization_failed',
+  ])
+  notificationType?:
+    | 'all'
+    | 'price_drop'
+    | 'receipt_outcome'
+    | 'optimization_ready'
+    | 'optimization_failed';
+
+  @IsOptional()
+  @IsIn(['all', 'retryable', 'not_retryable'])
+  retryability?: 'all' | 'retryable' | 'not_retryable';
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  destination?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  search?: string;
+}
+
 class ConvertMissingProductRequestDto {
   @IsOptional()
   @IsString()
@@ -555,8 +602,17 @@ export class AdminDashboardController {
   }
 
   @Get('notification-deliveries')
-  async listNotificationDeliveries() {
-    return this.adminDashboardService.listNotificationDeliveries();
+  async listNotificationDeliveries(
+    @Query() query: ListNotificationDeliveriesQueryDto,
+  ) {
+    return this.adminDashboardService.listNotificationDeliveries({
+      channel: query.channel,
+      status: query.status ?? 'all',
+      notificationType: query.notificationType ?? 'all',
+      retryability: query.retryability ?? 'all',
+      destination: query.destination,
+      search: query.search,
+    });
   }
 
   @Post('notification-deliveries/:id/retry')

--- a/backend/src/admin/application/admin-dashboard.service.ts
+++ b/backend/src/admin/application/admin-dashboard.service.ts
@@ -8,6 +8,7 @@ import {
 
 import { CatalogProductsService } from '../../catalog/application/catalog-products.service';
 import { CatalogMediaService } from '../../catalog/application/catalog-media.service';
+import { type AdminNotificationDeliveryFiltersContract } from '../../common/contracts/admin.contract';
 import { EstablishmentsService } from '../../establishments/application/establishments.service';
 import { PrismaService } from '../../persistence/prisma.service';
 import { OfferManagementService } from '../../pricing/application/offer-management.service';
@@ -932,11 +933,18 @@ export class AdminDashboardService {
     return summary;
   }
 
-  async listNotificationDeliveries() {
+  async listNotificationDeliveries(
+    filters: AdminNotificationDeliveryFiltersContract = {
+      status: 'all',
+      notificationType: 'all',
+      retryability: 'all',
+    },
+  ) {
     const attempts =
       await this.prisma.userNotificationDeliveryAttempt.findMany({
+        where: this.buildNotificationDeliveryWhere(filters),
         orderBy: [{ updatedAt: 'desc' }, { createdAt: 'desc' }],
-        take: 100,
+        take: 250,
         include: {
           user: {
             select: {
@@ -974,12 +982,17 @@ export class AdminDashboardService {
         },
       });
 
-    const projected = attempts.map((attempt) =>
-      this.projectNotificationDelivery(attempt),
-    );
+    const projected = attempts
+      .map((attempt) => this.projectNotificationDelivery(attempt))
+      .filter((attempt) =>
+        this.matchesNotificationDeliveryProjectedFilters(attempt, filters),
+      )
+      .slice(0, 100);
 
     this.logger.log(
-      `Admin notification delivery diagnostics requested: ${projected.length} attempts returned`,
+      `Admin notification delivery diagnostics requested: ${projected.length} attempts returned filters=${JSON.stringify(
+        this.describeNotificationDeliveryFilters(filters),
+      )}`,
     );
 
     return projected;
@@ -1053,6 +1066,90 @@ export class AdminDashboardService {
     return attempts.map((attempt) =>
       this.projectNotificationDelivery(attempt),
     );
+  }
+
+  private buildNotificationDeliveryWhere(
+    filters: AdminNotificationDeliveryFiltersContract,
+  ) {
+    return {
+      ...(filters.channel ? { channel: filters.channel } : {}),
+      ...(filters.status !== 'all' ? { status: filters.status } : {}),
+      ...(filters.notificationType !== 'all'
+        ? { notification: { type: filters.notificationType } }
+        : {}),
+    };
+  }
+
+  private matchesNotificationDeliveryProjectedFilters(
+    attempt: ReturnType<typeof this.projectNotificationDelivery>,
+    filters: AdminNotificationDeliveryFiltersContract,
+  ) {
+    if (filters.retryability === 'retryable' && !attempt.canRetry) {
+      return false;
+    }
+
+    if (filters.retryability === 'not_retryable' && attempt.canRetry) {
+      return false;
+    }
+
+    const destination = filters.destination?.trim().toLowerCase();
+    if (destination) {
+      const destinationText = [
+        attempt.destination?.kind,
+        attempt.destination?.label,
+        attempt.destination?.status,
+        attempt.destination?.provider,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+
+      if (!destinationText.includes(destination)) {
+        return false;
+      }
+    }
+
+    const search = filters.search?.trim().toLowerCase();
+    if (search) {
+      const searchableText = [
+        attempt.id,
+        attempt.notificationId,
+        attempt.userId,
+        attempt.channel,
+        attempt.status,
+        attempt.owner.displayName,
+        attempt.owner.email,
+        attempt.notification.type,
+        attempt.notification.title,
+        attempt.notification.resourceType,
+        attempt.notification.resourceId,
+        attempt.destination?.label,
+        attempt.destination?.provider,
+        attempt.lastFailureReason,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+
+      if (!searchableText.includes(search)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private describeNotificationDeliveryFilters(
+    filters: AdminNotificationDeliveryFiltersContract,
+  ) {
+    return {
+      channel: filters.channel ?? 'all',
+      status: filters.status,
+      notificationType: filters.notificationType,
+      retryability: filters.retryability,
+      destination: filters.destination ? '[set]' : 'all',
+      search: filters.search ? '[set]' : 'all',
+    };
   }
 
   private projectNotificationDelivery(attempt: {

--- a/backend/src/common/contracts/admin.contract.ts
+++ b/backend/src/common/contracts/admin.contract.ts
@@ -73,6 +73,27 @@ export interface AdminNotificationDeliveryContract {
   } | null;
 }
 
+export interface AdminNotificationDeliveryFiltersContract {
+  channel?: 'email' | 'push';
+  status:
+    | 'all'
+    | 'queued'
+    | 'sending'
+    | 'retrying'
+    | 'delivered'
+    | 'failed'
+    | 'cancelled';
+  notificationType:
+    | 'all'
+    | 'price_drop'
+    | 'receipt_outcome'
+    | 'optimization_ready'
+    | 'optimization_failed';
+  retryability: 'all' | 'retryable' | 'not_retryable';
+  destination?: string;
+  search?: string;
+}
+
 export interface AdminShoppingListAuditContract {
   id: string;
   name: string;

--- a/backend/test/unit/admin/admin-dashboard.service.spec.ts
+++ b/backend/test/unit/admin/admin-dashboard.service.spec.ts
@@ -627,6 +627,104 @@ describe('AdminDashboardService', () => {
     expect(JSON.stringify(projected)).not.toContain('https://fcm.example');
   });
 
+  it('filters notification delivery diagnostics by channel, status, type, destination, search, and retryability', async () => {
+    const matchingAttempt = {
+      id: 'attempt-push-1',
+      notificationId: 'notification-1',
+      userId: 'user-1',
+      channel: 'push',
+      status: 'retrying',
+      attemptCount: 2,
+      maxAttempts: 4,
+      providerMessageId: null,
+      lastFailureReason: 'temporary provider error',
+      terminalFailureReason: null,
+      nextAttemptAt: new Date('2026-06-26T11:00:00Z'),
+      lastAttemptAt: new Date('2026-06-26T10:00:00Z'),
+      deliveredAt: null,
+      createdAt: new Date('2026-06-26T09:00:00Z'),
+      updatedAt: new Date('2026-06-26T10:01:00Z'),
+      user: {
+        id: 'user-1',
+        displayName: 'Cliente Push',
+        email: 'cliente@pricely.local',
+      },
+      notification: {
+        id: 'notification-1',
+        type: 'optimization_ready',
+        title: 'Lista pronta',
+        resourceType: 'optimization_run',
+        resourceId: 'run-1',
+        createdAt: new Date('2026-06-26T08:59:00Z'),
+      },
+      emailDestination: null,
+      pushDevice: {
+        id: 'device-1',
+        platform: 'android',
+        provider: 'fcm',
+        deviceTokenTail: 'token-tail-123',
+        isActive: true,
+      },
+    };
+    const filteredOutAttempt = {
+      ...matchingAttempt,
+      id: 'attempt-push-2',
+      attemptCount: 4,
+      notification: {
+        ...matchingAttempt.notification,
+        title: 'Outro evento',
+      },
+    };
+    const prisma = {
+      userNotificationDeliveryAttempt: {
+        findMany: jest
+          .fn()
+          .mockResolvedValue([matchingAttempt, filteredOutAttempt]),
+      },
+    };
+    const service = new AdminDashboardService(
+      prisma as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+    await expect(
+      service.listNotificationDeliveries({
+        channel: 'push',
+        status: 'retrying',
+        notificationType: 'optimization_ready',
+        retryability: 'retryable',
+        destination: 'android',
+        search: 'lista',
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'attempt-push-1',
+        canRetry: true,
+        destination: expect.objectContaining({
+          label: 'android redacted:il-123',
+        }),
+      }),
+    ]);
+
+    expect(prisma.userNotificationDeliveryAttempt.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          channel: 'push',
+          status: 'retrying',
+          notification: { type: 'optimization_ready' },
+        },
+        take: 250,
+      }),
+    );
+  });
+
   it('projects receipt line extraction, maker action, and price comparison for admin review', async () => {
     const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
     const prisma = {

--- a/docs/product/notification-center.md
+++ b/docs/product/notification-center.md
@@ -112,7 +112,8 @@ without sending to external providers or storing raw provider payloads.
 - Bounded scheduler is implemented for due delivery attempts with startup and
   interval ticks, structured logs, no overlapping batches, capped batch size,
   and environment kill switches.
-- Add admin filters/search for delivery diagnostics before volume grows.
+- Admin diagnostics include filters for channel, status, notification type,
+  retryability, redacted destination, and general search.
 - Extend release readiness with provider credential checks, unsubscribe rollback,
   quiet-hour validation, sandbox smoke, and incident response.
 - Add broader release coverage for sandbox success, retryable provider failure,

--- a/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
+++ b/specs/001-grocery-optimizer/contracts/grocery-optimizer-api.yaml
@@ -358,6 +358,43 @@ paths:
   /admin/notification-deliveries:
     get:
       summary: List redacted notification delivery attempts for admin diagnostics
+      parameters:
+        - in: query
+          name: channel
+          schema:
+            type: string
+            enum: [email, push]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [queued, sending, retrying, delivered, failed, cancelled]
+        - in: query
+          name: notificationType
+          schema:
+            type: string
+            enum:
+              [
+                price_drop,
+                receipt_outcome,
+                optimization_ready,
+                optimization_failed,
+              ]
+        - in: query
+          name: retryability
+          schema:
+            type: string
+            enum: [retryable, not_retryable]
+        - in: query
+          name: destination
+          schema:
+            type: string
+          description: Search against redacted email or push destination labels
+        - in: query
+          name: search
+          schema:
+            type: string
+          description: Search attempt id, notification id, owner label, title, resource, or redacted error
       responses:
         '200':
           description: Notification delivery attempts returned newest first

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -663,7 +663,7 @@ validated with sandbox behavior.
 
 - [X] T270 Add provider-neutral notification delivery contracts, sandbox email/push adapters, and backend coverage for provider-gated execution in `backend/src/notifications/` and `backend/test/unit/notifications/`
 - [X] T271 Add a notification delivery worker or scheduler with bounded batch size, structured logs, and safe disable flags in `backend/src/jobs/` and `backend/src/notifications/`
-- [ ] T272 Add admin delivery filters/search for channel, status, destination, notification type, and retryability in `backend/src/admin/` and `web/src/dashboard/`
+- [X] T272 Add admin delivery filters/search for channel, status, destination, notification type, and retryability in `backend/src/admin/` and `web/src/dashboard/`
 - [ ] T273 Add release and rollback checklist entries for provider credentials, unsubscribe safety, quiet-hour policy, sandbox smoke, and incident response in `docs/release/`
 - [ ] T274 Add end-to-end release coverage for sandbox delivery attempts, deferred quiet-hour attempts, retryable provider failure, and terminal provider failure across backend/web/mobile where applicable
 

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -509,6 +509,27 @@ type AdminNotificationDeliveryResponse = {
   } | null;
 };
 
+type AdminNotificationDeliveryFilters = {
+  channel?: 'email' | 'push';
+  status?:
+    | 'all'
+    | 'queued'
+    | 'sending'
+    | 'retrying'
+    | 'delivered'
+    | 'failed'
+    | 'cancelled';
+  notificationType?:
+    | 'all'
+    | 'price_drop'
+    | 'receipt_outcome'
+    | 'optimization_ready'
+    | 'optimization_failed';
+  retryability?: 'all' | 'retryable' | 'not_retryable';
+  destination?: string;
+  search?: string;
+};
+
 type AdminProcessingJobDetailResponse = AdminProcessingJobResponse & {
   optimizationRun?:
     | (NonNullable<AdminProcessingJobResponse['optimizationRun']> & {
@@ -1463,9 +1484,19 @@ export async function cancelAdminProcessingJob(
   );
 }
 
-export async function fetchAdminNotificationDeliveries(token: string) {
+export async function fetchAdminNotificationDeliveries(
+  token: string,
+  filters: AdminNotificationDeliveryFilters = {},
+) {
+  const query = new URLSearchParams();
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value && value !== 'all') {
+      query.set(key, value);
+    }
+  });
+
   return apiFetch<AdminNotificationDeliveryResponse[]>(
-    '/admin/notification-deliveries',
+    `/admin/notification-deliveries${query.size ? `?${query.toString()}` : ''}`,
     {},
     token,
   );
@@ -1950,6 +1981,7 @@ export type {
   AdminMetricsResponse,
   AdminPublicSearchMetricsResponse,
   AdminOfferResponse,
+  AdminNotificationDeliveryFilters,
   AdminNotificationDeliveryResponse,
   AdminProductResponse,
   AdminProductVariantResponse,

--- a/web/src/dashboard/dashboard-pages.spec.tsx
+++ b/web/src/dashboard/dashboard-pages.spec.tsx
@@ -624,6 +624,55 @@ describe('Admin dashboard pages', () => {
     expect(screen.queryByText('Go to link')).toBeNull();
   });
 
+  it('applies notification delivery destination and search filters from the queue page', async () => {
+    fetchAdminMetrics.mockResolvedValue({
+      queuedJobs: 0,
+      activeUsers: 1,
+      shoppingListsCount: 0,
+      optimizationRunsCount: 0,
+      activeRegions: 1,
+      activeEstablishments: 1,
+      activeOffers: 0,
+      productCount: 0,
+      globalEstimatedSavings: 0,
+    });
+    fetchAdminQueueHealth.mockResolvedValue({
+      queuedJobs: 0,
+      runningJobs: 0,
+      failedJobs: 0,
+      completedJobs: 0,
+      jobsByStatus: {},
+      queues: [],
+      recentFailures: [],
+    });
+    fetchAdminProcessingJobs.mockResolvedValue([]);
+    fetchAdminNotificationDeliveries.mockResolvedValue([]);
+
+    render(<AdminQueuePage />);
+
+    const destinationInput = await screen.findByLabelText('Destino');
+    fireEvent.change(destinationInput, {
+      target: { value: 'android' },
+    });
+    fireEvent.change(screen.getByLabelText('Busca'), {
+      target: { value: 'Lista pronta' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /filtrar/i }));
+
+    await waitFor(() =>
+      expect(fetchAdminNotificationDeliveries).toHaveBeenLastCalledWith(
+        'token',
+        expect.objectContaining({
+          destination: 'android',
+          search: 'Lista pronta',
+          retryability: 'all',
+          status: 'all',
+          notificationType: 'all',
+        }),
+      ),
+    );
+  });
+
   it('renders queue detail as operational diagnostics without business audit payloads', async () => {
     fetchAdminProcessingJobDetail.mockResolvedValue({
       id: 'job-1',

--- a/web/src/dashboard/dashboard-pages.tsx
+++ b/web/src/dashboard/dashboard-pages.tsx
@@ -23,6 +23,7 @@ import {
   type AdminEstablishmentResponse,
   type AdminMetricsResponse,
   type MissingProductRequestResponse,
+  type AdminNotificationDeliveryFilters,
   type AdminNotificationDeliveryResponse,
   type AdminOfferResponse,
   type AdminPublicSearchMetricsResponse,
@@ -99,6 +100,13 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import {
   Table,
@@ -112,6 +120,7 @@ import {
 function useAdminData<T>(
   loader: (token: string) => Promise<T>,
   initialValue: T,
+  dependencies: unknown[] = [],
 ) {
   const { accessToken } = usePricely();
   const [data, setData] = useState<T>(initialValue);
@@ -136,7 +145,7 @@ function useAdminData<T>(
 
   useEffect(() => {
     void reload();
-  }, [accessToken]);
+  }, [accessToken, ...dependencies]);
 
   return { data, error, reload };
 }
@@ -334,6 +343,43 @@ function notificationDeliverySeverity(
     return 'healthy' as const;
   }
   return 'info' as const;
+}
+
+type AdminNotificationDeliveryFilterState = Required<
+  Pick<
+    AdminNotificationDeliveryFilters,
+    'status' | 'notificationType' | 'retryability'
+  >
+> &
+  Pick<AdminNotificationDeliveryFilters, 'channel' | 'destination' | 'search'>;
+
+const defaultNotificationDeliveryFilters: AdminNotificationDeliveryFilterState =
+  {
+    status: 'all',
+    notificationType: 'all',
+    retryability: 'all',
+    channel: undefined,
+    destination: '',
+    search: '',
+  };
+
+function notificationDeliveryFilterKey(
+  filters: AdminNotificationDeliveryFilterState,
+) {
+  return JSON.stringify(filters);
+}
+
+function toNotificationDeliveryApiFilters(
+  filters: AdminNotificationDeliveryFilterState,
+): AdminNotificationDeliveryFilters {
+  return {
+    channel: filters.channel,
+    status: filters.status,
+    notificationType: filters.notificationType,
+    retryability: filters.retryability,
+    destination: filters.destination?.trim() || undefined,
+    search: filters.search?.trim() || undefined,
+  };
 }
 
 function receiptTrustLabel(
@@ -5252,6 +5298,20 @@ export function AdminReceiptAuditPage() {
 
 export function AdminQueuePage() {
   const { accessToken } = usePricely();
+  const [deliveryFilterDraft, setDeliveryFilterDraft] =
+    useState<AdminNotificationDeliveryFilterState>(
+      defaultNotificationDeliveryFilters,
+    );
+  const [deliveryFilters, setDeliveryFilters] =
+    useState<AdminNotificationDeliveryFilterState>(
+      defaultNotificationDeliveryFilters,
+    );
+  const deliveryFilterKey = notificationDeliveryFilterKey(deliveryFilters);
+  const notificationDeliveryLoader = (token: string) =>
+    fetchAdminNotificationDeliveries(
+      token,
+      toNotificationDeliveryApiFilters(deliveryFilters),
+    );
   const { data: metrics } = useAdminData<AdminMetricsResponse | null>(
     fetchAdminMetrics,
     null,
@@ -5269,8 +5329,9 @@ export function AdminQueuePage() {
     error: notificationDeliveriesError,
     reload: reloadNotificationDeliveries,
   } = useAdminData<AdminNotificationDeliveryResponse[]>(
-    fetchAdminNotificationDeliveries,
+    notificationDeliveryLoader,
     [],
+    [deliveryFilterKey],
   );
   const [deliveryActionError, setDeliveryActionError] = useState<string | null>(
     null,
@@ -5278,6 +5339,18 @@ export function AdminQueuePage() {
   const [activeDeliveryAction, setActiveDeliveryAction] = useState<
     string | null
   >(null);
+  const applyDeliveryFilters = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setDeliveryFilters({
+      ...deliveryFilterDraft,
+      destination: deliveryFilterDraft.destination?.trim() ?? '',
+      search: deliveryFilterDraft.search?.trim() ?? '',
+    });
+  };
+  const clearDeliveryFilters = () => {
+    setDeliveryFilterDraft(defaultNotificationDeliveryFilters);
+    setDeliveryFilters(defaultNotificationDeliveryFilters);
+  };
 
   const runDeliveryAction = async (
     delivery: AdminNotificationDeliveryResponse,
@@ -5475,6 +5548,149 @@ export function AdminQueuePage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="grid gap-3">
+          <form
+            className="grid gap-3 rounded-lg border border-border/70 bg-muted/20 p-3 lg:grid-cols-[1fr_1fr_1fr_1fr_auto]"
+            onSubmit={applyDeliveryFilters}
+          >
+            <label className="grid gap-1 text-xs font-medium text-muted-foreground">
+              Canal
+              <Select
+                onValueChange={(value) =>
+                  setDeliveryFilterDraft((current) => ({
+                    ...current,
+                    channel:
+                      value === 'all' ? undefined : (value as 'email' | 'push'),
+                  }))
+                }
+                value={deliveryFilterDraft.channel ?? 'all'}
+              >
+                <SelectTrigger className="w-full bg-background">
+                  <SelectValue placeholder="Canal" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos</SelectItem>
+                  <SelectItem value="email">Email</SelectItem>
+                  <SelectItem value="push">Push</SelectItem>
+                </SelectContent>
+              </Select>
+            </label>
+            <label className="grid gap-1 text-xs font-medium text-muted-foreground">
+              Status
+              <Select
+                onValueChange={(value) =>
+                  setDeliveryFilterDraft((current) => ({
+                    ...current,
+                    status:
+                      value as AdminNotificationDeliveryFilterState['status'],
+                  }))
+                }
+                value={deliveryFilterDraft.status}
+              >
+                <SelectTrigger className="w-full bg-background">
+                  <SelectValue placeholder="Status" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos</SelectItem>
+                  <SelectItem value="queued">Em fila</SelectItem>
+                  <SelectItem value="sending">Enviando</SelectItem>
+                  <SelectItem value="retrying">Retry</SelectItem>
+                  <SelectItem value="delivered">Entregue</SelectItem>
+                  <SelectItem value="failed">Falhou</SelectItem>
+                  <SelectItem value="cancelled">Cancelada</SelectItem>
+                </SelectContent>
+              </Select>
+            </label>
+            <label className="grid gap-1 text-xs font-medium text-muted-foreground">
+              Tipo
+              <Select
+                onValueChange={(value) =>
+                  setDeliveryFilterDraft((current) => ({
+                    ...current,
+                    notificationType:
+                      value as AdminNotificationDeliveryFilterState['notificationType'],
+                  }))
+                }
+                value={deliveryFilterDraft.notificationType}
+              >
+                <SelectTrigger className="w-full bg-background">
+                  <SelectValue placeholder="Tipo" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos</SelectItem>
+                  <SelectItem value="price_drop">Preço</SelectItem>
+                  <SelectItem value="receipt_outcome">Nota fiscal</SelectItem>
+                  <SelectItem value="optimization_ready">
+                    Otimização pronta
+                  </SelectItem>
+                  <SelectItem value="optimization_failed">
+                    Otimização falhou
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </label>
+            <label className="grid gap-1 text-xs font-medium text-muted-foreground">
+              Retry
+              <Select
+                onValueChange={(value) =>
+                  setDeliveryFilterDraft((current) => ({
+                    ...current,
+                    retryability:
+                      value as AdminNotificationDeliveryFilterState['retryability'],
+                  }))
+                }
+                value={deliveryFilterDraft.retryability}
+              >
+                <SelectTrigger className="w-full bg-background">
+                  <SelectValue placeholder="Retry" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos</SelectItem>
+                  <SelectItem value="retryable">Pode retry</SelectItem>
+                  <SelectItem value="not_retryable">Sem retry</SelectItem>
+                </SelectContent>
+              </Select>
+            </label>
+            <div className="grid gap-2 lg:col-span-5 lg:grid-cols-[1fr_1fr_auto_auto]">
+              <label className="grid gap-1 text-xs font-medium text-muted-foreground">
+                Destino
+                <Input
+                  onChange={(event) =>
+                    setDeliveryFilterDraft((current) => ({
+                      ...current,
+                      destination: event.target.value,
+                    }))
+                  }
+                  placeholder="email mascarado, fcm, android"
+                  value={deliveryFilterDraft.destination}
+                />
+              </label>
+              <label className="grid gap-1 text-xs font-medium text-muted-foreground">
+                Busca
+                <Input
+                  onChange={(event) =>
+                    setDeliveryFilterDraft((current) => ({
+                      ...current,
+                      search: event.target.value,
+                    }))
+                  }
+                  placeholder="id, usuário, título ou erro"
+                  value={deliveryFilterDraft.search}
+                />
+              </label>
+              <Button className="self-end" type="submit" variant="outline">
+                <SearchIcon className="size-4" />
+                Filtrar
+              </Button>
+              <Button
+                className="self-end"
+                onClick={clearDeliveryFilters}
+                type="button"
+                variant="ghost"
+              >
+                Limpar
+              </Button>
+            </div>
+          </form>
           {notificationDeliveriesError ? (
             <Alert variant="destructive">
               <AlertTitle>Falha ao carregar entregas</AlertTitle>


### PR DESCRIPTION
## Summary
- Add admin query filters for notification delivery diagnostics by channel, status, notification type, retryability, destination, and search.
- Add dashboard filters for notification deliveries using shadcn select/input controls.
- Update API types, OpenAPI contract, roadmap, and notification center docs.

## Validation
- backend: npm run build
- backend: npm run lint
- backend: npm test
- web: npm run build
- web: npm run lint
- web: npm test
- git diff --check

Issue: #463