### PR TITLE
Close Phase 36 notification hardening

### DIFF
--- a/docs/product/notification-center.md
+++ b/docs/product/notification-center.md
@@ -94,9 +94,13 @@ diagnostics.
 
 ## Phase 36 delivery hardening
 
-**Status (2026-06-26)**: Started with provider-neutral delivery contracts and
-sandbox adapters. Sandbox delivery can exercise email and push state transitions
-without sending to external providers or storing raw provider payloads.
+**Status (2026-06-27)**: Complete on `homolog` at
+`22910d3b82cc7a1f9f8ba8748ba6427f7239c6af`. CI, Release Readiness, and Deploy
+Homolog Server passed after T274. Provider-gated outbound delivery now has
+sandbox email/push adapters, bounded worker scheduling, admin delivery
+filtering/search, release/rollback gates, and release coverage for sandbox
+success, quiet-hour deferral, retryable provider failure, and terminal provider
+failure.
 
 ### Provider gating
 
@@ -107,7 +111,7 @@ without sending to external providers or storing raw provider payloads.
 - Provider responses update the delivery attempt as `delivered`, `retrying`, or
   `failed`; in-app notifications remain the canonical record.
 
-### Remaining Phase 36 work
+### Completed Phase 36 scope
 
 - Bounded scheduler is implemented for due delivery attempts with startup and
   interval ticks, structured logs, no overlapping batches, capped batch size,

--- a/specs/001-grocery-optimizer/tasks.md
+++ b/specs/001-grocery-optimizer/tasks.md
@@ -667,6 +667,13 @@ validated with sandbox behavior.
 - [X] T273 Add release and rollback checklist entries for provider credentials, unsubscribe safety, quiet-hour policy, sandbox smoke, and incident response in `docs/release/`
 - [X] T274 Add end-to-end release coverage for sandbox delivery attempts, deferred quiet-hour attempts, retryable provider failure, and terminal provider failure across backend/web/mobile where applicable
 
+**Phase 36 completion note (2026-06-27)**: Provider-gated notification delivery
+hardening was completed on `homolog` commit
+`22910d3b82cc7a1f9f8ba8748ba6427f7239c6af`. PR #470 closed T274 with Release
+Readiness coverage for sandbox delivery success, quiet-hour deferral, retryable
+provider failure, and terminal provider failure. CI, Release Readiness, and
+Deploy Homolog Server passed after merge.
+
 ---
 
 ## Dependencies & Execution Order


### PR DESCRIPTION
Adds the Phase 36 completion note after T270-T274, recording homolog SHA 22910d3b82cc7a1f9f8ba8748ba6427f7239c6af and the green CI, Release Readiness, and Deploy Homolog Server status after T274. Validation: git diff --check. Issue: #471