### PR TITLE
Document notification delivery release rollback checklist

### DIFF
--- a/docs/deployment/production-release-runbook.md
+++ b/docs/deployment/production-release-runbook.md
@@ -11,6 +11,8 @@ A production candidate can be promoted only when:
 5. Chromium, Firefox, and WebKit smoke tests pass.
 6. Flutter analyze, tests, and the Android release build pass.
 7. The homolog admin search panel has no active SLO alert.
+8. If notification delivery is enabled or changed, the notification delivery gate
+   in `docs/release/release-readiness.md` is recorded in the release issue.
 
 Record the commit SHA, workflow URLs, migration names, backup filename, and
 operator in the release issue.
@@ -19,13 +21,17 @@ operator in the release issue.
 
 1. Freeze unrelated schema changes.
 2. Confirm `INCIDENT_WEBHOOK_URL`, `APP_ENVIRONMENT`, and `APP_RELEASE`.
-3. Create and verify a pre-deploy database backup.
-4. Deploy the immutable backend and web images for the accepted SHA.
-5. Run `npm run db:migrate:policy`.
-6. Run `npm run db:migrate:deploy:safe`.
-7. Start the application containers.
-8. Validate health, login, public offers, admin metrics, receipt placeholders,
+3. Confirm notification worker flags, provider mode, quiet-hour policy, and
+   unsubscribe rollback status when notification delivery changes.
+4. Create and verify a pre-deploy database backup.
+5. Deploy the immutable backend and web images for the accepted SHA.
+6. Run `npm run db:migrate:policy`.
+7. Run `npm run db:migrate:deploy:safe`.
+8. Start the application containers.
+9. Validate health, login, public offers, admin metrics, receipt placeholders,
    queues, and one persisted search sample.
+10. If notification delivery changed, run the sandbox notification smoke and
+    confirm admin diagnostics show redacted destination/provider data only.
 
 Do not run seeders or reset the database during production promotion.
 
@@ -39,8 +45,11 @@ Use this when the new schema remains backward compatible:
 
 1. Redeploy the previous immutable image SHA.
 2. Keep the migrated database.
-3. Run health and authentication smoke tests.
-4. Open a corrective migration task before the next promotion.
+3. If the incident involves outbound notifications, disable
+   `NOTIFICATION_DELIVERY_WORKER_ENABLED` before redeploying and keep delivery
+   attempt rows for audit.
+4. Run health and authentication smoke tests.
+5. Open a corrective migration task before the next promotion.
 
 ### Database restore rollback
 

--- a/docs/product/notification-center.md
+++ b/docs/product/notification-center.md
@@ -114,8 +114,8 @@ without sending to external providers or storing raw provider payloads.
   and environment kill switches.
 - Admin diagnostics include filters for channel, status, notification type,
   retryability, redacted destination, and general search.
-- Extend release readiness with provider credential checks, unsubscribe rollback,
-  quiet-hour validation, sandbox smoke, and incident response.
+- Release readiness now includes provider credential checks, unsubscribe
+  rollback, quiet-hour validation, sandbox smoke, and incident response.
 - Add broader release coverage for sandbox success, retryable provider failure,
   terminal provider failure, and quiet-hour deferral.
 

--- a/docs/release/release-readiness.md
+++ b/docs/release/release-readiness.md
@@ -29,6 +29,64 @@
 - CI must keep backend, web, mobile, and workflow-security jobs green.
 - Local Docker remains the validation target until Railway services are provisioned.
 
