### PR TITLE
Add homolog server diagnostics workflow

### DIFF
--- a/.github/workflows/homolog-server-diagnostics.yml
+++ b/.github/workflows/homolog-server-diagnostics.yml
@@ -1,0 +1,101 @@
+name: Homolog Server Diagnostics
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    name: Diagnose homolog server
+    runs-on: ubuntu-latest
+    env:
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_PATH: ${{ vars.DEPLOY_PATH }}
+      VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL || 'https://apipricely.grmeireles.dev' }}
+    steps:
+      - name: Validate inputs
+        shell: bash
+        run: |
+          [ -n "$DEPLOY_HOST" ] || { echo "Missing secret DEPLOY_HOST"; exit 1; }
+          [ -n "$DEPLOY_USER" ] || { echo "Missing secret DEPLOY_USER"; exit 1; }
+          [ -n "${{ secrets.DEPLOY_SSH_KEY }}" ] || { echo "Missing secret DEPLOY_SSH_KEY"; exit 1; }
+          [ -n "$DEPLOY_PATH" ] || { echo "Missing variable DEPLOY_PATH"; exit 1; }
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
+
+      - name: Add server to known hosts
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          ssh-keyscan -T 15 -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: Inspect compose, ports, and proxy hints
+        shell: bash
+        run: |
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "DEPLOY_PATH='$DEPLOY_PATH' VITE_API_BASE_URL='$VITE_API_BASE_URL' bash -s" <<'ENDSSH'
+          set -euo pipefail
+
+          echo "== Host identity =="
+          hostname
+          date -u
+
+          echo "== Compose public env =="
+          if [ -f "$DEPLOY_PATH/.env" ]; then
+            grep -E '^(BACKEND_IMAGE|WEB_IMAGE|IMAGE_TAG|BACKEND_PORT|WEB_PORT|WEB_APP_URL|VITE_API_BASE_URL|NODE_ENV)=' "$DEPLOY_PATH/.env" || true
+          else
+            echo "Missing $DEPLOY_PATH/.env"
+          fi
+
+          echo "== Docker containers =="
+          docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Ports}}\t{{.Status}}'
+
+          echo "== Compose status =="
+          if [ -f "$DEPLOY_PATH/docker-compose.yml" ]; then
+            cd "$DEPLOY_PATH"
+            docker compose --env-file .env ps
+          fi
+
+          echo "== Listening TCP ports =="
+          if command -v ss >/dev/null 2>&1; then
+            ss -ltnp || true
+          elif command -v netstat >/dev/null 2>&1; then
+            netstat -ltnp || true
+          fi
+
+          backend_port="$(grep -E '^BACKEND_PORT=' "$DEPLOY_PATH/.env" | tail -1 | cut -d= -f2- || true)"
+          backend_port="${backend_port:-3000}"
+          api_base="${VITE_API_BASE_URL%/}"
+
+          echo "== Server-local route smoke =="
+          for base in "http://127.0.0.1:${backend_port}" "$api_base"; do
+            echo "-- Base: $base"
+            for route in /health /admin/processing-jobs /admin/queue-health /admin/missing-product-requests /admin/notification-deliveries; do
+              status="$(curl -sS -L --connect-timeout 5 --max-time 15 -o /tmp/pricely-diagnostic-body -w '%{http_code}' "$base$route" || true)"
+              body="$(head -c 220 /tmp/pricely-diagnostic-body 2>/dev/null || true)"
+              printf '%s %s %s\n' "$status" "$route" "$body"
+            done
+          done
+
+          echo "== Proxy service hints =="
+          for service in nginx caddy traefik cloudflared; do
+            if command -v systemctl >/dev/null 2>&1; then
+              systemctl is-active "$service" >/dev/null 2>&1 && systemctl status "$service" --no-pager -l || true
+            fi
+          done
+
+          echo "== Proxy config hints =="
+          for path in /etc/nginx /etc/caddy /etc/traefik /etc/cloudflared /etc/systemd/system; do
+            if [ -d "$path" ]; then
+              echo "-- $path"
+              grep -RInE 'apipricely|pricely|localhost:3000|127\.0\.0\.1:3000|localhost:3003|127\.0\.0\.1:3003|:5173' "$path" 2>/dev/null || true
+            fi
+          done
+          ENDSSH


### PR DESCRIPTION
## Summary
- add a manual Homolog Server Diagnostics workflow
- inspect compose env, running containers, listening ports, local/public route status, and proxy config hints
- avoid printing backend runtime env/secrets

Refs #475

## Validation
- git diff --check