### PR TITLE
Fix admin queue status smoke selector

### DIFF
--- a/web/e2e/mvp-smoke.spec.ts
+++ b/web/e2e/mvp-smoke.spec.ts
@@ -838,11 +838,14 @@ test('MVP admin flow covers route protection and queue detail', async ({
 
   await page.goto('/dashboard/fila');
   await expect(page.getByText('Saude da fila')).toBeVisible();
-  await expect(page.getByText('Nota fiscal: Mercado Centro')).toBeVisible();
+  const queueItem = page
+    .getByRole('article')
+    .filter({ hasText: 'Nota fiscal: Mercado Centro' });
+  await expect(queueItem).toBeVisible();
   await expect(
     page.getByText(/ID t.cnico: receipt .* receipt-1 .* job job-1/),
   ).toBeVisible();
-  await page.getByText('Em fila', { exact: true }).hover();
+  await queueItem.getByText('Em fila', { exact: true }).hover();
   await expect(page.getByText(/Job aguardando worker/i)).toBeVisible();
   await page.goto('/dashboard/fila/job-1');
 


### PR DESCRIPTION
Scopes the admin queue status smoke selector to the queue item article so it no longer collides with the admin delivery status filter option named Em fila. Validated with web lint, web build, targeted Chromium, Firefox, and WebKit smoke tests, and git diff --check. Issue: #465