+## Notification Delivery Gate
+
+Outbound notification delivery must stay provider-gated until the release issue
+records all checks below for the promoted SHA:
+
+- Provider credentials are present only in the target environment secret store.
+- `QUEUE_WORKERS_ENABLED` and `NOTIFICATION_DELIVERY_WORKER_ENABLED` are set to
+  the intended values for the environment.
+- `NOTIFICATION_DELIVERY_BATCH_SIZE` and
+  `NOTIFICATION_DELIVERY_POLL_INTERVAL_MS` match the release plan.
+- Sandbox email and push adapters are the active providers unless the release
+  explicitly enables an external provider.
+- Email unsubscribe tokens are generated, hashed at rest, and absent from
+  production API responses.
+- Category-level unsubscribe behavior has been checked for price, receipt, and
+  optimization notifications.
+- Quiet-hour defaults are documented for the release, including timezone,
+  start/end minutes, and expected deferral behavior.
+- Admin notification delivery filters can find attempts by channel, status,
+  notification type, retryability, destination label, and technical id.
+
+### Sandbox Smoke
+
+Run sandbox notification smoke before enabling broad delivery:
+
+1. Create one notification with a verified email destination and assert a
+   sandbox email attempt reaches `delivered`.
+2. Create one notification with a registered push device and assert a sandbox
+   push attempt reaches `delivered`.
+3. Force a retryable sandbox provider failure and assert the attempt becomes
+   `retrying` with a future `nextAttemptAt`.
+4. Force a terminal sandbox provider failure and assert the attempt becomes
+   `failed` with a redacted provider error.
+5. Enable quiet hours for a non-critical notification and assert the attempt is
+   deferred to the user-local quiet-hour end.
+6. Confirm in-app notifications remain visible even when outbound attempts are
+   deferred, retrying, failed, or disabled.
+
+Record the admin diagnostics URL or screenshot, the attempt ids, and the
+workflow/runbook link in the release issue. Do not record raw email addresses,
+push tokens, unsubscribe tokens, or provider payloads.
+
+### Notification Rollback
+
+Use the least disruptive rollback that stops outbound sends first:
+
+1. Set `NOTIFICATION_DELIVERY_WORKER_ENABLED=false`.
+2. If the issue affects all workers, set `QUEUE_WORKERS_ENABLED=false`.
+3. Redeploy or restart workers so the kill switch is applied.
+4. Verify no new attempts move from `queued` or `retrying` to `sending`.
+5. Cancel or retry affected attempts from admin only after product owner
+   approval.
+6. Revert the release SHA only if disabling workers does not stop user impact or
+   the app cannot serve in-app notifications safely.
+
+Do not delete delivery attempts during rollback. Keep failed and cancelled rows
+for audit, provider reconciliation, and user-support context.
+
 ## Incident Triage
 
 - Classify incidents by auth/session, entitlement ledger, optimization result, receipt
@@ -36,3 +94,17 @@
 - Preserve append-only ledger and sanitized receipt logs for investigation.
 - Remove raw receipt files on user deletion or privacy request when file retention is
   enabled.
+
+### Notification Incidents
+
+Classify notification incidents separately when they involve provider
+credentials, unsubscribe safety, quiet-hour violations, delivery volume, retry
+loops, or admin action mistakes.
+
+- First response is to disable notification delivery workers, not to purge data.
+- Incident payloads may include release, environment, aggregate counts, channel,
+  status, provider label, and redacted destination label.
+- Incident payloads must not include email addresses, push tokens, unsubscribe
+  tokens, provider message bodies, receipt contents, addresses, or search terms.
+- User-facing mitigation should prefer in-app notification continuity while
+  outbound email/push remains disabled.

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -664,7 +664,7 @@ validated with sandbox behavior.
 - [X] T270 Add provider-neutral notification delivery contracts, sandbox email/push adapters, and backend coverage for provider-gated execution in `backend/src/notifications/` and `backend/test/unit/notifications/`
 - [X] T271 Add a notification delivery worker or scheduler with bounded batch size, structured logs, and safe disable flags in `backend/src/jobs/` and `backend/src/notifications/`
 - [X] T272 Add admin delivery filters/search for channel, status, destination, notification type, and retryability in `backend/src/admin/` and `web/src/dashboard/`
-- [ ] T273 Add release and rollback checklist entries for provider credentials, unsubscribe safety, quiet-hour policy, sandbox smoke, and incident response in `docs/release/`
+- [X] T273 Add release and rollback checklist entries for provider credentials, unsubscribe safety, quiet-hour policy, sandbox smoke, and incident response in `docs/release/`
 - [ ] T274 Add end-to-end release coverage for sandbox delivery attempts, deferred quiet-hour attempts, retryable provider failure, and terminal provider failure across backend/web/mobile where applicable
 
 ---


### PR DESCRIPTION
Implements Phase 36 T273. Adds the notification delivery release gate, sandbox smoke, rollback order, and incident response rules to release docs, links the production runbook to the gate, updates the product status, and marks T273 complete. Validation: git diff --check.